### PR TITLE
Add structured spec clarifier and pipeline integration

### DIFF
--- a/apps/fa/hints.py
+++ b/apps/fa/hints.py
@@ -6,6 +6,30 @@ from datetime import date, timedelta
 from typing import Any, Dict, List, Optional
 
 
+# Questions to ask when specific fields are missing from the structured spec
+MISSING_FIELD_QUESTIONS = {
+    "date_range": "What date range should we use (e.g., last month, between 2025-08-01 and 2025-08-31)?",
+    "tables": "Which tables should we use (e.g., debtor_trans, debtors_master, gl_trans)?",
+    "metric": "Which metric should we compute (e.g., sum of net sales, count of invoices)?",
+    "entity": "Top by what entity (customer, supplier, item, account, or a dimension)?",
+}
+
+# Lightweight domain hints handed to the clarifier
+DOMAIN_HINTS = {
+    "entities": ["customer", "supplier", "item", "account", "dimension"],
+    "table_aliases": [
+        "debtor_trans",
+        "debtors_master",
+        "supp_trans",
+        "gl_trans",
+        "bank_trans",
+        "stock_moves",
+        "item_codes",
+    ],
+    "metric_registry": {"net_sales": "sum(quantity * price * (1-discount))"},
+}
+
+
 def _last_month_bounds() -> tuple[str, str]:
     today = date.today()
     first_this = today.replace(day=1)

--- a/core/clarifier.py
+++ b/core/clarifier.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+import json
+import re
+from typing import Tuple, Dict, Any, Optional
+
+from core.specs import QuestionSpec
+from core.model_loader import load_model, load_clarifier_model
+
+
+_SMALTALK = re.compile(r'^\s*(hi|hello|hey|السلام عليكم|مرحبا|أهلًا|اهلا|ازيك)\b', re.I)
+_HELP = re.compile(r'help|what can you do|how (?:do|can) you help|ممكن تساعد|تقدر تعمل ايه', re.I)
+
+SYS = (
+    "You are a planning assistant. Output compact JSON only. "
+    "Schema:\n"
+    "{"
+    "  \"intent\": \"smalltalk|help|raw_sql|sql_request|ambiguous\","
+    "  \"datasource\": null|string,"
+    "  \"date_column\": null|string,"
+    "  \"date_range\": null|string,"
+    "  \"entity\": null|string,"
+    "  \"tables\": string[],"
+    "  \"metric_key\": null|string,"
+    "  \"metric_expr\": null|string,"
+    "  \"group_by\": string[],"
+    "  \"top_k\": null|int,"
+    "  \"filters\": string[]"
+    "}\n"
+    "Rules: If user typed SQL, intent=raw_sql. If greeting/help, mark accordingly. "
+    "If information is missing, leave fields null/empty (do NOT hallucinate)."
+)
+
+FEW_SHOT = (
+    "Q: top 10 customers by sales last month\n"
+    "JSON: {\"intent\":\"sql_request\",\"datasource\":null,\"date_column\":null,\"date_range\":\"last month\",\"entity\":\"customer\",\"tables\":[],\"metric_key\":\"net_sales\",\"metric_expr\":null,\"group_by\":[\"customer\"],\"top_k\":10,\"filters\":[]}\n"
+    "Q: hello\n"
+    "JSON: {\"intent\":\"smalltalk\",\"datasource\":null,\"date_column\":null,\"date_range\":null,\"entity\":null,\"tables\":[],\"metric_key\":null,\"metric_expr\":null,\"group_by\":[],\"top_k\":null,\"filters\":[]}\n"
+)
+
+
+def _to_json(text: str) -> Dict[str, Any]:
+    text = text.strip()
+    if text.startswith("```"):
+        text = text.strip("`")
+        text = re.sub(r'^\s*json', "", text, flags=re.I).strip()
+    try:
+        return json.loads(text)
+    except Exception:
+        m = re.search(r'\{.*\}', text, re.S)
+        if m:
+            return json.loads(m.group(0))
+        raise
+
+
+class ClarifierAgent:
+    """LLM-assisted intent classifier and spec extractor."""
+
+    def __init__(self, settings):
+        self.settings = settings
+        self.llm = load_clarifier_model(settings) or load_model(settings)
+
+    def classify_and_extract(
+        self, question: str, prefixes, domain_hints: Dict[str, Any]
+    ) -> QuestionSpec:
+        qt = question.strip()
+        if not qt:
+            return QuestionSpec(intent="smalltalk", prefixes=list(prefixes or []))
+        if _SMALTALK.search(qt):
+            return QuestionSpec(intent="smalltalk", prefixes=list(prefixes or []))
+        if _HELP.search(qt):
+            return QuestionSpec(intent="help", prefixes=list(prefixes or []))
+        if re.search(r'\bselect\b|\bfrom\b', qt, re.I):
+            return QuestionSpec(intent="raw_sql", prefixes=list(prefixes or []))
+
+        context = ""
+        if domain_hints.get("entities"):
+            context += f"Entities: {', '.join(domain_hints['entities'])}\n"
+        if domain_hints.get("table_aliases"):
+            context += f"Tables: {', '.join(domain_hints['table_aliases'])}\n"
+        if domain_hints.get("metric_registry"):
+            context += "Metrics: " + ", ".join(domain_hints["metric_registry"].keys()) + "\n"
+
+        prompt = (
+            f"{SYS}\n{FEW_SHOT}"
+            f"Context:\n{context}\n"
+            f"Q: {question}\nJSON:"
+        )
+        text = self.llm.generate(prompt, max_new_tokens=256, temperature=0.0, top_p=1.0)
+        try:
+            data = _to_json(text)
+        except Exception:
+            return QuestionSpec(intent="ambiguous", prefixes=list(prefixes or []))
+
+        spec = QuestionSpec(
+            intent=data.get("intent", "sql_request"),
+            prefixes=list(prefixes or []),
+            datasource=data.get("datasource"),
+            date_column=data.get("date_column"),
+            date_range=data.get("date_range"),
+            entity=data.get("entity"),
+            tables=list(data.get("tables") or []),
+            metric_key=data.get("metric_key"),
+            metric_expr=data.get("metric_expr"),
+            group_by=list(data.get("group_by") or []),
+            top_k=data.get("top_k"),
+            filters=list(data.get("filters") or []),
+        )
+        return spec

