### PR TITLE
Fix admin inquiry processing and settings upsert

### DIFF
--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 from flask import Blueprint, request, jsonify, current_app
 from werkzeug.exceptions import BadRequest
-from sqlalchemy import text, bindparam
-from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy import text
+import json
 from core.inquiries import append_admin_note, fetch_inquiry
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
@@ -23,73 +23,83 @@ def settings_bulk():
     ns = payload.get("namespace") or "fa::common"
     updated_by = payload.get("updated_by") or "api"
 
-    upsert_sql = text(
-        """
-        INSERT INTO mem_settings(
-            namespace, key, value, value_type, scope, scope_id,
-            category, description, overridable, updated_by,
-            created_at, updated_at, is_secret
-        )
-        VALUES (
-            :ns, :key, :val, :vtype, :scope, :scope_id,
-            :cat, :desc, COALESCE(:ovr, true), :upd,
-            NOW(), NOW(), COALESCE(:sec, false)
-        )
-        ON CONFLICT (namespace, key, scope, COALESCE(scope_id, ''))
-        DO UPDATE SET
-            value       = EXCLUDED.value,
-            value_type  = EXCLUDED.value_type,
-            updated_by  = EXCLUDED.updated_by,
-            updated_at  = NOW(),
-            is_secret   = EXCLUDED.is_secret
-        """
-    ).bindparams(bindparam("val", type_=JSONB))
+    CASTS = {
+        "json": "CAST(:val AS jsonb)",
+        "int": "CAST(:val AS integer)",
+        "bool": "CAST(:val AS boolean)",
+        "string": "CAST(:val AS text)",
+        None: "CAST(:val AS jsonb)",
+    }
 
     def _infer_value_type(v):
         if isinstance(v, bool):
             return "bool"
         if isinstance(v, int):
             return "int"
-        if isinstance(v, float):
-            return "float"
-        if isinstance(v, (dict, list)):
+        if isinstance(v, (list, dict)):
             return "json"
         return "string"
 
-    items_out = []
+    items = payload.get("settings") or []
+    updated = []
+
     with mem_engine.begin() as c:
-        for item in payload.get("settings") or []:
-            key = item["key"]
-            scope = item.get("scope", "namespace")
-            scope_id = item.get("scope_id")
-            is_secret = bool(item.get("is_secret", False))
-            cat = item.get("category")
-            desc = item.get("description")
-            ovr = item.get("overridable")
-            val_py = item.get("value")
-            vtype = item.get("value_type") or _infer_value_type(val_py)
+        for it in items:
+            key = it["key"]
+            scope = it.get("scope", "namespace")
+            scope_id = it.get("scope_id")
+            val = it.get("value")
+            vtype = it.get("value_type") or _infer_value_type(val)
+            is_secret = bool(it.get("is_secret", False))
+
+            if vtype == "json":
+                bound_val = json.dumps(val)
+            elif vtype == "bool":
+                bound_val = str(bool(val)).lower()
+            elif vtype == "int":
+                bound_val = int(val) if val is not None else None
+            else:
+                bound_val = "" if val is None else str(val)
+
+            value_expr = CASTS.get(vtype, CASTS[None])
+
+            upsert_sql = text(
+                f"""
+            INSERT INTO mem_settings(namespace, key, value, value_type, scope, scope_id,
+                                     category, description, overridable, updated_by, created_at, updated_at, is_secret)
+            VALUES (:ns, :key, {value_expr}, :vtype, :scope, :scope_id,
+                    :cat, :desc, COALESCE(:ovr, true), :upd_by, NOW(), NOW(), :is_secret)
+            ON CONFLICT (namespace, key, scope, COALESCE(scope_id, ''))
+            DO UPDATE SET
+                value      = EXCLUDED.value,
+                value_type = EXCLUDED.value_type,
+                updated_by = EXCLUDED.updated_by,
+                updated_at = NOW(),
+                is_secret  = EXCLUDED.is_secret
+            """
+            )
 
             c.execute(
                 upsert_sql,
                 {
                     "ns": ns,
                     "key": key,
-                    "val": val_py,
+                    "val": bound_val,
                     "vtype": vtype,
                     "scope": scope,
                     "scope_id": scope_id,
-                    "cat": cat,
-                    "desc": desc,
-                    "ovr": ovr,
-                    "upd": updated_by,
-                    "sec": is_secret,
+                    "cat": it.get("category"),
+                    "desc": it.get("description"),
+                    "ovr": it.get("overridable"),
+                    "upd_by": updated_by,
+                    "is_secret": is_secret,
                 },
             )
