### PR TITLE
Add datasource registry and FA research seeding

### DIFF
--- a/apps/fa/research.py
+++ b/apps/fa/research.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from typing import List, Dict, Any
+import os, glob, yaml, json
+from core.research import BaseResearcher, ResearchResult, SourceDoc
+
+class FAResearcher(BaseResearcher):
+    def search(self, question: str, prefixes: list[str]) -> ResearchResult:
+        metrics_dir = self.settings.get("FA_METRICS_PATH", scope="namespace", namespace=self.namespace) \
+                      or self.settings.get("FA_METRICS_PATH", scope="global", namespace=self.namespace) \
+                      or "apps/fa/metrics"
+        join_path = self.settings.get("FA_JOIN_GRAPH_PATH", scope="namespace", namespace=self.namespace) \
+                    or self.settings.get("FA_JOIN_GRAPH_PATH", scope="global", namespace=self.namespace) \
+                    or "apps/fa/join_graph.yaml"
+
+        sources: List[SourceDoc] = []
+        facts: Dict[str, Any] = {"fa": { "has_metrics": False, "has_joins": False, "metric_candidates": [], "joins": []}}
+
+        # Load metrics
+        if os.path.isdir(metrics_dir):
+            metric_files = sorted(glob.glob(os.path.join(metrics_dir, "*.yaml")))
+            for mf in metric_files:
+                try:
+                    with open(mf, "r", encoding="utf-8") as f:
+                        data = yaml.safe_load(f) or {}
+                    sources.append(SourceDoc(
+                        source_type="internal_doc",
+                        locator=mf, title=os.path.basename(mf),
+                        content=json.dumps(data, ensure_ascii=False)
+                    ))
+                    # pick a few metric keys
+                    for k, v in (data.get("metrics") or {}).items():
+                        facts["fa"]["metric_candidates"].append({"key": k, "def": v})
+                    facts["fa"]["has_metrics"] = True
+                except Exception:
+                    pass
+
+        # Load join graph
+        if os.path.exists(join_path):
+            try:
+                with open(join_path, "r", encoding="utf-8") as f:
+                    data = yaml.safe_load(f) or {}
+                sources.append(SourceDoc("internal_doc", join_path, "join_graph.yaml",
+                                         json.dumps(data, ensure_ascii=False)))
+                jlist = data.get("joins") or []
+                for j in jlist:
+                    facts["fa"]["joins"].append(j)
+                if jlist:
+                    facts["fa"]["has_joins"] = True
+            except Exception:
+                pass
+
+        summary = "FA research: metrics loaded={} joins loaded={}".format(
+            facts["fa"]["has_metrics"], facts["fa"]["has_joins"]
+        )
+        return ResearchResult(facts=facts, sources=sources, summary=summary)

