### PR TITLE
Fix JSONB parameter binding in admin bulk settings and notes

### DIFF
--- a/core/sql_exec.py
+++ b/core/sql_exec.py
@@ -22,6 +22,20 @@ def get_app_engine(settings, namespace: str) -> Engine:
     _ENGINES[key] = eng
     return eng
 
+
+def get_mem_engine(mem) -> Engine:
+    """Return a cached Engine for the given mem database."""
+    if isinstance(mem, Engine):
+        return mem
+    if isinstance(mem, str):
+        key = f"mem::{mem}"
+        if key in _ENGINES:
+            return _ENGINES[key]
+        eng = create_engine(mem, pool_pre_ping=True, pool_recycle=3600)
+        _ENGINES[key] = eng
+        return eng
+    raise RuntimeError("MEM_ENGINE not configured")
+
 def validate_select(sql: str) -> Tuple[bool, str]:
     s = sql.strip().lstrip("(")
     if not SAFE_SQL_RE.match(s):


### PR DESCRIPTION
## Summary
- Bind JSONB values directly in `/admin/settings/bulk` and support extra metadata
- Add engine helper `get_mem_engine`
- Safely append admin notes using typed JSONB parameters

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13cd033548323892cd9f1b551a344