### PR TITLE
Restore admin settings endpoint and register DW app

### DIFF
--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -1,131 +1,129 @@
 from __future__ import annotations
-from flask import Blueprint, request, jsonify, current_app
-from werkzeug.exceptions import BadRequest
-from sqlalchemy import text
-from core.inquiries import append_admin_note, fetch_inquiry
-from core.sql_exec import get_mem_engine
+
 import json
+
+from flask import Blueprint, current_app, jsonify, request
+from sqlalchemy import text
+from werkzeug.exceptions import BadRequest
+
+from core.inquiries import append_admin_note, fetch_inquiry
+from core.settings import Settings
+from core.sql_exec import get_mem_engine
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
-def _json_literal(val) -> str:
-    # Always send JSON to the DB; mem_settings.value is jsonb.
-    if isinstance(val, (dict, list, bool, int, float)) or val is None:
-        return json.dumps(val)
-    # Strings as JSON string
-    return json.dumps(str(val))
+def _mem_engine():
+    mem_engine = current_app.config.get("MEM_ENGINE")
+    if mem_engine is not None:
+        return mem_engine
 
+    pipeline = current_app.config.get("PIPELINE") or getattr(current_app, "pipeline", None)
+    if pipeline is not None:
+        candidate = getattr(pipeline, "mem_engine", None) or getattr(pipeline, "mem", None)
+        if candidate is not None:
+            current_app.config["MEM_ENGINE"] = candidate
+            return candidate
 
-def _infer_value_type(val, explicit: str | None) -> str:
-    if explicit:
-        return explicit
-    if isinstance(val, bool):
-        return "bool"
-    if isinstance(val, int):
-        return "int"
-    if isinstance(val, (dict, list)):
-        return "json"
-    return "string"
+    settings_obj = current_app.config.get("SETTINGS")
+    if isinstance(settings_obj, Settings):
+        mem_engine = get_mem_engine(settings_obj)
+    else:
+        mem_engine = get_mem_engine(Settings())
+
+    current_app.config["MEM_ENGINE"] = mem_engine
+    return mem_engine
 
 
 def _conn():
-    # Use the same engine the Pipeline made available
-    mem_engine = current_app.config.get("MEM_ENGINE")
-    if mem_engine is None:
-        raise RuntimeError("MEM_ENGINE not configured on app")
-    return mem_engine.connect()
+    return _mem_engine().connect()
+
+
+def _infer_vtype(value) -> str:
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "int"
+    if isinstance(value, float):
+        return "float"
+    if isinstance(value, (dict, list)):
+        return "json"
+    return "string"
 
 
 @admin_bp.post("/settings/bulk")
 def settings_bulk():
     payload = request.get_json(force=True) or {}
-    ns = payload.get("namespace") or "fa::common"
-    updated_by = payload.get("updated_by") or "api"
+    namespace = (payload.get("namespace") or "dw::common").strip()
+    updated_by = payload.get("updated_by") or "admin"
     items = payload.get("settings") or []
 
-    mem_engine = current_app.config.get("MEM_ENGINE")
-    if mem_engine is None:
-        return jsonify({"ok": False, "error": "MEM_ENGINE not configured"}), 500
+    mem_engine = _mem_engine()
 
-    # Ensure the two partial unique indexes exist
-    with mem_engine.begin() as conn:
-        conn.execute(text(
-            "CREATE UNIQUE INDEX IF NOT EXISTS ux_settings_ns_key_scope_null "
-            "ON mem_settings(namespace, key, scope) WHERE scope_id IS NULL"
-        ))
-        conn.execute(text(
-            "CREATE UNIQUE INDEX IF NOT EXISTS ux_settings_ns_key_scope_id "
-            "ON mem_settings(namespace, key, scope, scope_id) WHERE scope_id IS NOT NULL"
-        ))
-
-    upsert_null = text("""
+    upsert_sql = text(
+        """
+        WITH up AS (
+            UPDATE mem_settings
+               SET value      = CAST(:val AS jsonb),
+                   value_type = :vtype,
+                   category   = COALESCE(:cat, category),
+                   description= COALESCE(:desc, description),
+                   overridable= COALESCE(:ovr, overridable),
+                   updated_by = :upd,
+                   updated_at = NOW(),
+                   is_secret  = :sec
+             WHERE namespace=:ns
+               AND key=:key
+               AND scope=:scope
+               AND COALESCE(scope_id,'') = COALESCE(:scope_id,'')
+         RETURNING 1
+        )
         INSERT INTO mem_settings(
             namespace, key, value, value_type, scope, scope_id,
-            overridable, updated_by, created_at, updated_at, is_secret
+            category, description, overridable, updated_by, created_at, updated_at, is_secret
         )
-        VALUES (
-            :ns, :key, CAST(:val AS jsonb), :vtype, :scope, NULL,
-            COALESCE(:ovr, true), :upd, NOW(), NOW(), COALESCE(:sec, false)
-        )
-        ON CONFLICT (namespace, key, scope) WHERE scope_id IS NULL
-        DO UPDATE SET
-            value      = EXCLUDED.value,
-            value_type = EXCLUDED.value_type,
-            updated_by = EXCLUDED.updated_by,
-            updated_at = NOW(),
-            is_secret  = EXCLUDED.is_secret;
-    """)
-
-    upsert_scoped = text("""
-        INSERT INTO mem_settings(
-            namespace, key, value, value_type, scope, scope_id,
-            overridable, updated_by, created_at, updated_at, is_secret
-        )
-        VALUES (
-            :ns, :key, CAST(:val AS jsonb), :vtype, :scope, :scope_id,
-            COALESCE(:ovr, true), :upd, NOW(), NOW(), COALESCE(:sec, false)
-        )
-        ON CONFLICT (namespace, key, scope, scope_id) WHERE scope_id IS NOT NULL
-        DO UPDATE SET
-            value      = EXCLUDED.value,
-            value_type = EXCLUDED.value_type,
-            updated_by = EXCLUDED.updated_by,
-            updated_at = NOW(),
-            is_secret  = EXCLUDED.is_secret;
-    """)
+        SELECT :ns, :key, CAST(:val AS jsonb), :vtype, :scope, :scope_id,
+               :cat, :desc, COALESCE(:ovr, true), :upd, NOW(), NOW(), :sec
+        WHERE NOT EXISTS (SELECT 1 FROM up);
+        """
+    )
 
     upserted = 0
     with mem_engine.begin() as conn:
