### PR TITLE
Fix datasource bootstrap and robust settings bulk

### DIFF
--- a/core/datasources.py
+++ b/core/datasources.py
@@ -1,113 +1,59 @@
-# core/datasources.py
 from __future__ import annotations
 
-import json
-import os
-from typing import Any, Dict, Optional
-
+from typing import Dict, Optional
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine
+from .settings import Settings
 
 
 class DatasourceRegistry:
     """
-    Builds a pool of SQLAlchemy engines from settings.
-
-    Priority:
-      1) DB_CONNECTIONS  (array of {"name","url","role"})
-      2) APP_DB_URL      (single URL; name = DEFAULT_DATASOURCE or 'app')
-      3) env APP_DB_URL / FA_DB_URL (same fallback as #2)
-
-    Default selection:
-      - DEFAULT_DATASOURCE if present
-      - else: if exactly one engine exists, use that
+    Builds SQLAlchemy engines from mem_settings:
+      - DB_CONNECTIONS: [{"name":"frontaccounting_bk","url":"...","role":"oltp"}, ...]
+      - DEFAULT_DATASOURCE: name to use when none is requested
+      - APP_DB_URL: fallback single-URL when DB_CONNECTIONS is not set
+      - FA_DB_URL: final env fallback
     """
 
-    def __init__(self, settings: Any, namespace: Optional[str] = None) -> None:
+    def __init__(self, settings: Settings, namespace: str):
         self.settings = settings
-        # keep the namespace for potential future scoping; Settings typically already resolves scope
-        self.namespace = namespace or getattr(settings, "namespace", None)
-        self.engines: Dict[str, Engine] = {}
+        self.namespace = namespace
+        self._engines: Dict[str, any] = {}
         self.default_name: Optional[str] = None
 
-        self._load_from_settings()
+        conns = self.settings.get_json("DB_CONNECTIONS", scope="namespace") or []
+        default_ds = self.settings.get("DEFAULT_DATASOURCE", scope="namespace")
+        app_url = (
+            self.settings.get("APP_DB_URL", scope="namespace")
+            or self.settings.get("APP_DB_URL")                       # global
+            or self.settings.get("FA_DB_URL")                        # env bridge
+        )
 
-    # --- public API ---------------------------------------------------------
-
-    def engine(self, name: Optional[str]) -> Engine:
-        """
-        Return an engine by name. If name is None, use the configured default.
-        If only one engine exists, that becomes the default implicitly.
-        """
-        target = name or self.default_name or (next(iter(self.engines)) if len(self.engines) == 1 else None)
-        if target and target in self.engines:
-            return self.engines[target]
-        raise RuntimeError("No datasource engine found for requested datasource.")
-
-    def has_any(self) -> bool:
-        return bool(self.engines)
-
-    # --- internals ----------------------------------------------------------
-
-    def _load_from_settings(self) -> None:
-        raw_conns = self.settings.get("DB_CONNECTIONS", None)
-        default_ds = self.settings.get("DEFAULT_DATASOURCE", None)
-
-        # Parse DB_CONNECTIONS if it arrived as a JSON string
-        connections: Optional[list] = None
-        if raw_conns:
-            if isinstance(raw_conns, str):
-                try:
-                    connections = json.loads(raw_conns)
-                except Exception:
-                    print("[datasources] WARNING: DB_CONNECTIONS is a string but not valid JSON; ignoring.")
-                    connections = None
-            elif isinstance(raw_conns, (list, tuple)):
-                connections = list(raw_conns)
-            else:
-                print("[datasources] WARNING: DB_CONNECTIONS has unexpected type; ignoring.")
-
-        # Fallback to APP_DB_URL (settings) or env
-        app_url = self.settings.get("APP_DB_URL", None) or os.getenv("APP_DB_URL") or os.getenv("FA_DB_URL")
-
-        if not connections and app_url:
-            # synthesize a single entry
-            name = default_ds or "app"
-            connections = [{"name": name, "url": app_url, "role": "oltp"}]
-            if not default_ds:
-                default_ds = name
-
-        if not connections:
-            print("[datasources] no engines created (check DB_CONNECTIONS or APP_DB_URL).")
-            self.default_name = None
-            self.engines = {}
-            return
-
-        created = []
-        for entry in connections:
-            try:
-                name = entry.get("name")
-                url = entry.get("url")
+        if conns:
+            for c in conns:
+                name = (c.get("name") or "").strip()
+                url = (c.get("url") or "").strip()
                 if not name or not url:
                     continue
-                # reasonable pool defaults; adjust if needed per RDS/MySQL
-                engine = create_engine(
-                    url,
-                    pool_pre_ping=True,
-                    pool_recycle=1800,
-                    pool_size=5,
-                    max_overflow=10,
-                )
-                self.engines[name] = engine
-                created.append(name)
-            except Exception as e:
-                print(f"[datasources] failed creating engine for {entry!r}: {e}")
-
-        # Decide default
-        self.default_name = default_ds or (created[0] if len(created) == 1 else None)
-
-        if not self.engines:
-            print("[datasources] no engines created after processing entries.")
+                self._engines[name] = create_engine(url, pool_pre_ping=True)
+            # pick default
+            if default_ds and default_ds in self._engines:
+                self.default_name = default_ds
+            elif self._engines:
+                self.default_name = next(iter(self._engines.keys()))
+        elif app_url:
+            # If we only have one URL, expose it under DEFAULT_DATASOURCE if present, else 'app'
+            name = default_ds or "app"
+            self._engines[name] = create_engine(app_url, pool_pre_ping=True)
+            self.default_name = name
         else:
-            print(f"[datasources] engines created: {created}; default={self.default_name!r}")
+            print("[datasources] no engines created (check DB_CONNECTIONS or APP_DB_URL).")
+
+    def engine(self, name: Optional[str]) -> any:
+        key = name or self.default_name
+        if key and key in self._engines:
+            return self._engines[key]
+        raise RuntimeError("No datasource engine found for requested datasource.")
+
+    def engines(self) -> Dict[str, any]:
+        return dict(self._engines)
 


### PR DESCRIPTION
## Summary
- handle APP_DB_URL + DEFAULT_DATASOURCE fallback when DB_CONNECTIONS absent
- strengthen /admin/settings/bulk with partial-index aware upserts

## Testing
- `python -m py_compile core/datasources.py core/admin_api.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c751f674e8832388748d1aa8d535da