### PR TITLE
Add inquiry reprocessing pipeline and admin note fixes

### DIFF
--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -130,7 +130,7 @@ def admin_reply(inq_id: int):
     mem_engine = pipeline.mem_engine
 
     try:
-        rounds = append_admin_note(mem_engine, inq_id, by=answered_by, text_note=admin_reply)
+        rounds = append_admin_note(mem_engine, inq_id, answered_by, admin_reply)
     except Exception as e:
         return jsonify({"ok": False, "error": f"append_failed: {e}"}), 500
 
@@ -138,7 +138,7 @@ def admin_reply(inq_id: int):
 
     if process:
         try:
-            result = pipeline.reprocess_inquiry(inq_id)
+            result = pipeline.reprocess_inquiry(inq_id, answered_by, admin_reply)
         except Exception as e:
             return jsonify({"ok": False, "inquiry_id": inq_id, "error": f"process_failed: {e}"}), 500
         out["processed"] = True


### PR DESCRIPTION
## Summary
- Implement robust inquiry reprocessing with admin note integration, SQL derivation, and validation/execute options
- Add datasource-aware SQL validation and execution safeguards
- Fix admin note JSON upsert and route to pass admin replies to pipeline
- Introduce free-form admin reply parser for FA hints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c538d5147c832386acd0c18de2e88d