-        for it in items:
-            key = it["key"]
-            scope = it.get("scope") or "namespace"
-            scope_id = it.get("scope_id")
-            vtype = _infer_value_type(it.get("value"), it.get("value_type"))
-            val = _json_literal(it.get("value"))
+        for item in items:
+            key = item.get("key")
+            if not key:
+                continue
+
+            value = item.get("value")
+            vtype = item.get("value_type") or _infer_vtype(value)
+            scope = (item.get("scope") or "namespace").strip() or "namespace"
+            scope_id = item.get("scope_id")
+            if scope_id == "":
+                scope_id = None
+
             params = {
-                "ns": ns,
+                "ns": namespace,
                 "key": key,
-                "val": val,
+                "val": json.dumps(value, ensure_ascii=False),
                 "vtype": vtype,
                 "scope": scope,
                 "scope_id": scope_id,
-                "ovr": it.get("overridable"),
+                "cat": item.get("category"),
+                "desc": item.get("description"),
+                "ovr": item.get("overridable"),
                 "upd": updated_by,
-                "sec": bool(it.get("is_secret", False)),
+                "sec": bool(item.get("is_secret", False)),
             }
-            if scope_id is None or scope_id == "":
-                conn.execute(upsert_null, params)
-            else:
-                conn.execute(upsert_scoped, params)
+            conn.execute(upsert_sql, params)
             upserted += 1
 
-    return jsonify({"ok": True, "namespace": ns, "updated_by": updated_by, "upserted": upserted})
+    return jsonify({"ok": True, "namespace": namespace, "updated_by": updated_by, "upserted": upserted})
 
 
 @admin_bp.get("/settings/get")
 def settings_get():
-    """Quick fetch: /admin/settings/get?namespace=fa::common&key=RESEARCH_MODE"""
+    """Quick fetch: /admin/settings/get?namespace=dw::common&key=RESEARCH_MODE"""
     ns = request.args.get("namespace", "default")
     key = request.args.get("key")
     where = "WHERE namespace = :ns"
@@ -133,7 +131,10 @@ def settings_get():
     if key:
         where += " AND key = :k"
         params["k"] = key
-    sql = text(f"SELECT id, namespace, key, value, value_type, scope, scope_id, updated_at FROM mem_settings {where} ORDER BY key;")
+    sql = text(
+        f"SELECT id, namespace, key, value, value_type, scope, scope_id, updated_at "
+        f"FROM mem_settings {where} ORDER BY key;"
+    )
     with _conn() as c:
         rows = [dict(r._mapping) for r in c.execute(sql, params)]
     return jsonify({"ok": True, "items": rows})
@@ -141,9 +142,10 @@ def settings_get():
 
 # ----- Admin reply (append note safely & drive the pipeline) -----
 
+
 @admin_bp.get("/inquiries/<int:inq_id>")
 def get_inquiry(inq_id: int):
-    mem = current_app.config["MEM_ENGINE"]
+    mem = _mem_engine()
     row = fetch_inquiry(mem, inq_id)
     if not row:
         return jsonify({"error": "not_found"}), 404
@@ -182,7 +184,3 @@ def admin_process(inq_id: int):
         return jsonify({"ok": True, "inquiry_id": inq_id, **out})
     except Exception as e:
         return jsonify({"ok": False, "inquiry_id": inq_id, "error": str(e)}), 500
-
-# helper
-
- 

--- a/main.py
+++ b/main.py
@@ -1,19 +1,34 @@
 """Flask application entry point for DocuWare endpoints."""
 
-from flask import Flask
+import os
+
+from flask import Flask, jsonify
 
 from core.pipeline import Pipeline
 from core.settings import Settings
-from apps.dw.app import dw_bp
 
 
 def create_app():
     app = Flask(__name__)
 
-    settings = Settings(namespace="dw::common")
-    pipeline = Pipeline(settings=settings, namespace="dw::common")
+    namespace = os.getenv("ACTIVE_NAMESPACE", "dw::common")
+    settings = Settings(namespace=namespace)
+    pipeline = Pipeline(settings=settings, namespace=namespace)
+
+    app.config["ACTIVE_NAMESPACE"] = namespace
+    app.config["SETTINGS"] = settings
+    app.config["PIPELINE"] = pipeline
+    app.config["MEM_ENGINE"] = pipeline.mem_engine
+    app.pipeline = pipeline
+
+    from apps.dw.app import dw_bp
+    from core.admin_api import admin_bp
 
     app.register_blueprint(dw_bp)
+    app.register_blueprint(admin_bp)
 
-    app.pipeline = pipeline
+    @app.get("/healthz")
+    def healthz():
+        return jsonify({"ok": True, "app": "dw", "namespace": namespace})
+
     return app


### PR DESCRIPTION
## Summary
- register the DocuWare and admin blueprints in the Flask app while wiring pipeline context into the Flask config and adding a health check
- refactor the admin settings bulk endpoint to use an update-then-insert pattern and centralise access to the memory engine

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9e1a1d0108323865dd61202d971ee