### PR TITLE
Add admin note auto-apply flow

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,8 +19,8 @@ def create_app() -> Flask:
     app.config["MEM_ENGINE"] = pipeline.mem_engine
     app.config["SETTINGS"] = pipeline.settings
 
-    # Force the /admin prefix here even if someone removes it in the blueprint
-    app.register_blueprint(admin_bp, url_prefix="/admin")
+    # admin_bp already has url_prefix="/admin"
+    app.register_blueprint(admin_bp)
 
     app.register_blueprint(fa_bp, url_prefix="/fa")
 


### PR DESCRIPTION
## Summary
- add simple fetch_inquiry and append_admin_note helpers using JSON and named params
- expose admin inquiry GET and reply endpoints with automatic apply/retry flow
- support inline admin note application within pipeline and email result

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c203f763f88323ad307efbc5552d35