### PR TITLE
Handle FA hint signatures and greet intent

### DIFF
--- a/core/intent.py
+++ b/core/intent.py
@@ -88,3 +88,13 @@ class IntentRouter:
 
         # Last resort
         return Intent("ambiguous", "default")
+
+
+# Convenience global router for simple intent checks
+_DEFAULT_ROUTER = IntentRouter()
+
+
+def detect_intent(text: str) -> Intent:
+    """Classify *text* into a lightweight Intent instance."""
+    return _DEFAULT_ROUTER.classify(text)
+


### PR DESCRIPTION
## Summary
- Add a lightweight intent detector and greeting/help gate in `/fa/answer`
- Wrap `make_fa_hints` with `_fa_make_hints` to support old and new signatures
- Expose `detect_intent` helper for quick intent classification

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfff70ee108323aacadb2785154408