### PR TITLE
Enable admin-note processing with fallback clarifier

### DIFF
--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -3,7 +3,7 @@ from flask import Blueprint, request, jsonify, current_app
 from werkzeug.exceptions import BadRequest
 from sqlalchemy import text, bindparam
 from sqlalchemy.dialects.postgresql import JSONB
-from core.inquiries import append_admin_note, fetch_inquiry
+from core.inquiries import append_admin_note, fetch_inquiry, summarize_admin_notes
 
 admin_bp = Blueprint("admin_bp", __name__, url_prefix="/admin")
 
@@ -120,28 +120,40 @@ def admin_reply(inq_id: int):
     mem = current_app.config["MEM_ENGINE"]
     data = request.get_json(force=True) or {}
 
-    answered_by = data.get("answered_by") or data.get("by") or "admin"
-    admin_reply = data.get("admin_reply") or data.get("reply")
+    by = data.get("answered_by") or data.get("by") or "admin"
+    reply = (data.get("admin_reply") or data.get("reply") or "").strip()
+    do_process = str(data.get("process", "0")).lower() in {"1", "true", "yes", "y"}
 
-    if not admin_reply:
+    if not reply:
         return jsonify({"ok": False, "error": "admin_reply is required"}), 400
 
     try:
-        rounds = append_admin_note(mem, inq_id, by=answered_by, text_note=admin_reply)
+        rounds = append_admin_note(mem, inq_id, by=by, text_note=reply)
     except Exception as e:
         return jsonify({"ok": False, "error": f"append_failed: {e}"}), 500
 
-    # Optional auto process if client asks
-    if str(data.get("process", "0")).lower() in {"1", "true", "yes", "y"}:
-        pipeline = current_app.config["PIPELINE"]
-        try:
-            # inline=True → don’t send emails or escalate; just return JSON
-            out = pipeline.apply_admin_and_retry(inq_id, inline=True)
-            return jsonify({"ok": True, "inquiry_id": inq_id, **out})
-        except Exception as e:
-            return jsonify({"ok": False, "error": f"process_failed: {e}", "inquiry_id": inq_id}), 500
+    if not do_process:
+        return jsonify({"ok": True, "inquiry_id": inq_id, "clarification_rounds": rounds})
 
-    return jsonify({"ok": True, "inquiry_id": inq_id, "clarification_rounds": rounds}), 200
+    pipeline = current_app.config["PIPELINE"]
+    row = fetch_inquiry(mem, inq_id)
+    if not row:
+        return jsonify({"ok": False, "inquiry_id": inq_id, "error": "inquiry_not_found"}), 404
+
+    admin_ctx = summarize_admin_notes(row.get("admin_notes"))
+    prefixes = row.get("prefixes") or []
+    out = pipeline.answer(
+        question=row["question"],
+        context={
+            "prefixes": prefixes,
+            "auth_email": row.get("auth_email"),
+            "namespace": row.get("namespace"),
+        },
+        inquiry_id=inq_id,
+        hints=None,
+        admin_context=admin_ctx,
+    )
+    return jsonify(out)
 
 
 @admin_bp.post("/inquiries/<int:inq_id>/process")


### PR DESCRIPTION
## Summary
- Handle admin notes safely with JSON adapter and helper summaries
- Add heuristic fallback clarifier in FA planner and wire into pipeline
- Allow admin API to process inquiries immediately using admin context

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c47bed9c148323b9c5f8f4c3b6a494