### PR TITLE
Handle admin clarification replies inline

### DIFF
--- a/apps/fa/hints.py
+++ b/apps/fa/hints.py
@@ -1,6 +1,6 @@
 # apps/fa/hints.py
 from __future__ import annotations
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 
 def _build(payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -10,12 +10,27 @@ def _build(payload: Dict[str, Any]) -> Dict[str, Any]:
 
     q = (payload.get("question") or "").strip()
     prefixes = list(payload.get("prefixes") or [])
+    clarifications: Optional[Dict[str, Any]] = payload.get("clarifications") or None
 
     # App-agnostic, lightweight hints (date range, simple eq filters)
     base = core_make_hints(q)
 
     # FA-specific keyword expansion (customers, invoices, etc.)
     base["keywords"] = expand_keywords(q.split())
+
+    # Apply clarifications when provided (date range, date column, etc.)
+    if clarifications:
+        if dr := clarifications.get("date_range"):
+            # support either dict(start/end) or string alias
+            if isinstance(dr, dict):
+                base["date_range"] = dr
+            elif isinstance(dr, str):
+                from core.hints import make_hints as _mh
+                dr_parsed = _mh(dr).get("date_range")
+                if dr_parsed:
+                    base["date_range"] = dr_parsed
+        if dc := clarifications.get("date_column"):
+            base["date_column"] = dc
 
     # Always pass-through prefixes to downstream planner
     base["prefixes"] = prefixes
@@ -31,13 +46,15 @@ def make_fa_hints(*args, **kwargs) -> Dict[str, Any]:
     if args and len(args) == 1 and isinstance(args[0], dict):
         return _build(args[0])
 
-    # Legacy: 3 positional args -> (mem_engine, prefixes, question)
+    # Legacy: 3 positional args -> (mem_engine, prefixes, question[, clarifications])
     if len(args) >= 3:
         mem_engine, prefixes, question = args[:3]
+        clar = args[3] if len(args) > 3 else None
         return _build({
             "mem_engine": mem_engine,
             "prefixes": prefixes,
             "question": question,
+            "clarifications": clar,
         })
 
     # Named kwargs (accept either shape)
@@ -48,5 +65,6 @@ def make_fa_hints(*args, **kwargs) -> Dict[str, Any]:
         "mem_engine": kwargs.get("mem_engine"),
         "prefixes": kwargs.get("prefixes") or [],
         "question": kwargs.get("question") or "",
+        "clarifications": kwargs.get("clarifications"),
     })
 


### PR DESCRIPTION
## Summary
- Support inquiry follow-ups by allowing admin replies and clarifications to be passed through `fa/answer`
- Expand FA hint generation to incorporate clarification metadata like date ranges and columns
- Enable pipeline to resolve clarified inquiries: update inquiry, re-plan SQL, validate & execute, log run, and return results

## Testing
- `python -m py_compile apps/fa/app.py apps/fa/hints.py core/pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c02b27ef9c83239d3f170f9af81520