--- a/apps/fa/seeders.py
+++ b/apps/fa/seeders.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+from typing import Any, Dict
+from sqlalchemy import text
+import yaml, os, glob, json
+
+def seed_fa_knowledge(mem_engine, namespace: str, metrics_dir: str, join_graph_path: str) -> Dict[str, Any]:
+    inserted = {"metrics": 0, "joins": 0}
+    with mem_engine.begin() as c:
+        # Insert join graph
+        if os.path.exists(join_graph_path):
+            data = yaml.safe_load(open(join_graph_path, "r", encoding="utf-8")) or {}
+            for j in data.get("joins", []):
+                c.execute(text("""
+                    INSERT INTO mem_join_graph(namespace, from_table, from_column, to_table, to_column,
+                                               join_type, cardinality, is_preferred, confidence)
+                    VALUES (:ns, :ft, :fc, :tt, :tc, :jt, :card, COALESCE(:pref,false), COALESCE(:conf,1.0))
+                    ON CONFLICT (namespace, from_table, from_column, to_table, to_column) DO NOTHING
+                """), {
+                    "ns": namespace,
+                    "ft": j.get("from_table"), "fc": j.get("from_column"),
+                    "tt": j.get("to_table"),   "tc": j.get("to_column"),
+                    "jt": j.get("join_type", "INNER"),
+                    "card": j.get("cardinality"),
+                    "pref": j.get("is_preferred"),
+                    "conf": j.get("confidence", 1.0)
+                })
+                inserted["joins"] += 1
+
+        # Insert metrics
+        if os.path.isdir(metrics_dir):
+            for mf in sorted(glob.glob(os.path.join(metrics_dir, "*.yaml"))):
+                data = yaml.safe_load(open(mf, "r", encoding="utf-8")) or {}
+                for key, meta in (data.get("metrics") or {}).items():
+                    c.execute(text("""
+                        INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
+                                                calculation_sql, required_tables, required_columns,
+                                                parameters, category, owner, version, is_active)
+                        VALUES (:ns, :key, :name, :desc, :sql, :rt, :rc, :params, :cat, :owner, :ver, true)
+                        ON CONFLICT (namespace, metric_key, version) DO NOTHING
+                    """), {
+                        "ns": namespace,
+                        "key": key,
+                        "name": meta.get("name") or key,
+                        "desc": meta.get("description"),
+                        "sql":  meta.get("calculation_sql"),
+                        "rt":   json.dumps(meta.get("required_tables") or []),
+                        "rc":   json.dumps(meta.get("required_columns") or []),
+                        "params": json.dumps(meta.get("parameters") or {}),
+                        "cat":  meta.get("category"),
+                        "owner": meta.get("owner"),
+                        "ver":  int(meta.get("version", 1)),
+                    })
+                    inserted["metrics"] += 1
+
+    return inserted

--- a/core/clarifier.py
+++ b/core/clarifier.py
@@ -4,7 +4,7 @@ import re
 from typing import Tuple, Dict, Any, Optional
 
 from core.specs import QuestionSpec
-from core.model_loader import load_model, load_clarifier_model
+from core.model_loader import load_model, load_clarifier
 
 
 _SMALTALK = re.compile(r'^\s*(hi|hello|hey|السلام عليكم|مرحبا|أهلًا|اهلا|ازيك)\b', re.I)
@@ -57,7 +57,7 @@ class ClarifierAgent:
 
     def __init__(self, settings):
         self.settings = settings
