### PR TITLE
Handle admin reply reprocessing and hint parsing

### DIFF
--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -158,7 +158,7 @@ def admin_reply(inq_id: int):
 
     if process:
         try:
-            proc = pipeline.process_inquiry(inq_id)
+            proc = pipeline.reprocess_inquiry(inq_id)
             result["processed"] = True
             result["result"] = proc
         except Exception as e:


### PR DESCRIPTION
## Summary
- Normalize question handling and add tolerant admin-note parser in FA hints
- Safely append admin notes using JSON binding
- Reprocess inquiries via new pipeline hook and expose it through admin reply API

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5f530dc308323bec999e46fe51983