--- a/core/specs.py
+++ b/core/specs.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+from dataclasses import dataclass, field, asdict
+from typing import List, Optional, Dict, Any
+
+
+@dataclass
+class QuestionSpec:
+    """Structured representation of a user's question."""
+    intent: str = "sql_request"  # sql_request | raw_sql | smalltalk | help | ambiguous
+    datasource: Optional[str] = None
+    prefixes: List[str] = field(default_factory=list)
+
+    # canonical analysis fields (domain-agnostic)
+    date_column: Optional[str] = None
+    date_range: Optional[str] = None
+    entity: Optional[str] = None
+    tables: List[str] = field(default_factory=list)
+    metric_key: Optional[str] = None
+    metric_expr: Optional[str] = None
+    group_by: List[str] = field(default_factory=list)
+    top_k: Optional[int] = None
+    filters: List[str] = field(default_factory=list)
+
+    # LLM confidence or notes
+    notes: List[str] = field(default_factory=list)
+
+    def missing_fields(self) -> List[str]:
+        missing: List[str] = []
+        if not self.date_range:
+            missing.append("date_range")
+        if not self.entity and (self.top_k or (self.group_by and len(self.group_by) == 1)):
+            missing.append("entity")
+        if not self.metric_key and not self.metric_expr:
+            missing.append("metric")
+        if not self.tables:
+            missing.append("tables")
+        return missing
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+def merge_specs(base: QuestionSpec, patch: QuestionSpec) -> QuestionSpec:
+    """Merge two QuestionSpec objects, preferring explicit values from `patch`."""
+    out = QuestionSpec(**base.as_dict())
+    for fld in (
+        "intent",
+        "datasource",
+        "date_column",
+        "date_range",
+        "entity",
+        "metric_key",
+        "metric_expr",
+        "top_k",
+    ):
+        val = getattr(patch, fld)
+        if val:
+            setattr(out, fld, val)
+    for lf in ("prefixes", "tables", "group_by", "filters", "notes"):
+        lst = list(getattr(out, lf) or [])
+        for v in getattr(patch, lf) or []:
+            if v and v not in lst:
+                lst.append(v)
+        setattr(out, lf, lst)
+    return out


### PR DESCRIPTION
## Summary
- Introduce `QuestionSpec` dataclass for structured query intent and merging helpers
- Add LLM-assisted `ClarifierAgent` to classify intents and extract question specs
- Provide FA hint mappings and domain hints for clarifier
- Integrate clarifier and spec checks into pipeline answer flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c405274eac8323a334172361fc20c8