### PR TITLE
FA: researcher fallback, datasource registry, first-use seeding, snippet autosave, friendly empty results (clarifier disabled)

### DIFF
--- a/core/datasources.py
+++ b/core/datasources.py
@@ -1,73 +1,45 @@
 from __future__ import annotations
-from dataclasses import dataclass
 from typing import Dict, Optional, Any, List
-import json
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from .settings import Settings
 
-@dataclass
-class Datasource:
-    name: str
-    url: str
-    role: str = "oltp"
 
 class DatasourceRegistry:
     """
-    Builds SQLAlchemy engines from DB_CONNECTIONS setting (namespace-scoped).
-    Falls back to single APP_DB_URL if present.
+    Builds a map {name: sqlalchemy.Engine} from mem_settings.DB_CONNECTIONS.
+    Falls back to APP_DB_URL as 'default' when DB_CONNECTIONS is absent.
     """
-    def __init__(self, settings, namespace: str):
+
+    def __init__(self, settings: Settings):
         self.settings = settings
-        self.namespace = namespace
-        self._engines: Dict[str, Engine] = {}
-        self._default_name: Optional[str] = None
+        self._engines: Dict[str, Any] = {}
         self._load()
 
-    def _load(self):
-        conns = self.settings.get("DB_CONNECTIONS", scope="namespace", namespace=self.namespace)
-        if not conns:
-            # backward compat: APP_DB_URL as the only datasource
-            app_url = self.settings.get("APP_DB_URL", scope="namespace", namespace=self.namespace)
-            if app_url:
-                ds = Datasource(name="default", url=app_url, role="oltp")
-                self._engines[ds.name] = self._mk_engine(ds.url)
-                self._default_name = ds.name
-            return
+    def _load(self) -> None:
+        conns = self.settings.get("DB_CONNECTIONS", scope="namespace") or []
+        # Support old shape {name:url}
+        if isinstance(conns, dict):
+            conns = [{"name": k, "url": v, "role": "oltp"} for k, v in conns.items()]
 
-        for entry in conns:
-            name = entry.get("name")
-            url  = entry.get("url")
-            role = entry.get("role", "oltp")
-            if not name or not url:
-                continue
-            self._engines[name] = self._mk_engine(url)
-        default_name = self.settings.get("DEFAULT_DATASOURCE", scope="namespace", namespace=self.namespace) or None
-        if default_name and default_name in self._engines:
-            self._default_name = default_name
-        elif self._engines and not self._default_name:
-            # first as default
-            self._default_name = list(self._engines.keys())[0]
+        for d in conns:
+            name = d.get("name")
+            url = d.get("url")
+            if name and url and name not in self._engines:
+                self._engines[name] = create_engine(url, pool_pre_ping=True, future=True)
 
-    def _mk_engine(self, url: str) -> Engine:
-        # conservative defaults; MySQL & Postgres friendly
-        return create_engine(
-            url,
-            pool_pre_ping=True,
-            pool_recycle=1800,
-            future=True,
-        )
+        # Fallback single-app URL
+        app_url = self.settings.get("APP_DB_URL", scope="namespace")
+        if app_url and "default" not in self._engines:
+            self._engines["default"] = create_engine(app_url, pool_pre_ping=True, future=True)
 
-    def engine(self, name: Optional[str] = None) -> Engine:
-        if name is None:
-            if not self._default_name:
-                raise RuntimeError("No datasource configured")
-            name = self._default_name
-        if name not in self._engines:
-            raise KeyError(f"Unknown datasource: {name}")
-        return self._engines[name]
+    def engine(self, name: Optional[str] = None):
+        if not name:
+            name = self.settings.get("DEFAULT_DATASOURCE", scope="namespace") or "default"
+        eng = self._engines.get(name) or self._engines.get("default")
+        if not eng:
+            raise RuntimeError("No datasource engine found for requested datasource.")
+        return eng
 
     def list(self) -> List[str]:
-        return list(self._engines.keys())
+        return sorted(self._engines.keys())
 
-    def default_name(self) -> Optional[str]:
-        return self._default_name

--- a/core/research.py
+++ b/core/research.py
@@ -1,45 +1,86 @@
 from __future__ import annotations
-from dataclasses import dataclass
-from typing import List, Dict, Any, Optional, Tuple
-import hashlib
+from typing import Any, Dict, List, Optional
+import importlib, hashlib
+from sqlalchemy import text
+from .settings import Settings
 
-@dataclass
-class SourceDoc:
-    source_type: str      # 'internal_doc', 'web', ...
-    locator: str          # path or URL
-    title: str
-    content: str          # parsed text
-    is_redistributable: bool = True
 
