### PR TITLE
Decouple pipeline hints, fix admin note JSON, dynamic FA types

### DIFF
--- a/apps/fa/hints.py
+++ b/apps/fa/hints.py
@@ -137,6 +137,22 @@ def make_fa_hints(mem_engine, prefixes: List[str], question: str) -> Dict[str, A
     return hints
 
 
+def fa_types_for(settings, namespace: str, categories: list[str]) -> list[int]:
+    """
+    Look up debtor/supplier/bank system type codes from mem_settings.FA_CATEGORY_MAP.
+    """
+    cmap = (settings.get("FA_CATEGORY_MAP", namespace=namespace) or {})
+    types: list[int] = []
+    for cat in categories:
+        meta = cmap.get(cat) or {}
+        for t in meta.get("types", []):
+            try:
+                types.append(int(t))
+            except Exception:
+                continue
+    return sorted(set(types))
+
+
 def parse_admin_answer(answer: str) -> Dict[str, Any]:
     """Placeholder for backward compatibility; returns empty overrides."""
     return {}

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -38,8 +38,13 @@ from core.inquiries import (
     get_admin_notes,
 )
 from core.emailer import Emailer
+# Core-level fallback clarifying questions (app can override by returning hints["questions"])
+DEFAULT_MISSING_FIELD_QUESTIONS = [
+    "What date range should we use (e.g., last month, between 2025-08-01 and 2025-08-31)?",
+    "Which tables should we use (e.g., invoices, customers, GL)?",
+    "Which metric should we compute (e.g., net sales, count of invoices)?",
+]
 from apps.fa.hints import (
-    MISSING_FIELD_QUESTIONS,
     DOMAIN_HINTS,
 )
 from apps.fa.agents import normalize_admin_reply
@@ -1258,9 +1263,11 @@ class Pipeline:
                 inquiry_id = self._log_inquiry(
                     ns, prefixes, question, auth_email, status="needs_clarification"
                 )
-            questions = [
-                MISSING_FIELD_QUESTIONS.get(m, f"Please clarify: {m}") for m in missing
-            ]
+            questions = (
+                (hints.get("questions") if hints else None)
+                or [f"Please clarify: {m}" for m in missing]
+                or DEFAULT_MISSING_FIELD_QUESTIONS
+            )
             return self._needs_clarification(inquiry_id, ns, questions)
 
         # -- 1) context


### PR DESCRIPTION
## Summary
- remove dependency on app-specific hint constants and provide core default clarifying questions
- correctly bind admin notes as JSON when appending
- look up FA type codes from settings instead of hardcoding

## Testing
- `pytest`
- `python -m py_compile core/pipeline.py core/inquiries.py apps/fa/hints.py apps/fa/agents.py`


------
https://chatgpt.com/codex/tasks/task_e_68c607f030a88323a95d3789947d56a6