### PR TITLE
Ensure mem engine initialization and robust admin note handling

### DIFF
--- a/apps/fa/app.py
+++ b/apps/fa/app.py
@@ -168,7 +168,7 @@ def fa_seed():
     ns = data.get("namespace") or "fa::common"
     try:
         settings = Settings(namespace=ns)
-        mem = get_mem_engine(settings.memory_db_url())
+        mem = get_mem_engine(settings)
         res = seed_if_missing(mem, ns, settings=settings, force=bool(data.get("force")))
         return jsonify({"ok": True, "namespace": ns, **res})
     except Exception as e:

--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -3,7 +3,6 @@ from flask import Blueprint, request, jsonify, current_app
 from werkzeug.exceptions import BadRequest
 from sqlalchemy import text
 from core.inquiries import append_admin_note, fetch_inquiry
-from core.settings import Settings
 from core.sql_exec import get_mem_engine
 import json
 
@@ -158,13 +157,13 @@ def admin_reply(inq_id: int):
     admin_reply_txt = (data.get("admin_reply") or "").strip()
     process = bool(data.get("process"))
 
-    mem = get_mem_engine(Settings())
+    pipeline = current_app.config["PIPELINE"]
+    mem = get_mem_engine(pipeline.settings)
     rounds = append_admin_note(mem, inq_id, by=answered_by, text_note=admin_reply_txt)
 
     result = {"ok": True, "inquiry_id": inq_id, "clarification_rounds": rounds}
 
     if process:
-        pipeline = current_app.config["PIPELINE"]
         proc = pipeline.reprocess_inquiry(inq_id, namespace=pipeline.namespace)
         result.update({"processed": True, "result": proc})
 

--- a/main.py
+++ b/main.py
@@ -5,12 +5,14 @@ from core.settings import Settings
 from core.pipeline import Pipeline
 from apps.fa.app import fa_bp
 from core.admin_api import admin_bp
+from core.sql_exec import init_mem_engine
 
 def create_app() -> Flask:
     app = Flask(__name__)
 
     settings = Settings()
     pipeline = Pipeline(settings=settings, namespace="fa::common")
+    init_mem_engine(settings)
 
     app.extensions = getattr(app, "extensions", {})
     app.extensions["pipeline"] = pipeline


### PR DESCRIPTION
## Summary
- lazily initialize global memory engine with settings/env fallback
- expose pipeline mem engine and warm up at app start
- fix admin note insertion and use pipeline mem engine in admin API

## Testing
- `python -m py_compile apps/fa/app.py core/admin_api.py core/inquiries.py core/pipeline.py core/sql_exec.py main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c80285874c832395ea1170ce34670d