### PR TITLE
Enable admin note replay and inquiry resume

### DIFF
--- a/apps/fa/agents.py
+++ b/apps/fa/agents.py
@@ -137,6 +137,14 @@ class PlannerAgentFA(CorePlanner):
             f"Hints:\n{hint_txt}\n"
             "Return as:\nSQL:\n<sql>\nRationale:\n<why>\n"
         )
+
+        if hints and hints.get("admin_notes"):
+            prompt += (
+                "\n\n# Admin clarifications (authoritative):\n"
+                + hints["admin_notes"]
+                + "\n# Use these clarifications to finalize the SQL. Return **SQL only**."
+            )
+
         out = self.llm.generate(prompt, max_new_tokens=256, temperature=0.2, top_p=0.9)
         return self._split(out)
 


### PR DESCRIPTION
## Summary
- Switch admin note storage to safe read-modify-write in `core/inquiries`
- Include admin notes in FA planner prompts
- Allow pipeline to resume existing inquiries with admin notes
- Extend admin API to append notes and optionally re-plan immediately

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c16f6b3dec832380603d8513c5f845