-        self.llm = load_clarifier_model(settings) or load_model(settings)
+        self.llm = load_clarifier(settings) or load_model(settings)
 
     def classify_and_extract(
         self, question: str, prefixes, domain_hints: Dict[str, Any]

--- a/core/datasources.py
+++ b/core/datasources.py
@@ -1,50 +1,73 @@
 from __future__ import annotations
-import threading
-from typing import Dict, Optional
+from dataclasses import dataclass
+from typing import Dict, Optional, Any, List
+import json
 from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
 
-from .settings import get_db_connections, get_default_datasource
+@dataclass
+class Datasource:
+    name: str
+    url: str
+    role: str = "oltp"
 
-
-class SqlRouter:
-    """Caches SQLAlchemy engines by logical datasource name."""
-
-    def __init__(self, settings):
-        self._settings = settings
-        self._lock = threading.Lock()
-        self._engines: Dict[str, any] = {}
-        self._sources: Dict[str, str] = {}
-        self._default: Optional[str] = None
+class DatasourceRegistry:
+    """
+    Builds SQLAlchemy engines from DB_CONNECTIONS setting (namespace-scoped).
+    Falls back to single APP_DB_URL if present.
+    """
+    def __init__(self, settings, namespace: str):
+        self.settings = settings
+        self.namespace = namespace
+        self._engines: Dict[str, Engine] = {}
+        self._default_name: Optional[str] = None
         self._load()
 
     def _load(self):
-        self._sources.clear()
-        self._engines.clear()
-        default = get_default_datasource(self._settings)
-        for s in get_db_connections(self._settings):
-            name = s["name"]
-            self._sources[name] = s["url"]
-            if s.get("default") and not default:
-                default = name
-        self._default = default
+        conns = self.settings.get("DB_CONNECTIONS", scope="namespace", namespace=self.namespace)
+        if not conns:
+            # backward compat: APP_DB_URL as the only datasource
+            app_url = self.settings.get("APP_DB_URL", scope="namespace", namespace=self.namespace)
+            if app_url:
+                ds = Datasource(name="default", url=app_url, role="oltp")
+                self._engines[ds.name] = self._mk_engine(ds.url)
+                self._default_name = ds.name
+            return
 
-    def reload(self):
-        with self._lock:
-            self._load()
+        for entry in conns:
+            name = entry.get("name")
+            url  = entry.get("url")
+            role = entry.get("role", "oltp")
+            if not name or not url:
+                continue
+            self._engines[name] = self._mk_engine(url)
+        default_name = self.settings.get("DEFAULT_DATASOURCE", scope="namespace", namespace=self.namespace) or None
+        if default_name and default_name in self._engines:
+            self._default_name = default_name
+        elif self._engines and not self._default_name:
+            # first as default
+            self._default_name = list(self._engines.keys())[0]
 
-    def list(self) -> dict:
-        return {"default": self._default, "sources": list(self._sources.keys())}
+    def _mk_engine(self, url: str) -> Engine:
+        # conservative defaults; MySQL & Postgres friendly
+        return create_engine(
+            url,
+            pool_pre_ping=True,
+            pool_recycle=1800,
+            future=True,
+        )
 
-    def get_engine(self, name: Optional[str] = None):
-        key = name or self._default
-        if not key:
-            raise RuntimeError("No default datasource configured.")
-        with self._lock:
-            eng = self._engines.get(key)
-            if eng is None:
-                url = self._sources.get(key)
-                if not url:
-                    raise KeyError(f"Datasource not found: {key}")
-                eng = create_engine(url, pool_pre_ping=True)
-                self._engines[key] = eng
-            return eng
+    def engine(self, name: Optional[str] = None) -> Engine:
+        if name is None:
+            if not self._default_name:
+                raise RuntimeError("No datasource configured")
+            name = self._default_name
+        if name not in self._engines:
+            raise KeyError(f"Unknown datasource: {name}")
+        return self._engines[name]
+
+    def list(self) -> List[str]:
+        return list(self._engines.keys())
+
+    def default_name(self) -> Optional[str]:
+        return self._default_name

--- a/core/snippets.py
+++ b/core/snippets.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from typing import List, Dict, Any, Optional
+from sqlalchemy import text
+import json
+from datetime import datetime
+
+def save_snippet(mem_engine, namespace: str, sql_raw: str,
+                 input_tables: List[str], filters_applied: List[str],
+                 tags: List[str], datasource: Optional[str],
+                 doc_md: Optional[str] = None, title: Optional[str] = None,
+                 description: Optional[str] = None) -> int:
+    with mem_engine.begin() as c:
+        r = c.execute(text("""
+            INSERT INTO mem_snippets(namespace, title, description, sql_template, sql_raw,
+                                     input_tables, filters_applied, doc_md, tags, datasource,
+                                     created_at, updated_at)
+            VALUES (:ns, :title, :desc, :tmpl, :raw, :it, :filters, :doc, :tags, :ds, NOW(), NOW())
+            RETURNING id
+        """), {
+            "ns": namespace,
+            "title": title, "desc": description,
+            "tmpl": sql_raw,  # keep same for now
+            "raw": sql_raw,
+            "it": json.dumps(input_tables or []),
+            "filters": json.dumps(filters_applied or []),
+            "doc": doc_md or "",
+            "tags": json.dumps(tags or []),
+            "ds": datasource
+        })
+        return r.scalar_one()


### PR DESCRIPTION
## Summary
- support multi-datasource registry and snippet saving
- add research scaffolding with FA metrics/join seeding
- harden admin settings API and clarifier loader

## Testing
- `python -m py_compile apps/fa/app.py core/admin_api.py core/clarifier.py core/datasources.py core/inquiries.py core/model_loader.py core/pipeline.py core/research.py apps/fa/research.py apps/fa/seeders.py core/snippets.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c68d0df8dc8323940c49bb7b467bee