### PR TITLE
Add DocuWare blueprint with Oracle seeding utilities

### DIFF
--- a/apps/docuware/__init__.py
+++ b/apps/docuware/__init__.py
@@ -1,0 +1,4 @@
+"""DocuWare application module."""
+from .app import blueprint as docuware_bp
+
+__all__ = ["docuware_bp"]

--- a/apps/docuware/app.py
+++ b/apps/docuware/app.py
@@ -1,0 +1,334 @@
+"""DocuWare-specific Flask blueprint."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import text
+
+from core.inquiries import create_or_update_inquiry
+from core.pipeline import Pipeline
+from core.seed import upsert_metrics, upsert_mappings, upsert_snippet
+from core.settings import Settings
+from core.sql_exec import run_sql
+
+blueprint = Blueprint("docuware", __name__)
+
+NAMESPACE = "dw::common"
+_PIPELINE: Optional[Pipeline] = None
+_SETTINGS: Optional[Settings] = None
+
+
+@dataclass
+class DocuwarePlan:
+    ok: bool
+    sql: Optional[str] = None
+    rationale: Optional[str] = None
+    questions: Optional[List[str]] = None
+    error: Optional[str] = None
+
+
+def _get_settings() -> Settings:
+    global _SETTINGS
+    if _SETTINGS is None:
+        _SETTINGS = Settings(namespace=NAMESPACE)
+    return _SETTINGS
+
+
+def _get_pipeline() -> Pipeline:
+    global _PIPELINE
+    if _PIPELINE is None:
+        settings = _get_settings()
+        _PIPELINE = Pipeline(settings=settings, namespace=NAMESPACE)
+    return _PIPELINE
+
+
+def _coerce_prefixes(raw) -> List[str]:
+    if not raw:
+        return []
+    if isinstance(raw, (list, tuple, set)):
+        return [str(p) for p in raw if p is not None]
+    return [str(raw)]
+
+
+def _lookup_snippet_sql(pipe: Pipeline, title: str) -> Optional[str]:
+    with pipe.mem_engine.begin() as conn:
+        row = conn.execute(
+            text(
+                """
+                SELECT sql_raw
+                  FROM mem_snippets
+                 WHERE namespace = :ns AND title = :title
+                 ORDER BY updated_at DESC
+                 LIMIT 1
+                """
+            ),
+            {"ns": NAMESPACE, "title": title},
+        ).scalar()
+    return (row or "").strip() if row else None
+
+
+def _plan_from_question(pipe: Pipeline, question: str) -> DocuwarePlan:
+    q = (question or "").lower()
+    snippet_titles: List[str] = []
+    if "stakeholder" in q:
+        snippet_titles.append("Top stakeholders by gross value (last 12 months)")
+    if "expir" in q:
+        snippet_titles.append("Contracts expiring in next 90 days (buckets)")
+    if "department" in q or "owner department" in q:
+        snippet_titles.append("Gross value by department (this year)")
+
+    for title in snippet_titles:
+        sql = _lookup_snippet_sql(pipe, title)
+        if sql:
+            return DocuwarePlan(ok=True, sql=sql, rationale=f"Used seeded snippet '{title}'.")
+
+    return DocuwarePlan(
+        ok=False,
+        questions=[
+            "Could you clarify whether you need stakeholders, expiry buckets, or departmental totals?",
+            "Specify the desired date window (e.g., last 12 months, next 90 days).",
+        ],
+        error="no_matching_snippet",
+    )
+
+
+@blueprint.route("/dw/answer", methods=["POST"])
+def answer():
+    data = request.get_json(force=True, silent=True) or {}
+    question = (data.get("question") or "").strip()
+    if not question:
+        return jsonify({"ok": False, "error": "missing_question"}), 400
+
+    prefixes = _coerce_prefixes(data.get("prefixes"))
+    auth_email = data.get("auth_email")
+
+    pipe = _get_pipeline()
+    datasource = (
+        data.get("datasource")
+        or pipe.default_ds
+        or pipe.settings.default_datasource(NAMESPACE)
+        or "default"
+    )
+    try:
+        research_enabled = pipe.settings.research_allowed(datasource, namespace=NAMESPACE)
+    except Exception:
+        research_enabled = bool(pipe.settings.get("RESEARCH_MODE", namespace=NAMESPACE))
+
+    inquiry_id = create_or_update_inquiry(
+        pipe.mem_engine,
+        namespace=NAMESPACE,
+        prefixes=prefixes,
+        question=question,
+        auth_email=auth_email,
+        run_id=None,
+        research_enabled=research_enabled,
+        datasource=datasource,
+        status="open",
+    )
+
+    plan = _plan_from_question(pipe, question)
+    if not plan.ok or not plan.sql:
+        payload = {
+            "inquiry_id": inquiry_id,
+            "status": "needs_clarification",
+            "questions": plan.questions or [],
+        }
+        if plan.error:
+            payload["error"] = plan.error
+        return jsonify(payload)
+
+    engine = pipe.ds.engine(datasource)
+    result = run_sql(engine, plan.sql)
+    response = {
+        "inquiry_id": inquiry_id,
+        "status": "answered" if result.ok else "failed",
+        "sql": plan.sql,
+        "result": result.dict(),
+        "rationale": plan.rationale,
+    }
+    if result.ok and not result.rows:
+        response["note"] = (
+            "No rows returned. Try a wider date window (e.g., last 12 months) or check filters."
+        )
+    if not result.ok and result.error:
+        response["error"] = result.error
+    return jsonify(response), (200 if result.ok else 500)
+
+
+@blueprint.route("/dw/seed", methods=["POST"])
+def seed():
+    pipe = _get_pipeline()
+
+    metrics = [
+        {
+            "metric_key": "gross_contract_value",
+            "metric_name": "Gross Contract Value",
+            "description": "NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0)",
+            "calculation_sql": "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)",
+            "required_tables": ["Contract"],
+            "required_columns": ["CONTRACT_VALUE_NET_OF_VAT", "VAT"],
+            "category": "contracts",
+        },
+        {
+            "metric_key": "net_contract_value",
+            "metric_name": "Net Contract Value",
+            "calculation_sql": "NVL(CONTRACT_VALUE_NET_OF_VAT,0)",
+            "required_tables": ["Contract"],
+            "required_columns": ["CONTRACT_VALUE_NET_OF_VAT"],
+            "category": "contracts",
+        },
+        {
+            "metric_key": "vat_amount",
+            "metric_name": "VAT Amount",
+            "calculation_sql": "NVL(VAT,0)",
+            "required_tables": ["Contract"],
+            "required_columns": ["VAT"],
+            "category": "contracts",
+        },
+        {
+            "metric_key": "contract_count",
+            "metric_name": "Contract Count",
+            "calculation_sql": "COUNT(1)",
+            "required_tables": ["Contract"],
+            "required_columns": ["DWDOCID"],
+            "category": "contracts",
+        },
+    ]
+    metrics_result = upsert_metrics(pipe.mem_engine, namespace=NAMESPACE, metrics=metrics)
+
+    mappings = [
+        {
+            "alias": "stakeholder",
+            "canonical": "CONTRACT_STAKEHOLDER_*",
+            "mapping_type": "column",
+            "scope": "Contract",
+        },
+        {
+            "alias": "department",
+            "canonical": "DEPARTMENT_*",
+            "mapping_type": "column",
+            "scope": "Contract",
+        },
+        {
+            "alias": "owner_department",
+            "canonical": "OWNER_DEPARTMENT",
+            "mapping_type": "column",
+            "scope": "Contract",
+        },
+        {
+            "alias": "value_gross",
+            "canonical": "NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0)",
+            "mapping_type": "metric",
+            "scope": "Contract",
+        },
+        {
+            "alias": "value_net",
+            "canonical": "NVL(CONTRACT_VALUE_NET_OF_VAT,0)",
+            "mapping_type": "metric",
+            "scope": "Contract",
+        },
+    ]
+    mappings_result = upsert_mappings(
+        pipe.mem_engine, namespace=NAMESPACE, mappings=mappings
+    )
+
+    snippet_sql_1 = """
+SELECT
+  p.stakeholder,
+  SUM(NVL(c.CONTRACT_VALUE_NET_OF_VAT,0) + NVL(c.VAT,0)) AS gross_contract_value
+FROM Contract c
+CROSS APPLY (
+  SELECT '1' AS slot, c.CONTRACT_STAKEHOLDER_1 AS stakeholder, c.DEPARTMENT_1 AS department FROM dual
+  UNION ALL SELECT '2', c.CONTRACT_STAKEHOLDER_2, c.DEPARTMENT_2 FROM dual
+  UNION ALL SELECT '3', c.CONTRACT_STAKEHOLDER_3, c.DEPARTMENT_3 FROM dual
+  UNION ALL SELECT '4', c.CONTRACT_STAKEHOLDER_4, c.DEPARTMENT_4 FROM dual
+  UNION ALL SELECT '5', c.CONTRACT_STAKEHOLDER_5, c.DEPARTMENT_5 FROM dual
+  UNION ALL SELECT '6', c.CONTRACT_STAKEHOLDER_6, c.DEPARTMENT_6 FROM dual
+  UNION ALL SELECT '7', c.CONTRACT_STAKEHOLDER_7, c.DEPARTMENT_7 FROM dual
+  UNION ALL SELECT '8', c.CONTRACT_STAKEHOLDER_8, c.DEPARTMENT_8 FROM dual
+) p
+WHERE p.stakeholder IS NOT NULL
+  AND TRUNC(c.START_DATE, 'MM') >= ADD_MONTHS(TRUNC(SYSDATE, 'MM'), -12)
+GROUP BY p.stakeholder
+ORDER BY gross_contract_value DESC
+FETCH FIRST 10 ROWS ONLY
+"""
+    upsert_snippet(
+        pipe.mem_engine,
+        namespace=NAMESPACE,
+        title="Top stakeholders by gross value (last 12 months)",
+        sql_raw=snippet_sql_1,
+        input_tables=["Contract"],
+        tags=["dw", "contracts", "stakeholder", "top10"],
+    )
+
+    snippet_sql_2 = """
+SELECT
+  CASE
+    WHEN c.END_DATE >= TRUNC(SYSDATE) AND c.END_DATE < TRUNC(SYSDATE) + 30 THEN 'next_30_days'
+    WHEN c.END_DATE >= TRUNC(SYSDATE) AND c.END_DATE < TRUNC(SYSDATE) + 60 THEN 'next_60_days'
+    WHEN c.END_DATE >= TRUNC(SYSDATE) AND c.END_DATE < TRUNC(SYSDATE) + 90 THEN 'next_90_days'
+    ELSE 'other'
+  END AS bucket,
+  COUNT(1) AS contract_count,
+  SUM(NVL(c.CONTRACT_VALUE_NET_OF_VAT,0) + NVL(c.VAT,0)) AS gross_contract_value
+FROM Contract c
+WHERE c.END_DATE IS NOT NULL
+  AND c.END_DATE < TRUNC(SYSDATE) + 90
+GROUP BY
+  CASE
+    WHEN c.END_DATE >= TRUNC(SYSDATE) AND c.END_DATE < TRUNC(SYSDATE) + 30 THEN 'next_30_days'
+    WHEN c.END_DATE >= TRUNC(SYSDATE) AND c.END_DATE < TRUNC(SYSDATE) + 60 THEN 'next_60_days'
+    WHEN c.END_DATE >= TRUNC(SYSDATE) AND c.END_DATE < TRUNC(SYSDATE) + 90 THEN 'next_90_days'
+    ELSE 'other'
+  END
+ORDER BY 1
+"""
+    upsert_snippet(
+        pipe.mem_engine,
+        namespace=NAMESPACE,
+        title="Contracts expiring in next 90 days (buckets)",
+        sql_raw=snippet_sql_2,
+        input_tables=["Contract"],
+        tags=["dw", "contracts", "expiry", "buckets"],
+    )
+
+    snippet_sql_3 = """
+SELECT
+  p.department,
+  SUM(NVL(c.CONTRACT_VALUE_NET_OF_VAT,0) + NVL(c.VAT,0)) AS gross_contract_value
+FROM Contract c
+CROSS APPLY (
+  SELECT c.DEPARTMENT_1 AS department FROM dual
+  UNION ALL SELECT c.DEPARTMENT_2 FROM dual
+  UNION ALL SELECT c.DEPARTMENT_3 FROM dual
+  UNION ALL SELECT c.DEPARTMENT_4 FROM dual
+  UNION ALL SELECT c.DEPARTMENT_5 FROM dual
+  UNION ALL SELECT c.DEPARTMENT_6 FROM dual
+  UNION ALL SELECT c.DEPARTMENT_7 FROM dual
+  UNION ALL SELECT c.DEPARTMENT_8 FROM dual
+) p
+WHERE p.department IS NOT NULL
+  AND TRUNC(c.START_DATE, 'YYYY') = TRUNC(SYSDATE, 'YYYY')
+GROUP BY p.department
+ORDER BY gross_contract_value DESC
+"""
+    upsert_snippet(
+        pipe.mem_engine,
+        namespace=NAMESPACE,
+        title="Gross value by department (this year)",
+        sql_raw=snippet_sql_3,
+        input_tables=["Contract"],
+        tags=["dw", "contracts", "department", "ytd"],
+    )
+
+    return jsonify(
+        {
+            "ok": True,
+            "metrics": metrics_result.count,
+            "mappings": mappings_result.count,
+            "snippets": 3,
+        }
+    )

--- a/core/seed.py
+++ b/core/seed.py
@@ -1,0 +1,230 @@
+"""Utilities for seeding metrics, mappings, and snippets into the memory store."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+
+@dataclass
+class UpsertResult:
+    """Simple container capturing how many records were written."""
+
+    count: int
+
+
+def _json_or_null(value: Any) -> str:
+    """Return a JSON-serialised representation suitable for CAST(:param AS jsonb)."""
+
+    if value is None:
+        return "null"
+    return json.dumps(value)
+
+
+def upsert_metrics(
+    mem_engine: Engine,
+    *,
+    namespace: str,
+    metrics: Sequence[Mapping[str, Any]] | None,
+) -> UpsertResult:
+    """Insert or replace metric definitions for the provided namespace."""
+
+    items = list(metrics or [])
+    if not items:
+        return UpsertResult(count=0)
+
+    delete_sql = text(
+        "DELETE FROM mem_metrics WHERE namespace = :ns AND metric_key = :metric_key"
+    )
+    insert_sql = text(
+        """
+        INSERT INTO mem_metrics(
+            namespace,
+            metric_key,
+            metric_name,
+            description,
+            calculation_sql,
+            required_tables,
+            required_columns,
+            category,
+            is_active,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :namespace,
+            :metric_key,
+            :metric_name,
+            :description,
+            :calculation_sql,
+            CAST(:required_tables AS jsonb),
+            CAST(:required_columns AS jsonb),
+            :category,
+            TRUE,
+            NOW(),
+            NOW()
+        )
+        """
+    )
+
+    count = 0
+    with mem_engine.begin() as conn:
+        for metric in items:
+            metric_key = metric.get("metric_key")
+            if not metric_key:
+                continue
+            conn.execute(delete_sql, {"ns": namespace, "metric_key": metric_key})
+            payload = {
+                "namespace": namespace,
+                "metric_key": metric_key,
+                "metric_name": metric.get("metric_name") or metric_key,
+                "description": metric.get("description"),
+                "calculation_sql": metric.get("calculation_sql"),
+                "required_tables": _json_or_null(metric.get("required_tables")),
+                "required_columns": _json_or_null(metric.get("required_columns")),
+                "category": metric.get("category"),
+            }
+            conn.execute(insert_sql, payload)
+            count += 1
+    return UpsertResult(count=count)
+
+
+def upsert_mappings(
+    mem_engine: Engine,
+    *,
+    namespace: str,
+    mappings: Sequence[Mapping[str, Any]] | None,
+) -> UpsertResult:
+    """Insert or replace user-to-canonical term mappings."""
+
+    items = list(mappings or [])
+    if not items:
+        return UpsertResult(count=0)
+
+    delete_sql = text(
+        """
+        DELETE FROM mem_mappings
+         WHERE namespace = :ns
+           AND alias = :alias
+           AND COALESCE(scope, '') = COALESCE(:scope, '')
+        """
+    )
+    insert_sql = text(
+        """
+        INSERT INTO mem_mappings(
+            namespace,
+            alias,
+            canonical,
+            mapping_type,
+            scope,
+            is_active,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :namespace,
+            :alias,
+            :canonical,
+            :mapping_type,
+            :scope,
+            TRUE,
+            NOW(),
+            NOW()
+        )
+        """
+    )
+
+    count = 0
+    with mem_engine.begin() as conn:
+        for mapping in items:
+            alias = mapping.get("alias")
+            canonical = mapping.get("canonical")
+            if not alias or not canonical:
+                continue
+            scope = mapping.get("scope")
+            conn.execute(delete_sql, {"ns": namespace, "alias": alias, "scope": scope})
+            payload = {
+                "namespace": namespace,
+                "alias": alias,
+                "canonical": canonical,
+                "mapping_type": mapping.get("mapping_type"),
+                "scope": scope,
+            }
+            conn.execute(insert_sql, payload)
+            count += 1
+    return UpsertResult(count=count)
+
+
+def upsert_snippet(
+    mem_engine: Engine,
+    *,
+    namespace: str,
+    title: str,
+    sql_raw: str,
+    input_tables: Iterable[str] | None = None,
+    description: str | None = None,
+    tags: Sequence[str] | None = None,
+) -> None:
+    """Replace (namespace, title) snippet with provided SQL."""
+
+    delete_sql = text(
+        "DELETE FROM mem_snippets WHERE namespace = :ns AND title = :title"
+    )
+    insert_sql = text(
+        """
+        INSERT INTO mem_snippets(
+            namespace,
+            title,
+            description,
+            sql_template,
+            sql_raw,
+            input_tables,
+            output_columns,
+            filters_applied,
+            parameters,
+            doc_md,
+            doc_erd,
+            tags,
+            created_at,
+            updated_at
+        )
+        VALUES (
+            :namespace,
+            :title,
+            :description,
+            :sql_raw,
+            :sql_raw,
+            CAST(:input_tables AS jsonb),
+            CAST(:output_columns AS jsonb),
+            CAST(:filters_applied AS jsonb),
+            CAST(:parameters AS jsonb),
+            :doc_md,
+            :doc_erd,
+            CAST(:tags AS jsonb),
+            NOW(),
+            NOW()
+        )
+        """
+    )
+
+    doc_md = f"### {title}\n\n````sql\n{sql_raw.strip()}\n````"
+    payload = {
+        "namespace": namespace,
+        "title": title,
+        "description": description or "Seeded snippet",
+        "sql_raw": sql_raw.strip(),
+        "input_tables": _json_or_null(list(input_tables or [])),
+        "output_columns": "null",
+        "filters_applied": "null",
+        "parameters": "null",
+        "doc_md": doc_md,
+        "doc_erd": None,
+        "tags": _json_or_null(list(tags or [])),
+    }
+
+    with mem_engine.begin() as conn:
+        conn.execute(delete_sql, {"ns": namespace, "title": title})
+        conn.execute(insert_sql, payload)

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ from flask import Flask
 from core.settings import Settings
 from core.pipeline import Pipeline
 from apps.fa.app import fa_bp
+from apps.docuware import docuware_bp
 from core.admin_api import admin_bp
 from core.sql_exec import init_mem_engine
 
@@ -26,6 +27,7 @@ def create_app() -> Flask:
     app.register_blueprint(admin_bp)
 
     app.register_blueprint(fa_bp, url_prefix="/fa")
+    app.register_blueprint(docuware_bp)
 
     @app.get("/__routes")
     def _routes():


### PR DESCRIPTION
## Summary
- add a DocuWare Flask blueprint exposing /dw/answer and /dw/seed routes that reuse seeded snippets
- implement memory-store seed helpers for metrics, mappings, and snippets along with a normalized SQL execution result
- register the DocuWare blueprint in the application factory alongside the existing FA module

## Testing
- python -m compileall apps/docuware core main.py

------
https://chatgpt.com/codex/tasks/task_e_68c952f90a048323bb4e84b9d9235a3b