### PR TITLE
feat: auto-widen empty queries and autosave snippets

### DIFF
--- a/apps/fa/app.py
+++ b/apps/fa/app.py
@@ -372,6 +372,7 @@ def answer():
                 "status": "ok",
                 "sql": result.get("sql"),
                 "rationale": result.get("rationale"),
+                **({"message": result.get("message")} if result.get("message") else {}),
                 **({"warnings": warnings} if warnings else {}),
             }
         )

--- a/apps/fa/sqlutils.py
+++ b/apps/fa/sqlutils.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+import re
+
+_LAST_MONTH_EQ = re.compile(
+    r"""DATE_FORMAT\(\s*(?P<col>[a-zA-Z0-9_\.]+)\s*,\s*'%Y-%m'\s*\)\s*=\s*
+        DATE_FORMAT\(\s*CURRENT_DATE\s*-\s*INTERVAL\s*1\s*MONTH\s*,\s*'%Y-%m'\s*\)""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_BETWEEN_LITERAL = re.compile(
+    r"""(?P<col>[a-zA-Z0-9_\.]+)\s+BETWEEN\s+'(?P<start>\d{4}-\d{2}-\d{2})'\s+AND\s+'(?P<end>\d{4}-\d{2}-\d{2})'""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+def widen_date_filter_mysql(sql: str, days: int = 90) -> str:
+    """
+    Heuristic widener for common 'last month' or literal BETWEEN patterns in MySQL.
+    Rewrites to a rolling WINDOW:  col >= CURRENT_DATE - INTERVAL {days} DAY.
+    Returns original SQL if no recognizable pattern found.
+    """
+    # 1) DATE_FORMAT(col, '%Y-%m') = DATE_FORMAT(CURRENT_DATE - INTERVAL 1 MONTH, '%Y-%m')
+    def _repl_last_month(m: re.Match) -> str:
+        col = m.group("col")
+        return f"{col} >= CURRENT_DATE - INTERVAL {int(days)} DAY"
+
+    new_sql = _LAST_MONTH_EQ.sub(_repl_last_month, sql)
+    if new_sql != sql:
+        return new_sql
+
+    # 2) col BETWEEN 'YYYY-MM-DD' AND 'YYYY-MM-DD'  -> col >= CURRENT_DATE - INTERVAL {days} DAY
+    def _repl_between(m: re.Match) -> str:
+        col = m.group("col")
+        return f"{col} >= CURRENT_DATE - INTERVAL {int(days)} DAY"
+
+    newer_sql = _BETWEEN_LITERAL.sub(_repl_between, sql)
+    return newer_sql

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -31,7 +31,7 @@ from core.settings import Settings
 from core.sql_exec import get_app_engine, run_select, as_csv
 from core.datasources import DatasourceRegistry
 from core.research import load_researcher
-from core.snippets import save_snippet
+from core.snippets import persist_snippet, build_doc_md
 from core.sql_utils import extract_sql, looks_like_sql
 from core.inquiries import (
     create_or_update_inquiry,
@@ -40,6 +40,7 @@ from core.inquiries import (
     get_admin_notes,
 )
 from core.emailer import Emailer
+from apps.fa.sqlutils import widen_date_filter_mysql
 from apps.fa.hints import (
     MISSING_FIELD_QUESTIONS,
     DOMAIN_HINTS,
@@ -440,14 +441,49 @@ class Pipeline:
                 "error": f"validation/exec failed: {e}",
             }
 
+        message = None
+        sql_used = exec_result.get("sql_used", canonical_sql)
+        if exec_result.get("rowcount", 0) == 0:
+            if self.settings.empty_result_autoretry(ns):
+                retry = self._maybe_autowiden_and_retry(
+                    sql=canonical_sql, namespace=ns, prefixes=prefixes
+                )
+                if retry.get("rowcount", 0) > 0:
+                    exec_result = retry
+                    sql_used = retry.get("sql_used", canonical_sql)
+                    message = (
+                        f"No results for last month; expanded to last {self.settings.empty_result_window_days(ns)} days."
+                    )
+                else:
+                    exec_result = retry
+                    message = (
+                        "No results for last month. Try last 3 months or a specific range (e.g., between 2024-06-01 and 2024-08-31)."
+                    )
+            else:
+                message = "No results for last month. Try widening the date range."
+
+        snip_id = self._maybe_persist_snippet(
+            sql=sql_used,
+            namespace=ns,
+            datasource=self.settings.default_datasource(ns),
+            rows_count=exec_result.get("rowcount", 0),
+            question=question,
+            tags_extra=["autowiden"] if exec_result.get("autowiden_applied") else [],
+        )
+
         self._update_inquiry_status(inquiry_id, "answered")
-        return {
+        out = {
             "ok": True,
             "inquiry_id": inquiry_id,
             "status": "answered",
-            "sql": canonical_sql,
+            "sql": sql_used,
             "result": exec_result,
         }
+        if message:
+            out["message"] = message
+        if snip_id:
+            out["snippet_id"] = snip_id
+        return out
 
     def _update_inquiry_status(self, inquiry_id: int, status: str) -> None:
         with self.mem_engine.begin() as c:
@@ -478,7 +514,70 @@ class Pipeline:
             return {"explain": plan}
         else:
             rows = execute_sql(self.app_engine, safe_sql)
-            return {"rows": rows[:100], "rowcount": len(rows)}
+            return {"rows": rows[:100], "rowcount": len(rows), "sql_used": sql}
+
+    def _maybe_autowiden_and_retry(
+        self, *, sql: str, namespace: str, prefixes: list[str]
+    ) -> dict:
+        """
+        If the first execution returned zero rows, optionally widen date window and retry once.
+        Returns execution-like dict with autowiden_applied flag and sql_used.
+        """
+        window_days = self.settings.empty_result_window_days(namespace)
+        widened = widen_date_filter_mysql(sql, days=window_days)
+        if widened == sql:
+            return {"autowiden_applied": False, "sql_used": sql, "rowcount": 0, "rows": []}
+
+        exec2 = self._validate_and_execute_sql(namespace, prefixes, widened)
+        exec2["autowiden_applied"] = True
+        exec2["sql_used"] = widened
+        return exec2
+
+    def _maybe_persist_snippet(
+        self,
+        *,
+        sql: str,
+        namespace: str,
+        datasource: str | None,
+        rows_count: int,
+        question: str,
+        tags_extra=None,
+    ) -> Optional[int]:
+        """Save to mem_snippets when result is non-empty."""
+        if not self.settings.snippets_autosave(namespace):
+            return None
+        if rows_count <= 0:
+            return None
+
+        input_tabs = []
+        for tok in sql.split():
+            if tok.startswith("`") and tok.endswith("`"):
+                input_tabs.append(tok.strip("`"))
+        tags = ["fa", "auto", "snippet"] + list(tags_extra or [])
+        title = question[:80] if question else "Saved query"
+        doc = build_doc_md(
+            sql, title=title, rationale="Auto-saved after successful run", datasource=datasource
+        )
+        try:
+            snip_id = persist_snippet(
+                self.mem_engine,
+                namespace,
+                sql_raw=sql,
+                title=title,
+                description=None,
+                tags=tags,
+                input_tables=input_tabs,
+                filters_applied=[],
+                parameters={"source": "pipeline.autosave"},
+                doc_md=doc,
+                datasource=datasource,
+                verified=False,
+                verified_by=None,
+            )
+            return snip_id
+        except Exception as e:
+            print(f"[snippet] persist failed: {e}")
+            return None
 
     def reprocess_inquiry(self, inquiry_id: int, namespace: Optional[str] = None) -> Dict[str, Any]:
         """

--- a/core/settings.py
+++ b/core/settings.py
@@ -258,6 +258,26 @@ class Settings:
         v = self.get("ENDUSER_CAN_CLARIFY", namespace=namespace)
         return str(v).strip().lower() in {"1", "true", "yes", "y"}
 
+    def empty_result_autoretry(self, namespace: str | None = None) -> bool:
+        return bool(
+            self.get("EMPTY_RESULT_AUTORETRY", default=True, namespace=namespace)
+        )
+
+    def empty_result_window_days(self, namespace: str | None = None) -> int:
+        try:
+            return int(
+                self.get(
+                    "EMPTY_RESULT_AUTORETRY_DAYS", default=90, namespace=namespace
+                )
+            )
+        except Exception:
+            return 90
+
+    def snippets_autosave(self, namespace: str | None = None) -> bool:
+        return bool(
+            self.get("SNIPPETS_AUTOSAVE", default=True, namespace=namespace)
+        )
+
     def research_enabled(self, namespace: str | None = None) -> bool:
         """Namespace-aware research policy with sane fallbacks."""
         # 1) per-namespace toggle

--- a/core/snippets.py
+++ b/core/snippets.py
@@ -1,30 +1,71 @@
 from __future__ import annotations
-from typing import List, Dict, Any, Optional
+from typing import Iterable, Optional, Sequence
 from sqlalchemy import text
 import json
-from datetime import datetime
+import datetime as dt
 
-def save_snippet(mem_engine, namespace: str, sql_raw: str,
-                 input_tables: List[str], filters_applied: List[str],
-                 tags: List[str], datasource: Optional[str],
-                 doc_md: Optional[str] = None, title: Optional[str] = None,
-                 description: Optional[str] = None) -> int:
+def build_doc_md(sql: str,
+                 title: str | None = None,
+                 rationale: str | None = None,
+                 datasource: str | None = None) -> str:
+    title = title or "Saved query"
+    lines = [f"# {title}"]
+    if datasource:
+        lines.append(f"- **Datasource**: `{datasource}`")
+    if rationale:
+        lines.append(f"- **Rationale**: {rationale}")
+    lines += ["", "```sql", sql.strip(), "```"]
+    return "\n".join(lines)
+
+def persist_snippet(mem_engine,
+                    namespace: str,
+                    sql_raw: str,
+                    *,
+                    title: str | None = None,
+                    description: str | None = None,
+                    tags: Optional[Sequence[str]] = None,
+                    input_tables: Optional[Sequence[str]] = None,
+                    filters_applied: Optional[Sequence[str]] = None,
+                    parameters: Optional[dict] = None,
+                    doc_md: Optional[str] = None,
+                    datasource: Optional[str] = None,
+                    verified: bool = False,
+                    verified_by: Optional[str] = None) -> int:
+    """
+    Inserts into mem_snippets and returns new snippet id.
+    """
     with mem_engine.begin() as c:
-        r = c.execute(text("""
-            INSERT INTO mem_snippets(namespace, title, description, sql_template, sql_raw,
-                                     input_tables, filters_applied, doc_md, tags, datasource,
-                                     created_at, updated_at)
-            VALUES (:ns, :title, :desc, :tmpl, :raw, :it, :filters, :doc, :tags, :ds, NOW(), NOW())
-            RETURNING id
-        """), {
-            "ns": namespace,
-            "title": title, "desc": description,
-            "tmpl": sql_raw,  # keep same for now
-            "raw": sql_raw,
-            "it": json.dumps(input_tables or []),
-            "filters": json.dumps(filters_applied or []),
-            "doc": doc_md or "",
-            "tags": json.dumps(tags or []),
-            "ds": datasource
-        })
-        return r.scalar_one()
+        res = c.execute(
+            text("""
+                INSERT INTO mem_snippets(
+                    namespace, title, description,
+                    sql_template, sql_raw,
+                    input_tables, filters_applied, parameters,
+                    doc_md, tags, datasource, is_verified, verified_by, created_at, updated_at
+                )
+                VALUES (
+                    :ns, :title, :desc,
+                    :tpl, :raw,
+                    :in_tabs, :filters, :params,
+                    :doc_md, :tags, :ds, :ver, :ver_by, NOW(), NOW()
+                )
+                RETURNING id
+            """),
+            {
+                "ns": namespace,
+                "title": title,
+                "desc": description,
+                "tpl": None,  # reserved for future parameterization
+                "raw": sql_raw,
+                "in_tabs": json.dumps(list(input_tables or [])),
+                "filters": json.dumps(list(filters_applied or [])),
+                "params": json.dumps(parameters or {}),
+                "doc_md": doc_md or build_doc_md(sql_raw, title, datasource=datasource),
+                "tags": json.dumps(list(tags or [])),
+                "ds": datasource,
+                "ver": bool(verified),
+                "ver_by": verified_by,
+            },
+        )
+        new_id = res.scalar_one()
+    return int(new_id)


### PR DESCRIPTION
## Summary
- add SQL date widener for MySQL queries
- persist executed SQL snippets with minimal Markdown docs
- auto-retry empty results with wider window and save snippet when successful
- expose friendly pipeline message in /fa/answer responses

## Testing
- `python -m py_compile apps/fa/sqlutils.py core/snippets.py core/settings.py core/pipeline.py apps/fa/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6a6e36b6c8323a73da6a4f724a90f