### PR TITLE
Fix settings bulk SQL and clarifier loader

### DIFF
--- a/core/memdb.py
+++ b/core/memdb.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from core.settings import Settings
+
+class MemoryDB:
+    """Lightweight helper around an Engine for mem_settings."""
+    def __init__(self, settings: Settings) -> None:
+        url = settings.get("MEMORY_DB_URL") or "sqlite://"
+        self.engine: Engine = create_engine(url, pool_pre_ping=True, pool_recycle=3600)


### PR DESCRIPTION
## Summary
- rewrite admin settings bulk upsert to use consistent bind params, JSONB cast, and constraint-based conflict handling
- add MemoryDB helper for mem_settings engine access
- harden clarifier loader by forcing NF4 quantization on CPU and exposing optional hf_kwargs in `_load_hf`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c725dd02c883238f9a4fd5a7346d22