### PR TITLE
Simplify app configuration and research toggle

### DIFF
--- a/apps/fa/agents.py
+++ b/apps/fa/agents.py
@@ -176,3 +176,7 @@ class ValidatorAgentFA(CoreValidator):
 
 def expand_sql_for_prefixes(canonical_sql: str, prefixes: Iterable[str]) -> str:
     return union_for_prefixes(canonical_sql, prefixes)
+
+
+def get_planner(llm, settings):
+    return PlannerAgentFA(llm, settings)

--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -296,9 +296,9 @@ def admin_reply_inquiry(inq_id: int):
 
     mem = current_app.config["MEM_ENGINE"]
     pipeline = current_app.config["PIPELINE"]
-    fa_engine = pipeline.fa_engine
-    if not fa_engine:
-        return jsonify({"error": "FA DB not configured"}), 500
+    app_engine = pipeline.app_engine
+    if not app_engine:
+        return jsonify({"error": "APP DB not configured"}), 500
 
     # Load inquiry
     with mem.connect() as con:
@@ -332,7 +332,7 @@ def admin_reply_inquiry(inq_id: int):
 
     # Validate with EXPLAIN
     try:
-        with fa_engine.connect() as c:
+        with app_engine.connect() as c:
             c.execute(text(f"EXPLAIN {sql_strip}"))
     except Exception as e:
         # Keep awaiting_admin and notify admins why it failed
@@ -342,7 +342,7 @@ def admin_reply_inquiry(inq_id: int):
 
     # Execute and build CSV (no LIMIT here; add one if you want to cap size)
     try:
-        with fa_engine.connect() as c:
+        with app_engine.connect() as c:
             rs = c.execute(text(sql_strip))
             cols = list(rs.keys())
             sio = StringIO()

--- a/core/admin_helpers.py
+++ b/core/admin_helpers.py
@@ -51,7 +51,7 @@ def derive_sql_from_admin_reply(
     augmented_q = f"{question}\n\nADMIN HINTS: {admin_reply}".strip()
 
     # ---- Step 2: plan via pipeline (small note: returns canonical SQL + rationale)
-    plan_out = pipeline.answer(source=source, prefixes=prefixes, question=augmented_q)
+    plan_out = pipeline.answer(question=augmented_q, context={"prefixes": prefixes, "source": source}, hints=None)
 
     # If planner still needs clarification or failed, bubble that up unchanged
     if plan_out.get("status") != "ok":

--- a/core/research.py
+++ b/core/research.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Tuple, Optional
 import importlib
 
-from .settings import Settings, get_research_policy
+from .settings import Settings
 
 class Researcher:
     def search(self, question: str, context: Dict[str, Any]) -> Tuple[str, List[int]]:
@@ -18,7 +18,7 @@ def _load_class(path: str):
 
 def build_researcher(settings) -> Optional[Any]:
     try:
-        if not bool(settings.get("RESEARCH_MODE", False)):
+        if not settings.research_enabled():
             return None
     except Exception:
         return None
@@ -42,15 +42,10 @@ def build_researcher(settings) -> Optional[Any]:
     return NullResearcher()
 
 
-def maybe_research(settings: Settings, question: str, datasource_name: str | None = None) -> str | None:
-    if not settings.get("RESEARCH_MODE"):
+def maybe_research(settings: Settings, question: str, namespace: str | None = None) -> str | None:
+    if not settings.research_enabled(namespace):
         return None
-    policy = get_research_policy(settings)
-    if datasource_name and policy:
-        if not policy.get(datasource_name, False):
-            return None
-    # load researcher class if provided
-    cls_path = settings.get("RESEARCHER_CLASS")
+    cls_path = settings.get("RESEARCHER_CLASS", namespace=namespace)
     if not cls_path:
         return None
     mod, _, cls = cls_path.rpartition(".")


### PR DESCRIPTION
## Summary
- Normalize settings access with `get_app_db_url` and `research_enabled` helpers
- Load app-specific planners dynamically and route intents before planning
- Remove per-database research policy in favor of a single `RESEARCH_MODE`

## Testing
- `python -m py_compile core/settings.py core/sql_exec.py core/research.py core/pipeline.py core/admin_helpers.py apps/fa/agents.py apps/fa/app.py core/admin_api.py`
- `check_exllamav2` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf6732da908323b656fee43957a85a