### PR TITLE
Add rule-based FA planner and seeding endpoint

### DIFF
--- a/apps/fa/agents.py
+++ b/apps/fa/agents.py
@@ -1,361 +1,88 @@
-"""
-FA-specific agents that compose the core scaffolds with domain prompts.
-This file can evolve independently from the core.
-"""
 from __future__ import annotations
+import re
+from typing import Any, Dict, Optional, Tuple
 
-from typing import Any, Dict, Iterable, List, Tuple, Optional
-import re, json, textwrap
+# --- small helper: admin reply normalizer (kept for pipeline compatibility) ---
+def normalize_admin_reply(text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not text:
+        return None
+    # Keep simple; you can expand it later to parse YAML-ish admin hints.
+    return {"raw": text}
 
-
-from core.agents import ClarifierAgent as CoreClarifier, PlannerAgent as CorePlanner, ValidatorAgent as CoreValidator
-from apps.fa.adapters import match_metric, parse_date_range, inject_date_filter, union_for_prefixes
-
-
-def normalize_admin_reply(text: str) -> Dict[str, Any]:
+# --- planner ---
+class FAPlanner:
     """
-    Accepts YAML/JSON/compact one-liners or loose natural language and returns a
-    normalized hint dict the planner expects.
+    Very small rule-based planner that handles:
+      - "top N customers by sales [last month]"
+    Falls back to a single clarifying question for anything else.
     """
-    t = (text or "").strip()
 
-    # 1) Try YAML/JSON first
-    try:
-        import yaml
-        y = yaml.safe_load(t)
-        if isinstance(y, dict) and ("tables" in y or "metric" in y or "date" in y):
-            return y
-    except Exception:
-        pass
-    try:
-        j = json.loads(t)
-        if isinstance(j, dict) and ("tables" in j or "metric" in j or "date" in j):
-            return j
-    except Exception:
-        pass
-
-    # 2) Compact "key: ...; key: ..." one-liner
-    if ";" in t and ":" in t:
-        out: Dict[str, Any] = {}
-        parts = [p.strip() for p in t.split(";") if p.strip()]
-        for p in parts:
-            if ":" not in p:
-                continue
-            k, v = p.split(":", 1)
-            k = k.strip().lower()
-            v = v.strip()
-            if k == "tables":
-                # dt=debtor_trans, dtd=debtor_trans_details, dm=debtors_master
-                tbls = {}
-                for tok in re.split(r"[,\s]+", v):
-                    if "=" in tok:
-                        alias, name = tok.split("=", 1)
-                        tbls[alias.strip()] = name.strip()
-                if tbls:
-                    out["tables"] = tbls
-            elif k == "joins":
-                out["joins"] = [j.strip() for j in v.split(",") if j.strip()]
-            elif k == "date":
-                # "dt.tran_date last_month"
-                m = re.match(r"(?P<col>[\w\.]+)\s+(?P<period>[\w_]+)", v)
-                if m:
-                    out["date"] = {"column": m.group("col"), "period": m.group("period")}
-            elif k == "filters":
-                out["filters"] = [v]
-            elif k == "metric":
-                # "net_sales = SUM(...)"
-                m = re.match(r"(?P<key>[\w]+)\s*=\s*(?P<expr>.+)$", v, flags=re.I)
-                if m:
-                    out["metric"] = {"key": m.group("key"), "expr": m.group("expr")}
-            elif k == "group_by":
-                out["group_by"] = [x.strip() for x in v.split(",") if x.strip()]
-            elif k == "order_by":
-                out["order_by"] = v
-            elif k == "limit":
-                try:
-                    out["limit"] = int(v)
-                except Exception:
-                    pass
-        if out:
-            return out
-
-    # 3) Heuristic fallback for loose phrases like your original
-    lo = t.lower()
-    hint: Dict[str, Any] = {}
-    # tables
-    if "debtor_trans_details" in lo or "dtd" in lo:
-        hint.setdefault("tables", {})["dtd"] = "debtor_trans_details"
-    if "debtor_trans" in lo or "invoice" in lo or "invoices" in lo:
-        hint.setdefault("tables", {})["dt"] = "debtor_trans"
-    if "customer" in lo or "debtors_master" in lo:
-        hint.setdefault("tables", {})["dm"] = "debtors_master"
-    # joins (standard FA detail joins)
-    if "dtd" in hint.get("tables", {}) and "dt" in hint.get("tables", {}):
-        hint["joins"] = [
-            "dtd.debtor_trans_no = dt.trans_no",
-            "dtd.debtor_trans_type = dt.type",
-        ]
-    if "dm" in hint.get("tables", {}) and "dt" in hint.get("tables", {}):
-        hint.setdefault("joins", []).append("dm.debtor_no = dt.debtor_no")
-    # date
-    if "tran_date" in lo or "date column" in lo or "date" in lo:
-        hint["date"] = {"column": "dt.tran_date", "period": "last_month" if "last month" in lo else "auto"}
-    # filters: net of credit notes => include (1,11)
-    if "net of credit" in lo or "credit note" in lo or "credit notes" in lo:
-        hint["filters"] = ["dt.type IN (1,11)"]
-    # metric
-    if "sum net" in lo or "net of credit" in lo:
-        hint["metric"] = {
-            "key": "net_sales",
-            "expr": "SUM((CASE WHEN dt.type=11 THEN -1 ELSE 1 END) * dtd.unit_price * (1 - dtd.discount_percent) * dtd.quantity)",
-        }
-    # group/order
-    if "top 10 customers" in lo or "top customers" in lo:
-        hint["group_by"] = ["dm.name"]
-        hint["order_by"] = "net_sales DESC"
-        hint["limit"] = 10
-
-    return hint
-
-
-class ClarifierAgentFA(CoreClarifier):
-    def __init__(self, llm_handle, settings):
-        super().__init__(llm_handle)
-        self.settings = settings
-    """
-        ClarifierAgentFA
-        ----------------
-        Purpose:
-          Decide whether to ask follow-up questions *based on policy* and context richness.
-
-        Policy (ASK_MODE read from Settings; default by ENVIRONMENT):
-          - "metric_first": if a metric alias matches the question → **skip asking** and let planner proceed.
-          - "always_ask": always ask when context is weak/ambiguous.
-          - "never_ask": never ask—proceed straight to planning.
-
-        Inputs:
-          - question: raw user question (str)
-          - context: dict with tables/columns/metrics populated by Pipeline.build_context_pack()
-
-        Output:
-          - (need: bool, questions: List[str])
-
-        Steps:
-          1) Read ASK_MODE from settings with sane defaults.
-          2) If "never_ask" → skip questions.
-          3) If "metric_first" and a metric matches → skip questions.
-          4) Otherwise, ask 0–2 lightweight questions when context looks ambiguous.
-        """
-    def __init__(self, llm_handle: Any, settings: Any) -> None:
-        self.llm = llm_handle
+    def __init__(self, llm: Any, settings: Any) -> None:
+        self.llm = llm
         self.settings = settings
 
-    def maybe_ask(self, question: str, context: Dict[str, Any]) -> Tuple[bool, List[str]]:
-        # 1) Read policy; default to metric_first in dev, always_ask in prod.
-        env = (self.settings.get("ENVIRONMENT", "local") or "local").lower()
-        default_mode = "metric_first" if env in ("local", "dev", "development") else "always_ask"
-        ask_mode = (self.settings.get("ASK_MODE", default_mode) or default_mode).lower()
+    def get_prefix(self, context: Dict[str, Any]) -> str:
+        prefixes = (context or {}).get("prefixes") or []
+        return prefixes[0] if prefixes else ""
 
-        # 2) Short-circuit when policy says "never_ask"
-        if ask_mode == "never_ask":
-            return False, []  # proceed directly to planning
+    def T(self, prefix: str, name: str) -> str:
+        # Backticked + prefix, works for MySQL/MariaDB
+        return f"`{prefix}{name}`"
 
-        # 3) If policy is metric_first and the question clearly matches a metric, don't ask
-        if ask_mode == "metric_first":
-            metrics = context.get("metrics", {}) or {}
-            if match_metric(question, metrics):
-                return False, []  # proceed; planner will use the metric
-
-        # 4) Heuristic: ask when context is ambiguous (few/no tables, many columns, or date hint)
-        qs: List[str] = []
-        tables = context.get("tables", [])
-        columns = context.get("columns", [])
-        if not tables:
-            qs.append("Should we use sales/invoices (debtor_trans), customers (debtors_master), or GL?")
-        if any("date" in (c.get("column_name","").lower()) for c in columns):
-            qs.append("What date range should we use?")
-        need = len(qs) > 0
-        return need, qs[:2]  # keep it short
-
-
-
-class PlannerAgentFA(CorePlanner):
-    def __init__(self, llm_handle, settings):
-        super().__init__(llm_handle)
-        self.settings = settings
-
-
-    """
-       PlannerAgentFA
-       --------------
-       Purpose:
-         Prefer semantic metrics when available; fall back to core planner otherwise.
-
-       Steps:
-         1) Try to match a metric key/alias from context.metrics.
-         2) If matched, optionally inject a date predicate (last month, ytd, etc.).
-         3) Return canonical (unprefixed) SQL + rationale for the Validator.
-         4) Else, fall back to the core planner prompt.
-       """
+    def fallback_clarifying_question(self, question: str, context: Dict[str, Any]) -> str:
+        return "Which tables and date range should we use?"
 
     def plan(
         self,
         question: str,
-        context: Dict[str, Any],
+        context: Dict[str, Any] | None = None,
+        *,
         hints: Dict[str, Any] | None = None,
         admin_hints: Dict[str, Any] | None = None,
     ) -> Tuple[str, str]:
-        """
-        Plan canonical (unprefixed) SQL for FA-like schemas using tables/columns in context
-        and FA-specific hints (dates, categories, dimensions, items).
-        """
-        if admin_hints:
-            try:
-                from apps.fa.hints import try_build_sql_from_hints
 
-                sql0 = try_build_sql_from_hints(admin_hints, context.get("prefixes") or [])
-                if sql0:
-                    return sql0, "constructed from admin hints"
-            except Exception:
-                pass
-            try:
-                admin_txt = textwrap.indent(json.dumps(admin_hints, indent=2), "  ")
-                hints = dict(hints or {})
-                hints["admin_notes"] = admin_txt
-            except Exception:
-                pass
+        q = (question or "").lower().strip()
+        ctx = context or {}
+        prefix = self.get_prefix(ctx)
 
-        tables = ", ".join(sorted({t['table_name'] for t in context.get('tables', [])}))
-        cols = ", ".join(sorted({f"{c['table_name']}.{c['column_name']}" for c in context.get('columns', [])}))
-        metrics = context.get("metrics", {}) or {}
+        # detect "top N"
+        m_top = re.search(r"\btop\s+(\d+)\b", q)
+        top_n = int(m_top.group(1)) if m_top else 10
 
-        # marshal hints for prompt
-        h: List[str] = []
-        if hints:
-            if dr := hints.get("date_range"): h.append(
-                f"DateRange: {dr['start']}..{dr['end']} (grain={dr.get('grain', 'day')})")
-            if eq := hints.get("eq_filters"): h.append("EqFilters: " + ", ".join([f"{k}={v}" for k, v in eq.items()]))
-            if cats := hints.get("categories"):
-                pretty = [f"{c.get('table')} types={c.get('types')}" for c in cats]
-                h.append("Categories: " + "; ".join(pretty))
-            if dims := hints.get("dimensions"):
-                pretty = [f"{k} IN {v}" for k, v in dims.items()]
-                h.append("Dimensions: " + "; ".join(pretty))
-            if items := hints.get("items"):
-                h.append("Items: " + ", ".join(items))
-        hint_txt = "\n".join(h) if h else "(none)"
+        wants_customers = ("customer" in q) or ("customers" in q)
+        mentions_sales  = ("sale" in q) or ("sales" in q) or ("revenue" in q)
+        mentions_month  = ("month" in q) or ("last month" in q) or ("previous month" in q)
 
-        prompt = (
-            "You are a senior SQL generator for MariaDB/MySQL.\n"
-            "Return only one SQL query.\n"
-            "Wrap it exactly like:\n\n```sql\nSELECT ...\n```\n"
-            "After the block, provide a short rationale.\n\n"
-            "Constraints:\n"
-            "- Use ONLY the given tables and columns.\n"
-            "- Prefer known metrics when directly relevant (list provided).\n"
-            "- Never use SELECT *.\n"
-            "- Add LIMIT 50 on exploratory answers.\n"
-            "- If filters reference columns from other tables, add the necessary JOINs.\n"
-            "- If no date column is explicit, default sales to debtor_trans.tran_date.\n"
-            "- Apply day-level ranges when provided (BETWEEN :start AND :end inclusive).\n"
-            "- Dimensions can be dimension1_id..dimension4_id when present; join as needed.\n"
-            "- Items come from stock_master.stock_id; join via debtor_trans_details/sales_order_details when needed.\n"
-            "- If the question is ambiguous, ask a single clarifying question instead of guessing.\n\n"
-            f"Tables: {tables}\nColumns: {cols}\n"
-            f"Metrics: {', '.join(metrics.keys()) if metrics else '(none)'}\n"
-            f"Hints:\n{hint_txt}\n"
-            "Return as:\nSQL:\n<sql>\nRationale:\n<why>\n"
-        )
+        # We also accept "top customers by sales last ..." with no number (defaults to 10)
+        if wants_customers and mentions_sales:
+            date_filter = "AND DATE_FORMAT(dt.tran_date, '%Y-%m') = DATE_FORMAT(CURRENT_DATE - INTERVAL 1 MONTH, '%Y-%m')" \
+                          if mentions_month else \
+                          "AND DATE_FORMAT(dt.tran_date, '%Y-%m') = DATE_FORMAT(CURRENT_DATE - INTERVAL 1 MONTH, '%Y-%m')"
 
-        if hints and hints.get("admin_notes"):
-            prompt += (
-                "\n\n# Admin clarifications (authoritative):\n"
-                + hints["admin_notes"]
-                + "\n# Use these clarifications to finalize the SQL. Return **SQL only**."
-            )
+            # FrontAccounting types: 10=Sales Invoice, 11=Customer Credit Note
+            sql = f"""
+SELECT dm.name AS customer,
+       SUM((CASE WHEN dt.type = 11 THEN -1 ELSE 1 END)
+           * dtd.unit_price
+           * (1 - COALESCE(dtd.discount_percent, 0))
+           * dtd.quantity) AS net_sales
+FROM {self.T(prefix, 'debtor_trans')} AS dt
+JOIN {self.T(prefix, 'debtor_trans_details')} AS dtd
+  ON dtd.debtor_trans_no = dt.trans_no
+ AND dtd.debtor_trans_type = dt.type
+JOIN {self.T(prefix, 'debtors_master')} AS dm
+  ON dm.debtor_no = dt.debtor_no
+WHERE dt.type IN (10, 11)  -- 10=invoice, 11=credit note
+  {date_filter}
+GROUP BY dm.name
+ORDER BY net_sales DESC
+LIMIT {top_n};
+""".strip()
+            return sql, "rule_based:net_sales_by_customer"
 
-        out = self.llm.generate(prompt, max_new_tokens=256, temperature=0.2, top_p=0.9)
-        return self._split(out)
+        # Anything else → let the pipeline ask one clarifying question
+        raise RuntimeError("need_clarification")
 
-    def fallback_clarifying_question(self, question: str, context: dict | None, hints: dict | None):
-        """
-        Return a *small list* of targeted clarifying questions.
-        If you later enable the small clarifier model, you can swap this
-        heuristic with an LLM-based one; the signature can stay the same.
-        """
-        ctx_txt = " ".join(
-            [
-                str((context or {}).get("admin_notes") or ""),
-                str((hints or {}).get("prompt_boosters") or ""),
-                question or "",
-            ]
-        ).lower()
-
-        qs = []
-
-        if not re.search(r"\b(last|this|today|yesterday|month|year|week|between|\d{4}-\d{2}-\d{2})\b", ctx_txt):
-            qs.append(
-                "What date range should we use (e.g., last month, or between 2025-08-01 and 2025-08-31)?"
-            )
-
-        if not re.search(r"\b(sum|count|avg|average|net|gross|revenue|sales|amount|balance|qty|quantity)\b", ctx_txt):
-            qs.append("Which metric should we compute (e.g., net sales sum, count of invoices)?")
-
-        if not re.search(
-            r"\b(debtor[_\s]?trans|debtors[_\s]?master|supp[_\s]?trans|gl[_\s]?trans|bank[_\s]?trans|stock[_\s]?moves|items?)\b",
-            ctx_txt,
-        ):
-            qs.append("Which tables should we use (e.g., debtor_trans, debtors_master, gl_trans)?")
-
-        if not qs:
-            qs.append(
-                "I couldn’t derive a clean SQL. Can you confirm the main tables, date column, and metric?"
-            )
-
-        return qs[:3]
-
-    def _rule_based_plan(self, question: str, context: Dict[str, Any]) -> Tuple[str, str]:
-        q = question.lower()
-        # Heuristic for this very common ask
-        if ("customer" in q or "customers" in q) and "sales" in q and ("last month" in q or "previous month" in q):
-            sql = (
-                "WITH bounds AS (\n"
-                "  SELECT DATE_SUB(DATE_FORMAT(CURDATE(),'%Y-%m-01'), INTERVAL 1 MONTH) AS start_date,\n"
-                "         DATE_FORMAT(CURDATE(),'%Y-%m-01') AS end_date\n"
-                ")\n"
-                "SELECT dm.name AS customer_name,\n"
-                "       SUM(dt.ov_amount + dt.ov_gst) AS sales_amount\n"
-                "FROM debtor_trans dt\n"
-                "JOIN debtors_master dm ON dt.debtor_no = dm.debtor_no\n"
-                "CROSS JOIN bounds b\n"
-                "WHERE dt.type = 10\n"
-                "  AND dt.tran_date >= b.start_date AND dt.tran_date < b.end_date\n"
-                "GROUP BY dm.name\n"
-                "ORDER BY sales_amount DESC\n"
-                "LIMIT 10"
-            )
-            why = "Aggregate last month's sales (debtor_trans type=10) by debtor and return top 10."
-            return sql, why
-        # Default: force a clarifier up-stream
-        return ("SELECT 1 /* no plan */", "No plan from model; clarifier should ask for tables/date range.")
-
-
-
-class ValidatorAgentFA(CoreValidator):
-    def quick_validate(self, sql: str) -> Tuple[bool, Dict[str, Any]]:
-        sql_strip = sql.strip().lstrip("(")
-        import re
-        if not re.match(r"(?is)^(with|select|insert|update|delete|explain)\b", sql_strip):
-            return False, {"error": "planner returned non-SQL text", "preview": sql_strip[:160]}
-        return super().quick_validate(sql_strip)
-
-
-
-
-
-def expand_sql_for_prefixes(canonical_sql: str, prefixes: Iterable[str]) -> str:
-    return union_for_prefixes(canonical_sql, prefixes)
-
-
-def get_planner(llm, settings):
-    return PlannerAgentFA(llm, settings)
+# Factory used by core.pipeline
+def get_planner(llm: Any, settings: Any) -> FAPlanner:
+    return FAPlanner(llm, settings)

--- a/apps/fa/join_graph.yaml
+++ b/apps/fa/join_graph.yaml
@@ -1,24 +1,23 @@
-# Canonical (unprefixed) join graph for FA-like schemas
-# Expand with apps/fa/adapters.expand_join_graph_for_prefix(prefix)
+- from_table: debtor_trans_details
+  from_column: debtor_trans_no
+  to_table: debtor_trans
+  to_column: trans_no
+  join_type: INNER
+  cardinality: "N:1"
+  is_preferred: true
 
-joins:
-  - name: debtor_trans_to_master
-    from: debtor_trans
-    to: debtors_master
-    on: "debtor_trans.debtor_no = debtors_master.debtor_no"
-    type: INNER
-    cardinality: N:1
+- from_table: debtor_trans_details
+  from_column: debtor_trans_type
+  to_table: debtor_trans
+  to_column: type
+  join_type: INNER
+  cardinality: "N:1"
+  is_preferred: true
 
-  - name: sales_to_debtor
-    from: sales_orders
-    to: debtors_master
-    on: "sales_orders.debtor_no = debtors_master.debtor_no"
-    type: INNER
-    cardinality: N:1
-
-  - name: gl_trans_to_accounts
-    from: gl_trans
-    to: chart_master
-    on: "gl_trans.account = chart_master.account_code"
-    type: INNER
-    cardinality: N:1
+- from_table: debtor_trans
+  from_column: debtor_no
+  to_table: debtors_master
+  to_column: debtor_no
+  join_type: INNER
+  cardinality: "N:1"
+  is_preferred: true

--- a/apps/fa/metrics/net_sales.yaml
+++ b/apps/fa/metrics/net_sales.yaml
@@ -1,0 +1,25 @@
+metric_key: fa.net_sales
+metric_name: Net sales (invoices minus credit notes)
+description: >
+  Sum of line value (price * (1 - discount) * qty)
+  signed negative for Customer Credit Notes (type 11).
+calculation_sql: >
+  SUM((CASE WHEN dt.type = 11 THEN -1 ELSE 1 END)
+      * dtd.unit_price
+      * (1 - COALESCE(dtd.discount_percent, 0))
+      * dtd.quantity)
+required_tables:
+  - "debtor_trans as dt"
+  - "debtor_trans_details as dtd"
+required_columns:
+  - "dt.type"
+  - "dt.tran_date"
+  - "dtd.unit_price"
+  - "dtd.discount_percent"
+  - "dtd.quantity"
+parameters:
+  date_column: "dt.tran_date"
+  types_include: [10, 11]
+category: sales
+owner: apps.fa
+version: 1

--- a/apps/fa/seed.py
+++ b/apps/fa/seed.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+import os, glob, json
+from typing import Dict, Any, List
+import yaml
+from sqlalchemy import text
+from core.settings import Settings
+
+
+def _upsert_join_graph(conn, namespace: str, items: List[Dict[str, Any]]) -> int:
+    sql = text(
+        """
+        INSERT INTO mem_join_graph(namespace, from_table, from_column, to_table, to_column,
+                                   join_type, cardinality, is_preferred, confidence, discovered_by)
+        VALUES (:ns, :ft, :fc, :tt, :tc, :jt, :card, :pref, 1.0, 'manual')
+        ON CONFLICT (namespace, from_table, from_column, to_table, to_column)
+        DO UPDATE SET
+            join_type    = EXCLUDED.join_type,
+            cardinality  = EXCLUDED.cardinality,
+            is_preferred = EXCLUDED.is_preferred,
+            updated_at   = NOW()
+    """
+    )
+    n = 0
+    for it in items:
+        params = {
+            "ns": namespace,
+            "ft": it["from_table"], "fc": it["from_column"],
+            "tt": it["to_table"],   "tc": it["to_column"],
+            "jt": it.get("join_type", "INNER"),
+            "card": it.get("cardinality"),
+            "pref": bool(it.get("is_preferred", False)),
+        }
+        conn.execute(sql, params)
+        n += 1
+    return n
+
+
+def _upsert_metric(conn, namespace: str, m: Dict[str, Any]) -> None:
+    sql = text(
+        """
+        INSERT INTO mem_metrics(namespace, metric_key, metric_name, description, calculation_sql,
+                                required_tables, required_columns, parameters, category, owner, version,
+                                is_active, verified_at, created_at, updated_at)
+        VALUES (:ns, :key, :name, :desc, :calc,
+                :req_tables, :req_cols, :params, :cat, :owner, :ver,
+                true, NOW(), NOW(), NOW())
+        ON CONFLICT (namespace, metric_key, version)
+        DO UPDATE SET
+            metric_name      = EXCLUDED.metric_name,
+            description      = EXCLUDED.description,
+            calculation_sql  = EXCLUDED.calculation_sql,
+            required_tables  = EXCLUDED.required_tables,
+            required_columns = EXCLUDED.required_columns,
+            parameters       = EXCLUDED.parameters,
+            category         = EXCLUDED.category,
+            owner            = EXCLUDED.owner,
+            is_active        = true,
+            updated_at       = NOW()
+    """
+    )
+    conn.execute(
+        sql,
+        {
+            "ns": namespace,
+            "key": m["metric_key"],
+            "name": m.get("metric_name"),
+            "desc": m.get("description"),
+            "calc": m["calculation_sql"],
+            "req_tables": json.dumps(m.get("required_tables") or []),
+            "req_cols": json.dumps(m.get("required_columns") or []),
+            "params": json.dumps(m.get("parameters") or {}),
+            "cat": m.get("category"),
+            "owner": m.get("owner"),
+            "ver": int(m.get("version") or 1),
+        },
+    )
+
+
+def seed_if_missing(mem_engine, namespace: str, settings: Settings, force: bool = False) -> Dict[str, Any]:
+    """
+    Load apps/fa/join_graph.yaml and apps/fa/metrics/*.yaml
+    into mem_join_graph and mem_metrics. If 'force' is False, we still upsert idempotently.
+    """
+    join_path = settings.get("FA_JOIN_GRAPH_PATH", namespace=namespace) or "apps/fa/join_graph.yaml"
+    metrics_dir = settings.get("FA_METRICS_PATH", namespace=namespace) or "apps/fa/metrics"
+
+    # read files
+    with open(join_path, "r", encoding="utf-8") as f:
+        join_items = yaml.safe_load(f) or []
+
+    metric_files = sorted(glob.glob(os.path.join(metrics_dir, "*.yaml")))
+    metrics: List[Dict[str, Any]] = []
+    for fp in metric_files:
+        with open(fp, "r", encoding="utf-8") as f:
+            metrics.append(yaml.safe_load(f) or {})
+
+    inserted = {"join_graph": 0, "metrics": 0}
+    with mem_engine.begin() as conn:
+        inserted["join_graph"] = _upsert_join_graph(conn, namespace, join_items)
+        for m in metrics:
+            if m and "metric_key" in m and "calculation_sql" in m:
+                _upsert_metric(conn, namespace, m)
+                inserted["metrics"] += 1
+    return inserted


### PR DESCRIPTION
## Summary
- replace FA planning with rule-based SQL planner for top customers by sales
- add join graph and net sales metric seeds
- expose /fa/seed endpoint and seeding utilities for memory

## Testing
- `python -m py_compile apps/fa/agents.py apps/fa/seed.py apps/fa/app.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c75f7b0664832384e7c073daa8040c