### PR TITLE
Add admin reprocess pipeline and hint parsing

### DIFF
--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -3,7 +3,7 @@ from flask import Blueprint, request, jsonify, current_app
 from werkzeug.exceptions import BadRequest
 from sqlalchemy import text, bindparam
 from sqlalchemy.dialects.postgresql import JSONB
-from core.inquiries import append_admin_note, fetch_inquiry, set_admin_reply
+from core.inquiries import append_admin_note, fetch_inquiry
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 
@@ -124,35 +124,32 @@ def admin_reply(inq_id: int):
     payload = request.get_json(force=True) or {}
     answered_by = payload.get("answered_by") or "unknown"
     admin_reply_text = payload.get("admin_reply") or ""
-    process = bool(payload.get("process"))
 
     mem = current_app.config["MEM_ENGINE"]
     pipeline = current_app.config["PIPELINE"]
 
     try:
-        rounds = append_admin_note(mem, inq_id, by=answered_by, text_note=admin_reply_text)
-        set_admin_reply(mem, inq_id, reply=admin_reply_text, answered_by=answered_by)
+        with mem.begin() as c:
+            rounds = append_admin_note(c, inq_id, by=answered_by, text_note=admin_reply_text)
     except Exception as e:
         return {"ok": False, "error": f"append_failed: {e}"}, 500
 
-    if process:
+    processed = False
+    proc_res = None
+    if payload.get("process"):
+        processed = True
         try:
-            result = pipeline.reprocess_inquiry(inq_id)
-            return {
-                "ok": True,
-                "inquiry_id": inq_id,
-                "clarification_rounds": rounds,
-                "processed": True,
-                "result": result,
-            }, 200
+            proc_res = pipeline.reprocess_inquiry(inq_id)
         except Exception as e:
-            return {
-                "ok": False,
-                "inquiry_id": inq_id,
-                "error": f"process_failed: {e}",
-            }, 500
+            return {"ok": False, "inquiry_id": inq_id, "error": f"process_failed: {e}"}, 200
 
-    return {"ok": True, "inquiry_id": inq_id, "clarification_rounds": rounds}, 200
+    return {
+        "ok": True,
+        "inquiry_id": inq_id,
+        "clarification_rounds": rounds,
+        "processed": processed,
+        "result": proc_res,
+    }, 200
 
 
 @admin_bp.post("/inquiries/<int:inq_id>/process")


### PR DESCRIPTION
## Summary
- Fix admin note append SQL for Postgres JSONB and store reply metadata
- Add Pipeline helpers to reprocess inquiries and validate/execute SQL
- Parse admin replies and derive safe SQL hints in FA app
- Wire admin reply endpoint to optional reprocessing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c55d8b625c8323936ef74bcb817198