### PR TITLE
Settings: multi-DB connections, research policy, inline admin clarify; core/app decouple

### DIFF
--- a/core/datasources.py
+++ b/core/datasources.py
@@ -3,40 +3,42 @@ import threading
 from typing import Dict, Optional
 from sqlalchemy import create_engine
 
-from .settings import get_db_sources
+from .settings import get_db_connections, get_default_datasource
 
 
 class SqlRouter:
-    """Cache SQLAlchemy engines by logical datasource name."""
+    """Caches SQLAlchemy engines by logical datasource name."""
 
-    def __init__(self, settings) -> None:
+    def __init__(self, settings):
         self._settings = settings
         self._lock = threading.Lock()
         self._engines: Dict[str, any] = {}
-        self._default_name: Optional[str] = None
-        self._load_from_settings()
-
-    def _load_from_settings(self) -> None:
         self._sources: Dict[str, str] = {}
-        default_name: Optional[str] = None
-        for s in get_db_sources(self._settings):
-            name = s.get("name")
-            if not name:
-                continue
-            self._sources[name] = s.get("url")
-            if s.get("default") and not default_name:
-                default_name = name
-        self._default_name = default_name
+        self._default: Optional[str] = None
+        self._load()
 
-    def reload(self) -> None:
+    def _load(self):
+        self._sources.clear()
+        self._engines.clear()
+        default = get_default_datasource(self._settings)
+        for s in get_db_connections(self._settings):
+            name = s["name"]
+            self._sources[name] = s["url"]
+            if s.get("default") and not default:
+                default = name
+        self._default = default
+
+    def reload(self):
         with self._lock:
-            self._engines.clear()
-            self._load_from_settings()
+            self._load()
+
+    def list(self) -> dict:
+        return {"default": self._default, "sources": list(self._sources.keys())}
 
     def get_engine(self, name: Optional[str] = None):
-        key = name or self._default_name
+        key = name or self._default
         if not key:
-            raise RuntimeError("No default datasource configured")
+            raise RuntimeError("No default datasource configured.")
         with self._lock:
             eng = self._engines.get(key)
             if eng is None:
@@ -46,6 +48,3 @@ class SqlRouter:
                 eng = create_engine(url, pool_pre_ping=True)
                 self._engines[key] = eng
             return eng
-
-    def list(self) -> dict:
-        return {"default": self._default_name, "sources": list(self._sources.keys())}

--- a/core/research.py
+++ b/core/research.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from typing import Any, Dict, List, Tuple, Optional
 import importlib
 
+from .settings import Settings, get_research_policy
+
 class Researcher:
     def search(self, question: str, context: Dict[str, Any]) -> Tuple[str, List[int]]:
         return "", []
@@ -38,3 +40,21 @@ def build_researcher(settings) -> Optional[Any]:
 
     # Future: add real providers here
     return NullResearcher()
+
+
+def maybe_research(settings: Settings, question: str, datasource_name: str | None = None) -> str | None:
+    if not settings.get("RESEARCH_MODE"):
+        return None
+    policy = get_research_policy(settings)
+    if datasource_name and policy:
+        if not policy.get(datasource_name, False):
+            return None
+    # load researcher class if provided
+    cls_path = settings.get("RESEARCHER_CLASS")
+    if not cls_path:
+        return None
+    mod, _, cls = cls_path.rpartition(".")
+    if not mod or not cls:
+        return None
+    C = getattr(importlib.import_module(mod), cls)
+    return C().run(question)


### PR DESCRIPTION
## Summary
- add typed settings for DB connections, research policy, admin emails and inline clarification
- route SQLAlchemy engines with a datasource router and gate research per policy
- verify admin API key using PBKDF2 hash with env fallback

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bcb7df85e483239e0b813e293d62fe