-            items_out.append(
-                {"key": key, "value": val_py, "value_type": vtype, "scope": scope}
+            updated.append(
+                {"key": key, "value": val, "value_type": vtype, "scope": scope}
             )
 
-    return {"ok": True, "items": items_out}, 200
+    return {"ok": True, "items": updated}, 200
 
 
 @admin_bp.get("/settings/get")
@@ -124,32 +134,37 @@ def admin_reply(inq_id: int):
     payload = request.get_json(force=True) or {}
     answered_by = payload.get("answered_by") or "unknown"
     admin_reply_text = payload.get("admin_reply") or ""
+    process = bool(payload.get("process"))
 
-    mem = current_app.config["MEM_ENGINE"]
     pipeline = current_app.config["PIPELINE"]
+    mem = pipeline.mem_engine
 
     try:
-        with mem.begin() as c:
-            rounds = append_admin_note(c, inq_id, by=answered_by, text_note=admin_reply_text)
+        rounds = append_admin_note(
+            mem,
+            inq_id,
+            by=answered_by,
+            text_note=admin_reply_text,
+            admin_reply=admin_reply_text,
+        )
     except Exception as e:
-        return {"ok": False, "error": f"append_failed: {e}"}, 500
+        return jsonify({"ok": False, "error": f"append_failed: {e}"}), 500
 
-    processed = False
-    proc_res = None
-    if payload.get("process"):
-        processed = True
-        try:
-            proc_res = pipeline.reprocess_inquiry(inq_id)
-        except Exception as e:
-            return {"ok": False, "inquiry_id": inq_id, "error": f"process_failed: {e}"}, 200
-
-    return {
+    result = {
         "ok": True,
         "inquiry_id": inq_id,
         "clarification_rounds": rounds,
-        "processed": processed,
-        "result": proc_res,
-    }, 200
+    }
+
+    if process:
+        try:
+            proc = pipeline.process_inquiry(inq_id)
+            result["processed"] = True
+            result["result"] = proc
+        except Exception as e:
+            return jsonify({"ok": False, "inquiry_id": inq_id, "error": f"process_failed: {e}"}), 500
+
+    return jsonify(result), 200
 
 
 @admin_bp.post("/inquiries/<int:inq_id>/process")

--- a/core/sql_utils.py
+++ b/core/sql_utils.py
@@ -54,3 +54,30 @@ def inject_between_date_filter(sql: str, fully_qualified_col: str, start_iso: st
     if _WHERE_RE.search(base):
         return f"{base} AND {cond}"
     return f"{base} WHERE {cond}"
+
+
+def ensure_limit_100(sql: str) -> str:
+    """Ensure the SQL statement has a LIMIT 100 if none present."""
+    base = _strip_semicolon(sql)
+    if re.search(r"\blimit\b", base, re.I):
+        return base
+    return f"{base} LIMIT 100"
+
+
+def explain_sql(engine, sql: str):
+    """Run EXPLAIN on the given SQL and return the plan rows."""
+    from sqlalchemy import text as _text
+
+    with engine.connect() as c:
+        rs = c.execute(_text(f"EXPLAIN {sql}"))
+        return [tuple(r) for r in rs.fetchall()]
+
+
+def execute_sql(engine, sql: str):
+    """Execute the SQL and return a list of rows (dicts)."""
+    from sqlalchemy import text as _text
+
+    with engine.connect() as c:
+        rs = c.execute(_text(sql))
+        cols = list(rs.keys())
+        return [dict(zip(cols, r)) for r in rs.fetchall()]


### PR DESCRIPTION
## Summary
- Fix JSONB admin note appends without mixing param styles
- Clean up settings bulk upsert with explicit type casts
- Add `Pipeline.process_inquiry` for admin-triggered reprocessing and update admin reply endpoint
- Provide SQL helper utilities for limit/explain/execute

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5f0ad8f648323a335ab42d4b98920