### PR TITLE
feat: add clarifier off switch and auto-retry for empty results

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 # Clarifier on CPU, 4-bit NF4, compute in fp32 (CPU-safe)
 CLARIFIER_MODEL_PATH=/var/www/longchain/models/Meta-Llama-3.1-8B-Instruct
-CLARIFIER_MODEL_BACKEND=hf-4bit
+CLARIFIER_MODEL_BACKEND=off
 CLARIFIER_DEVICE_MAP=cpu
 CLARIFIER_OFFLOAD_FP32=1           # harmless for 4bit; ignore if you like
 CLARIFIER_LOW_CPU_MEM=1

--- a/core/settings.py
+++ b/core/settings.py
@@ -260,7 +260,7 @@ class Settings:
 
     def empty_result_autoretry(self, namespace: str | None = None) -> bool:
         return bool(
-            self.get("EMPTY_RESULT_AUTORETRY", default=True, namespace=namespace)
+            self.get("EMPTY_RESULT_AUTORETRY", default=False, namespace=namespace)
         )
 
     def empty_result_window_days(self, namespace: str | None = None) -> int:


### PR DESCRIPTION
## Summary
- disable clarifier by default via `CLARIFIER_MODEL_BACKEND=off`
- make clarifier loader honor `CLARIFIER_MODEL_BACKEND` and accept HF kwargs
- safeguard pipeline when clarifier is missing and widen MySQL last-month queries on empty results
- default empty-result auto-retry to disabled

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c734098450832382131f921accad6f