-@dataclass
-class ResearchResult:
-    facts: Dict[str, Any]
-    sources: List[SourceDoc]
-    summary: str
+class NoopResearcher:
+    """Safe stub used when research is disabled or class fails to load."""
 
-class BaseResearcher:
-    def __init__(self, settings, namespace: str):
+    def __init__(self, settings: Settings | None = None):
         self.settings = settings
-        self.namespace = namespace
 
-    def search(self, question: str, prefixes: list[str]) -> ResearchResult:
-        # default: no-op
-        return ResearchResult(facts={}, sources=[], summary="")
+    def search(self, question: str, prefixes: List[str], settings: Settings) -> Dict[str, Any]:
+        # Shape expected by pipeline; feel free to extend later
+        return {"facts": [], "sources": []}
 
-# Simple loader from FQCN in settings
-def load_researcher(settings, namespace: str) -> Optional[BaseResearcher]:
-    fqcn = settings.get("RESEARCHER_CLASS", scope="global", namespace=namespace)
-    if not fqcn:
+
+def load_researcher(settings: Settings):
+    if not settings.get("RESEARCH_MODE", scope="namespace"):
+        print("[research] disabled via RESEARCH_MODE")
         return None
-    mod_name, cls_name = fqcn.rsplit(".", 1)
-    mod = __import__(mod_name, fromlist=[cls_name])
-    cls = getattr(mod, cls_name)
-    return cls(settings=settings, namespace=namespace)
+    cls_path = settings.get("RESEARCHER_CLASS", scope="global")
+    if not cls_path:
+        print("[research] RESEARCHER_CLASS not set; using NoopResearcher")
+        return NoopResearcher(settings)
+    try:
+        mod_name, cls_name = cls_path.rsplit(".", 1)
+        mod = importlib.import_module(mod_name)
+        cls = getattr(mod, cls_name)
+        inst = cls(settings=settings) if "settings" in getattr(cls, "__init__", (lambda: None)).__code__.co_varnames else cls()
+        print(f"[research] loaded: {cls_path}")
+        return inst
+    except Exception as e:
+        print(f"[research] load failed: {e}; using NoopResearcher")
+        return NoopResearcher(settings)
 
 
-# Backward compatibility shim
-def build_researcher(settings, namespace: Optional[str] = None) -> Optional[BaseResearcher]:
-    return load_researcher(settings, namespace=namespace)
+def persist_sources_and_link(mem_engine, namespace: str, run_id: int, items: List[Dict[str, Any]]) -> List[int]:
+    """
+    items: list of {title?, url?/locator?, content/text?, type?}
+    Writes to mem_sources and links each to mem_citations as (fact_type='run', fact_id=run_id).
+    Returns the list of inserted source ids.
+    """
+    if not items:
+        return []
+    source_ids: List[int] = []
+    with mem_engine.begin() as c:
+        for it in items:
+            title = it.get("title") or it.get("url") or "source"
+            locator = it.get("url") or it.get("locator")
+            content = it.get("content") or it.get("text") or ""
+            stype = it.get("type") or "web"
 
+            h = hashlib.sha256((content or "").encode("utf-8")).hexdigest()
+            sid = c.execute(
+                text(
+                    """
+                INSERT INTO mem_sources(namespace, source_type, locator, title, content_hash,
+                                        is_redistributable, parsed_content, added_at)
+                VALUES (:ns, :stype, :loc, :title, :h, true, :content, NOW())
+                ON CONFLICT (namespace, content_hash) DO UPDATE
+                SET last_accessed = NOW()
+                RETURNING id
+            """
+                ),
+                {"ns": namespace, "stype": stype, "loc": locator, "title": title, "h": h, "content": content},
+            ).scalar_one()
+            source_ids.append(sid)
 
-__all__ = ["load_researcher", "build_researcher"]
+            c.execute(
+                text(
+                    """
+                INSERT INTO mem_citations(namespace, fact_type, fact_id, source_id, quote, confidence, created_at)
+                VALUES (:ns, 'run', :rid, :sid, :quote, :conf, NOW())
+            """
+                ),
+                {
+                    "ns": namespace,
+                    "rid": run_id,
+                    "sid": sid,
+                    "quote": (content or "")[:240],
+                    "conf": 0.7,
+                },
+            )
+    return source_ids


### PR DESCRIPTION
## Summary
- Add datasource registry to resolve engines by name with default fallback
- Introduce NoopResearcher and helper to persist sources and citations
- Make clarifier model optional via environment and settings
- Ensure FA knowledge is ingested on first answer request and support bulk settings upsert
- Initialize pipeline with datasource registry and track default datasource

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7451dabb883239273e465edde413c