### PR TITLE
feat: harden datasource registry and settings

### DIFF
--- a/core/datasources.py
+++ b/core/datasources.py
@@ -1,37 +1,107 @@
 from __future__ import annotations
 
+"""Datasource registry with robust fallbacks.
+
+This registry constructs SQLAlchemy engines from several possible sources in
+priority order:
+
+1. `DB_CONNECTIONS` setting for the active namespace
+2. `APP_DB_URL`/`FA_DB_URL` setting for the namespace combined with
+   `DEFAULT_DATASOURCE`
+3. Environment variables `FA_DB_URL` or `APP_DB_URL`
+
+If no engines are created after checking the above, a warning is printed and
+any attempt to retrieve an engine will raise a ``RuntimeError``.
+"""
+
+import os
 from sqlalchemy import create_engine
 
 
+def _safe(v, default=None):
+    return v if v not in (None, "", []) else default
+
+
 class DatasourceRegistry:
-    def __init__(self, settings, *, namespace: str):
+    def __init__(self, settings, namespace: str | None = None):
+        """
+        Build engine map with multiple fallbacks.
+
+        Parameters
+        ----------
+        settings:
+            ``Settings`` instance providing configuration access.
+        namespace:
+            Namespace used when resolving settings; defaults to ``"default"``.
+        """
+
         self.settings = settings
-        self.namespace = namespace
-        self._engines = {}
+        self.namespace = namespace or "default"
+        self._engines: dict[str, any] = {}
+        self._default_name: str | None = None
+        self._build()
 
-        conns = self.settings.get_json("DB_CONNECTIONS", scope="namespace", default=[]) or []
+    def _build(self) -> None:
+        """Populate the internal engine map."""
+
+        # 1) Settings: DB_CONNECTIONS scoped to namespace
+        conns = (
+            self.settings.get_json(
+                "DB_CONNECTIONS", scope="namespace", namespace=self.namespace
+            )
+            or []
+        )
+
+        # 2) Fallback to APP_DB_URL/FA_DB_URL in settings
+        if not conns:
+            app_db_url = (
+                self.settings.get_str(
+                    "APP_DB_URL", scope="namespace", namespace=self.namespace
+                )
+                or self.settings.get_str(
+                    "FA_DB_URL", scope="namespace", namespace=self.namespace
+                )
+            )
+            if app_db_url:
+                ds_name = self.settings.get_str(
+                    "DEFAULT_DATASOURCE", scope="namespace", namespace=self.namespace
+                ) or "default"
+                conns = [{"name": ds_name, "url": app_db_url, "role": "oltp"}]
+
+        # 3) Environment variable fallback
+        if not conns:
+            app_db_url = os.getenv("FA_DB_URL") or os.getenv("APP_DB_URL")
+            if app_db_url:
+                ds_name = self.settings.get_str(
+                    "DEFAULT_DATASOURCE", scope="namespace", namespace=self.namespace
+                ) or "default"
+                conns = [{"name": ds_name, "url": app_db_url, "role": "oltp"}]
+
         for c in conns:
-            name = c.get("name")
-            url = c.get("url")
-            if name and url:
-                self._engines[name] = create_engine(url, pool_pre_ping=True)
-
-        # fallback to APP_DB_URL if no named DS provided
-        if not self._engines:
-            app_url = self.settings.get("APP_DB_URL", scope="namespace")
-            if app_url:
-                self._engines["__app__"] = create_engine(app_url, pool_pre_ping=True)
+            url = _safe(c.get("url"))
+            name = _safe(c.get("name"), "default")
+            if not url:
+                continue
+            try:
+                eng = create_engine(url, pool_pre_ping=True, pool_recycle=300)
+                self._engines[name] = eng
+                if not self._default_name:
+                    self._default_name = name
+            except Exception as e:  # pragma: no cover - logging only
+                print(f"[datasources] failed to create engine '{name}': {e}")
 
         if not self._engines:
             print("[datasources] no engines created (check DB_CONNECTIONS or APP_DB_URL).")
 
-        self._default = self.settings.get("DEFAULT_DATASOURCE", scope="namespace") or \
-                        ("frontaccounting_bk" if "frontaccounting_bk" in self._engines else None) or \
-                        ("__app__" if "__app__" in self._engines else None)
+    # ------------------------------------------------------------------
+    def engine(self, name: str | None = None):
+        """Return an engine by name or the configured default."""
 
-    def engine(self, name: str | None):
-        key = name or self._default
-        if key and key in self._engines:
-            return self._engines[key]
+        if name and name in self._engines:
+            return self._engines[name]
+        if self._default_name and self._default_name in self._engines:
+            return self._engines[self._default_name]
+        if len(self._engines) == 1:
+            return next(iter(self._engines.values()))
         raise RuntimeError("No datasource engine found for requested datasource.")
 

--- a/core/settings.py
+++ b/core/settings.py
@@ -175,8 +175,15 @@ class Settings:
                 return env_val
             return default
 
-    def get_json(self, key: str, *, scope="namespace", default=None):
-        v = self.get(key, scope=scope)
+    def get_json(
+        self,
+        key: str,
+        *,
+        scope: str = "namespace",
+        namespace: str | None = None,
+        default=None,
+    ):
+        v = self.get(key, scope=scope, namespace=namespace)
         return v if v is not None else default
 
     def get_str(
@@ -197,8 +204,15 @@ class Settings:
         return str(val)
 
 
-    def get_bool(self, key: str, *, scope="namespace", default=False) -> bool:
-        v = self.get(key, scope=scope)
+    def get_bool(
+        self,
+        key: str,
+        *,
+        scope: str = "namespace",
+        namespace: str | None = None,
+        default=False,
+    ) -> bool:
+        v = self.get(key, scope=scope, namespace=namespace)
         if isinstance(v, bool):
             return v
         if isinstance(v, str):
@@ -209,8 +223,15 @@ class Settings:
                 return False
         return bool(v) if v is not None else default
 
-    def get_int(self, key: str, *, scope="namespace", default=0) -> int:
-        v = self.get(key, scope=scope)
+    def get_int(
+        self,
+        key: str,
+        *,
+        scope: str = "namespace",
+        namespace: str | None = None,
+        default=0,
+    ) -> int:
+        v = self.get(key, scope=scope, namespace=namespace)
         try:
             return int(v)
         except Exception:


### PR DESCRIPTION
## Summary
- make DatasourceRegistry resilient with namespace-aware settings and env fallbacks
- support namespace-aware typed getters in Settings
- fix admin note JSONB append with safe psycopg2 binding
- respect namespace for empty-result auto-retry and snippet autosave in Pipeline

## Testing
- `python -m py_compile core/datasources.py core/settings.py core/inquiries.py core/pipeline.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c81769bb088323a15ac1bf69a21b4d