### PR TITLE
Use load_researcher helper and clarify device mapping

### DIFF
--- a/core/model_loader.py
+++ b/core/model_loader.py
@@ -536,6 +536,7 @@ def _load_hf(
     max_seq_len: int,
     gen_defaults: Dict[str, Any],
     s: _SettingsShim,
+    device_map: str = "auto",
 ) -> ModelHandle:
     """
     Load a HuggingFace model with optional quantization.
@@ -552,7 +553,7 @@ def _load_hf(
     hf_kwargs: Dict[str, Any] = {
         "trust_remote_code": True,
         "low_cpu_mem_usage": True,
-        "device_map": "auto",
+        "device_map": device_map,
     }
 
     if backend == "hf-4bit":
@@ -642,7 +643,8 @@ def load_clarifier(settings: Any | None = None) -> ModelHandle:
         "top_p": float(s.get("CLARIFIER_TOP_P", "0.9") or 0.9),
         "stop": [],
     }
-    handle = _load_hf(path, backend, max_len, gen_defaults, s)
+    device_map_env = str(os.getenv("CLARIFIER_DEVICE_MAP", "auto")).strip()
+    handle = _load_hf(path, backend, max_len, gen_defaults, s, device_map=device_map_env)
     try:
         handle.meta["role"] = "clarifier"
         handle.meta["max_seq_len"] = max_len

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -169,9 +169,7 @@ class Pipeline:
             return
 
         # build via research factory (handles class/provider/mode)
-        from core.research import build_researcher
-
-        self.researcher = build_researcher(self.settings)
+        self.researcher = load_researcher(self.settings, namespace=self.namespace)
         self._researcher_fingerprint = desired_key
 
     def _instantiate_researcher(self, class_path: str | None):

--- a/core/research.py
+++ b/core/research.py
@@ -35,3 +35,11 @@ def load_researcher(settings, namespace: str) -> Optional[BaseResearcher]:
     mod = __import__(mod_name, fromlist=[cls_name])
     cls = getattr(mod, cls_name)
     return cls(settings=settings, namespace=namespace)
+
+
+# Backward compatibility shim
+def build_researcher(settings, namespace: Optional[str] = None) -> Optional[BaseResearcher]:
+    return load_researcher(settings, namespace=namespace)
+
+
+__all__ = ["load_researcher", "build_researcher"]


### PR DESCRIPTION
## Summary
- replace deprecated `build_researcher` calls with `load_researcher`
- add `build_researcher` compatibility alias
- respect `CLARIFIER_DEVICE_MAP` when loading clarifier models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c6afcce9108323be4175073bf02a18