### PR TITLE
Handle APP_DB_URL fallback for datasource

### DIFF
--- a/core/datasources.py
+++ b/core/datasources.py
@@ -1,94 +1,113 @@
+# core/datasources.py
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, Optional, Any, List
+import json
+import os
+from typing import Any, Dict, Optional
+
 from sqlalchemy import create_engine
-from urllib.parse import urlparse
-import re
-
-
-@dataclass
-class DSConfig:
-    name: str
-    url: str
-    role: str = "oltp"
-
-
-def _dbname_from_url(url: str) -> str:
-    # mysql+pymysql://user:pass@host/dbname?charset=utf8mb4
-    try:
-        p = urlparse(url)
-        # path like "/dbname"
-        db = (p.path or "/").lstrip("/") or "app"
-        # strip query decorations if any (usually not in path)
-        db = re.split(r"[?#]", db, 1)[0]
-        return db
-    except Exception:
-        return "app"
+from sqlalchemy.engine import Engine
 
 
 class DatasourceRegistry:
     """
-    Loads datasource engines from settings:
-      - Prefer DB_CONNECTIONS (array of {name,url,role})
-      - Else fallback to APP_DB_URL as a single engine
-      - DEFAULT_DATASOURCE chooses the default; else only engine name
+    Builds a pool of SQLAlchemy engines from settings.
+
+    Priority:
+      1) DB_CONNECTIONS  (array of {"name","url","role"})
+      2) APP_DB_URL      (single URL; name = DEFAULT_DATASOURCE or 'app')
+      3) env APP_DB_URL / FA_DB_URL (same fallback as #2)
+
+    Default selection:
+      - DEFAULT_DATASOURCE if present
+      - else: if exactly one engine exists, use that
     """
 
-    def __init__(self, settings):
+    def __init__(self, settings: Any, namespace: Optional[str] = None) -> None:
         self.settings = settings
-        self.engines: Dict[str, Any] = {}
+        # keep the namespace for potential future scoping; Settings typically already resolves scope
+        self.namespace = namespace or getattr(settings, "namespace", None)
+        self.engines: Dict[str, Engine] = {}
         self.default_name: Optional[str] = None
-        self._build()
 
-    def _build(self) -> None:
-        # Try multi-DS first
-        conns: List[dict] = self.settings.get("DB_CONNECTIONS") or []
+        self._load_from_settings()
 
-        if not conns:
-            # Fallback to single app DS
-            app_url: Optional[str] = self.settings.get("APP_DB_URL")
-            if app_url:
-                default_name = (
-                    self.settings.get("DEFAULT_DATASOURCE")
-                    or _dbname_from_url(app_url)
-                    or "app"
-                )
-                conns = [{"name": default_name, "url": app_url, "role": "oltp"}]
+    # --- public API ---------------------------------------------------------
 
-        # Build engines
-        for c in conns:
-            name = str(c.get("name") or "").strip()
-            url = str(c.get("url") or "").strip()
-            if not name or not url:
-                continue
-            try:
-                self.engines[name] = create_engine(url, pool_pre_ping=True)
-            except Exception as e:
-                print(f"[datasources] failed to create engine for {name}: {e}")
+    def engine(self, name: Optional[str]) -> Engine:
+        """
+        Return an engine by name. If name is None, use the configured default.
+        If only one engine exists, that becomes the default implicitly.
+        """
+        target = name or self.default_name or (next(iter(self.engines)) if len(self.engines) == 1 else None)
+        if target and target in self.engines:
+            return self.engines[target]
+        raise RuntimeError("No datasource engine found for requested datasource.")
 
-        # Choose default
-        self.default_name = self.settings.get("DEFAULT_DATASOURCE")
-        if not self.default_name and self.engines:
-            # if only one engine, make it default
-            if len(self.engines) == 1:
-                self.default_name = next(iter(self.engines.keys()))
+    def has_any(self) -> bool:
+        return bool(self.engines)
 
-        # Log what we have
-        if not self.engines:
+    # --- internals ----------------------------------------------------------
+
+    def _load_from_settings(self) -> None:
+        raw_conns = self.settings.get("DB_CONNECTIONS", None)
+        default_ds = self.settings.get("DEFAULT_DATASOURCE", None)
+
+        # Parse DB_CONNECTIONS if it arrived as a JSON string
+        connections: Optional[list] = None
+        if raw_conns:
+            if isinstance(raw_conns, str):
+                try:
+                    connections = json.loads(raw_conns)
+                except Exception:
+                    print("[datasources] WARNING: DB_CONNECTIONS is a string but not valid JSON; ignoring.")
+                    connections = None
+            elif isinstance(raw_conns, (list, tuple)):
+                connections = list(raw_conns)
+            else:
+                print("[datasources] WARNING: DB_CONNECTIONS has unexpected type; ignoring.")
+
+        # Fallback to APP_DB_URL (settings) or env
+        app_url = self.settings.get("APP_DB_URL", None) or os.getenv("APP_DB_URL") or os.getenv("FA_DB_URL")
+
+        if not connections and app_url:
+            # synthesize a single entry
+            name = default_ds or "app"
+            connections = [{"name": name, "url": app_url, "role": "oltp"}]
+            if not default_ds:
+                default_ds = name
+
+        if not connections:
             print("[datasources] no engines created (check DB_CONNECTIONS or APP_DB_URL).")
-        else:
-            print(f"[datasources] engines: {list(self.engines.keys())}, default={self.default_name}")
+            self.default_name = None
+            self.engines = {}
+            return
 
-    def engine(self, name: Optional[str]) -> Any:
-        # Allow None / "" to mean "give me the default"
-        if not name:
-            name = self.default_name
-        if not name and self.engines:
-            # Last chance: single engine scenario
-            if len(self.engines) == 1:
-                return next(iter(self.engines.values()))
-        if not name or name not in self.engines:
-            raise RuntimeError("No datasource engine found for requested datasource.")
-        return self.engines[name]
+        created = []
+        for entry in connections:
+            try:
+                name = entry.get("name")
+                url = entry.get("url")
+                if not name or not url:
+                    continue
+                # reasonable pool defaults; adjust if needed per RDS/MySQL
+                engine = create_engine(
+                    url,
+                    pool_pre_ping=True,
+                    pool_recycle=1800,
+                    pool_size=5,
+                    max_overflow=10,
+                )
+                self.engines[name] = engine
+                created.append(name)
+            except Exception as e:
+                print(f"[datasources] failed creating engine for {entry!r}: {e}")
+
+        # Decide default
+        self.default_name = default_ds or (created[0] if len(created) == 1 else None)
+
+        if not self.engines:
+            print("[datasources] no engines created after processing entries.")
+        else:
+            print(f"[datasources] engines created: {created}; default={self.default_name!r}")
 

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -85,7 +85,7 @@ class Pipeline:
             else Settings(namespace=namespace)
         )
         # Build datasource registry and choose default engine early
-        self.ds = DatasourceRegistry(self.settings)
+        self.ds = DatasourceRegistry(self.settings, namespace=self.namespace)
         self.app_engine = self.ds.engine(None)
 
         self.researcher = load_researcher(self.settings)


### PR DESCRIPTION
## Summary
- Rework DatasourceRegistry to build engines from DB_CONNECTIONS or fallback APP_DB_URL
- Allow registry to synthesize single engine and select safe default
- Pass namespace to DatasourceRegistry in Pipeline initialization

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c74b2ff1988323b1de29f1ff221bfe