### PR TITLE
Improve settings helpers and datasource registration

### DIFF
--- a/core/datasources.py
+++ b/core/datasources.py
@@ -1,34 +1,60 @@
 from __future__ import annotations
 
+import os
+from typing import Dict, Optional
 from sqlalchemy import create_engine
-from typing import Any
+
+from .settings import Settings
 
 
 class DatasourceRegistry:
-    def __init__(self, settings, namespace: str):
+    """Build and cache SQLAlchemy engines from settings."""
+
+    def __init__(self, settings: Settings, namespace: str):
         self.settings = settings
         self.namespace = namespace
-        self._engines: dict[str, Any] = {}
-        conns = self.settings.get_json("DB_CONNECTIONS", scope="namespace", default=[]) or []
-        if not conns:
-            app_url = self.settings.get_str("APP_DB_URL", scope="namespace")
-            if app_url:
-                self._engines["__default__"] = create_engine(app_url, pool_pre_ping=True)
-        else:
-            for c in conns:
-                name = c.get("name") or c.get("role") or "__default__"
-                url = c["url"]
-                self._engines[name] = create_engine(url, pool_pre_ping=True)
+        self.engines: Dict[str, any] = {}
+        self.default: Optional[str] = self.settings.get_str(
+            "DEFAULT_DATASOURCE", namespace=self.namespace, scope="namespace"
+        )
 
-    def engine(self, name: str | None):
-        if name and name in self._engines:
-            return self._engines[name]
-        dflt = self.settings.get_str("DEFAULT_DATASOURCE", scope="namespace")
-        if dflt and dflt in self._engines:
-            return self._engines[dflt]
-        if len(self._engines) == 1:
-            return next(iter(self._engines.values()))
-        if "__default__" in self._engines:
-            return self._engines["__default__"]
+        # Preferred: DB_CONNECTIONS [{name, role, url}]
+        conns = self.settings.get_json(
+            "DB_CONNECTIONS", namespace=self.namespace, scope="namespace"
+        ) or []
+        for c in conns or []:
+            name = c.get("name")
+            url = c.get("url")
+            if name and url:
+                self.engines[name] = create_engine(
+                    url, pool_pre_ping=True, pool_recycle=1800
+                )
+                if not self.default:
+                    self.default = name
+
+        # Fallback: APP_DB_URL or env FA_DB_URL
+        if not self.engines:
+            app_url = self.settings.get_str(
+                "APP_DB_URL", namespace=self.namespace, scope="namespace"
+            ) or os.environ.get("FA_DB_URL")
+            if app_url:
+                name = self.default or "default"
+                self.engines[name] = create_engine(
+                    app_url, pool_pre_ping=True, pool_recycle=1800
+                )
+                if not self.default:
+                    self.default = name
+
+        if not self.engines:
+            print("[datasources] no engines created (check DB_CONNECTIONS or APP_DB_URL).")
+            raise RuntimeError("No datasource engine found for requested datasource.")
+
+    def engine(self, name: Optional[str]):
+        if name and name in self.engines:
+            return self.engines[name]
+        if self.default and self.default in self.engines:
+            return self.engines[self.default]
+        if len(self.engines) == 1:
+            return next(iter(self.engines.values()))
         raise RuntimeError("No datasource engine found for requested datasource.")
 


### PR DESCRIPTION
## Summary
- Add value_type-aware getters in `Settings` with caching and env fallback
- Register datasources from `DB_CONNECTIONS` or `APP_DB_URL` with sensible defaults
- Safely append admin notes and streamline inquiry reprocessing with optional auto-retry

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7f874a904832384286406d8df987b