### PR TITLE
Fix DW blueprint import and add DW app routes

### DIFF
--- a/apps/dw/__init__.py
+++ b/apps/dw/__init__.py
@@ -1,5 +1,3 @@
-"""DocuWare application package."""
+from .app import create_dw_blueprint
 
-from .app import dw_bp
-
-__all__ = ["dw_bp"]
+__all__ = ["create_dw_blueprint"]

--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -1,221 +1,196 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, current_app, jsonify, request
+from core.settings import Settings
+from core.sql_exec import get_mem_engine
 from sqlalchemy import text
-import re
-
-from core.pipeline import Pipeline
+import json
 
 
-def create_dw_blueprint(pipeline: Pipeline) -> Blueprint:
-    bp = Blueprint("dw", __name__)
-    namespace = pipeline.namespace
+def create_dw_blueprint(settings: Settings) -> Blueprint:
+    """
+    DW blueprint factory. We avoid any FA imports here.
+    """
+    bp = Blueprint("dw", __name__, url_prefix="/dw")
 
-    def _dw_engine():
-        return pipeline.ds.engine(None)
-
-    @bp.post("/seed")
+    @bp.route("/seed", methods=["POST"])
     def seed():
-        mem = pipeline.mem
+        """
+        Seed minimal knowledge for table Contract into memory DB (mem_* tables).
+        No Oracle views. Only mem_* tables are touched.
+        """
+        payload = request.get_json(silent=True) or {}
+        ns = payload.get("namespace") or "dw::common"
+        force = bool(payload.get("force", False))
 
-        metric_net = text(
-            """
-            INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
-                                    calculation_sql, required_tables, required_columns,
-                                    category, owner, is_active, verified_at, created_at, updated_at)
-            VALUES
-              (:ns,'contract_value_net','Contract Value (Net of VAT)',
-               'Base contract amount excluding VAT',
-               'NVL(CONTRACT_VALUE_NET_OF_VAT,0)',
-               '["Contract"]','["CONTRACT_VALUE_NET_OF_VAT"]',
-               'contracts','system', true, NOW(), NOW(), NOW())
-            ON CONFLICT (namespace, metric_key, version) DO NOTHING;
-            """
+        mem = get_mem_engine(settings)
+
+        # 1) Basic mappings / glossary for Contract (stakeholders & departments)
+        #    This helps the planner recognize common terms.
+        mappings = [
+            # alias, canonical, mapping_type, scope
+            ("stakeholder", "contract_stakeholder", "term", "global"),
+            ("department",  "department",           "term", "global"),
+            ("owner",       "contract_owner",       "term", "global"),
+            ("value",       "contract_value_gross", "metric","global"),
+            ("net value",   "contract_value_net",   "metric","global"),
+            ("vat",         "vat",                  "term", "global"),
+        ]
+
+        metrics = [
+            # metric_key, metric_name, calculation_sql, required_tables, required_columns, description
+            ("contract_value_gross",
+             "Contract Value (Gross)",
+             # NVL for Oracle
+             "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)",
+             ["Contract"],
+             ["CONTRACT_VALUE_NET_OF_VAT", "VAT"],
+             "Gross value = net + VAT"),
+
+            ("active_contracts_count",
+             "Active Contracts Count",
+             "COUNT(*) FILTER (WHERE END_DATE IS NULL OR END_DATE >= SYSDATE)",
+             ["Contract"],
+             ["END_DATE"],
+             "Number of contracts not yet expired"),
+        ]
+
+        # Snippet: unpivot stakeholders ↔ departments without creating a view (UNION ALL)
+        unpivot_sql = """
+        SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+               CONTRACT_VALUE_NET_OF_VAT, VAT,
+               NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS,
+               START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+               ENTITY_NO, DEPARTMENT_OUL, SLOT, STAKEHOLDER, DEPARTMENT
+        FROM (
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '1' AS SLOT, CONTRACT_STAKEHOLDER_1 AS STAKEHOLDER, DEPARTMENT_1 AS DEPARTMENT FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '2', CONTRACT_STAKEHOLDER_2, DEPARTMENT_2 FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '3', CONTRACT_STAKEHOLDER_3, DEPARTMENT_3 FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '4', CONTRACT_STAKEHOLDER_4, DEPARTMENT_4 FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '5', CONTRACT_STAKEHOLDER_5, DEPARTMENT_5 FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '6', CONTRACT_STAKEHOLDER_6, DEPARTMENT_6 FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '7', CONTRACT_STAKEHOLDER_7, DEPARTMENT_7 FROM Contract
+          UNION ALL
+          SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
+                 CONTRACT_VALUE_NET_OF_VAT, VAT,
+                 START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
+                 ENTITY_NO, DEPARTMENT_OUL,
+                 '8', CONTRACT_STAKEHOLDER_8, DEPARTMENT_8 FROM Contract
         )
-        metric_vat = text(
-            """
-            INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
-                                    calculation_sql, required_tables, required_columns,
-                                    category, owner, is_active, verified_at, created_at, updated_at)
-            VALUES
-              (:ns,'contract_value_vat','VAT Amount',
-               'Value-added tax amount on contract',
-               'NVL(VAT,0)',
-               '["Contract"]','["VAT"]',
-               'contracts','system', true, NOW(), NOW(), NOW())
-            ON CONFLICT (namespace, metric_key, version) DO NOTHING;
-            """
-        )
-        metric_gross = text(
-            """
-            INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
-                                    calculation_sql, required_tables, required_columns,
-                                    category, owner, is_active, verified_at, created_at, updated_at)
-            VALUES
-              (:ns,'contract_value_gross','Contract Value (Gross)',
-               'Net + VAT',
-               'NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)',
-               '["Contract"]','["CONTRACT_VALUE_NET_OF_VAT","VAT"]',
-               'contracts','system', true, NOW(), NOW(), NOW())
-            ON CONFLICT (namespace, metric_key, version) DO NOTHING;
-            """
-        )
+        """
 
-        snippet_sql = text(
-            """
-            INSERT INTO mem_snippets(namespace, title, description, sql_template, input_tables, output_columns, tags, created_at, updated_at, is_verified)
-            VALUES (
-              :ns,
-              'contract_stakeholders_rows',
-              'Unroll CONTRACT_STAKEHOLDER_[1..8] + DEPARTMENT_[1..8] into rows (no DB view).',
-              :tpl,
-              '["Contract"]',
-              '["DWDOCID","CONTRACT_ID","CONTRACT_OWNER","OWNER_DEPARTMENT","CONTRACT_VALUE_NET_OF_VAT","VAT","CONTRACT_VALUE_GROSS","START_DATE","END_DATE","REQUEST_DATE","CONTRACT_STATUS","REQUEST_TYPE","ENTITY_NO","DEPARTMENT_OUL","SLOT","STAKEHOLDER","DEPARTMENT"]',
-              '["dw","contracts","stakeholders","unnest"]',
-              NOW(), NOW(), true
-            )
-            ON CONFLICT DO NOTHING;
-            """
-        )
+        with mem.begin() as c:
+            if force:
+                c.execute(text("DELETE FROM mem_mappings WHERE namespace=:ns"), {"ns": ns})
+                c.execute(text("DELETE FROM mem_metrics  WHERE namespace=:ns"), {"ns": ns})
+                c.execute(text("DELETE FROM mem_snippets WHERE namespace=:ns"), {"ns": ns})
 
-        template_sql = """
-SELECT
-  DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-  CONTRACT_VALUE_NET_OF_VAT, VAT,
-  NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS,
-  START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-  ENTITY_NO, DEPARTMENT_OUL,
-  '1' AS SLOT, CONTRACT_STAKEHOLDER_1 AS STAKEHOLDER, DEPARTMENT_1 AS DEPARTMENT
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '2', CONTRACT_STAKEHOLDER_2, DEPARTMENT_2
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '3', CONTRACT_STAKEHOLDER_3, DEPARTMENT_3
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '4', CONTRACT_STAKEHOLDER_4, DEPARTMENT_4
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '5', CONTRACT_STAKEHOLDER_5, DEPARTMENT_5
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '6', CONTRACT_STAKEHOLDER_6, DEPARTMENT_6
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '7', CONTRACT_STAKEHOLDER_7, DEPARTMENT_7
-FROM Contract
-UNION ALL
-SELECT DWDOCID, CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT,
-       CONTRACT_VALUE_NET_OF_VAT, VAT,
-       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0),
-       START_DATE, END_DATE, REQUEST_DATE, CONTRACT_STATUS, REQUEST_TYPE,
-       ENTITY_NO, DEPARTMENT_OUL,
-       '8', CONTRACT_STAKEHOLDER_8, DEPARTMENT_8
-FROM Contract
-""".strip()
+            # Upsert mappings
+            for alias, canonical, mtype, scope in mappings:
+                c.execute(text("""
+                    INSERT INTO mem_mappings(namespace, alias, canonical, mapping_type, scope, source, confidence)
+                    VALUES (:ns, :alias, :canonical, :mtype, :scope, 'seed', 0.95)
+                    ON CONFLICT (namespace, alias, mapping_type, scope) DO UPDATE
+                      SET canonical = EXCLUDED.canonical,
+                          updated_at = NOW()
+                """), dict(ns=ns, alias=alias, canonical=canonical, mtype=mtype, scope=scope))
 
-        with mem.begin() as conn:
-            conn.execute(metric_net, {"ns": namespace})
-            conn.execute(metric_vat, {"ns": namespace})
-            conn.execute(metric_gross, {"ns": namespace})
-            conn.execute(snippet_sql, {"ns": namespace, "tpl": template_sql})
+            # Upsert metrics
+            for key, name, sql_expr, req_tables, req_cols, desc in metrics:
+                c.execute(text("""
+                    INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
+                                            calculation_sql, required_tables, required_columns, category, owner, is_active)
+                    VALUES(:ns, :key, :name, :desc, :calc, :rt::jsonb, :rc::jsonb, 'contracts','dw', true)
+                    ON CONFLICT (namespace, metric_key, version) DO UPDATE
+                      SET calculation_sql = EXCLUDED.calculation_sql,
+                          description      = EXCLUDED.description,
+                          updated_at       = NOW()
+                """), dict(
+                    ns=ns, key=key, name=name, desc=desc, calc=sql_expr,
+                    rt=json.dumps(req_tables), rc=json.dumps(req_cols)
+                ))
 
-        return jsonify(ok=True, namespace=namespace, metrics=3, snippets=1)
+            # Saved snippet for unpivot
+            c.execute(text("""
+                INSERT INTO mem_snippets(namespace, title, description, sql_template, input_tables, tags, is_verified, verified_by)
+                VALUES(:ns, 'dw_contract_stakeholders_unpivot',
+                       'UNION ALL unpivot of 8 stakeholder/department pairs (no DB views).',
+                       :sql, '["Contract"]'::jsonb, '["dw","contracts","unpivot"]'::jsonb, true, 'seed')
+                ON CONFLICT DO NOTHING
+            """), dict(ns=ns, sql=unpivot_sql))
 
-    @bp.post("/answer")
+        return jsonify({"ok": True, "namespace": ns, "seeded": {"mappings": len(mappings), "metrics": len(metrics), "snippets": 1}})
+
+    @bp.route("/answer", methods=["POST"])
     def answer():
-        payload = request.get_json(force=True)
-        question = (payload.get("question") or "").strip().lower()
+        """
+        Hand the question to Pipeline.answer using the DW namespace.
+        """
+        payload = request.get_json(force=True) or {}
+        question  = payload.get("question") or ""
+        auth_email = payload.get("auth_email")
+        prefixes   = payload.get("prefixes") or []   # keep shape consistent
 
-        if not question:
-            return jsonify(status="needs_clarification", questions=["Provide a question to answer."]), 200
+        # Use the pipeline created in main app factory
+        pipeline = current_app.config.get("pipeline")
+        if not pipeline:
+            return jsonify({"ok": False, "error": "Pipeline not available"}), 500
 
-        if "expir" in question and "day" in question:
-            match = re.search(r"next\s+(\d+)\s*day", question)
-            days = int(match.group(1)) if match else 30
-            sql = text(
-                """
-                SELECT CONTRACT_ID,
-                       CONTRACT_OWNER,
-                       OWNER_DEPARTMENT,
-                       END_DATE,
-                       NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS
-                  FROM Contract
-                 WHERE END_DATE BETWEEN TRUNC(SYSDATE) AND TRUNC(SYSDATE) + :days
-                 ORDER BY END_DATE ASC
-                """
+        try:
+            result = pipeline.answer(
+                question=question,
+                auth_email=auth_email,
+                prefixes=prefixes,
+                datasource="docuware",
+                namespace="dw::common",
             )
-            engine = _dw_engine()
-            with engine.begin() as conn:
-                rows = [dict(r) for r in conn.execute(sql, {"days": days}).mappings().all()]
-            return jsonify(status="answered", rows=rows, sql=str(sql)), 200
+        except NotImplementedError as exc:  # pragma: no cover - legacy pipeline stub
+            return jsonify({"ok": False, "error": str(exc)}), 501
 
-        if "top" in question and "stakeholder" in question:
-            sql = text(
-                """
-                SELECT STAKEHOLDER,
-                       SUM(NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)) AS GROSS_TOTAL
-                FROM (
-                    SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0) AS NETV, NVL(VAT,0) AS VAT,
-                           CONTRACT_STAKEHOLDER_1 AS STAKEHOLDER FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_2 FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_3 FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_4 FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_5 FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_6 FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_7 FROM Contract
-                    UNION ALL SELECT NVL(CONTRACT_VALUE_NET_OF_VAT,0), NVL(VAT,0), CONTRACT_STAKEHOLDER_8 FROM Contract
-                )
-                WHERE STAKEHOLDER IS NOT NULL
-                GROUP BY STAKEHOLDER
-                ORDER BY GROSS_TOTAL DESC
-                FETCH FIRST 10 ROWS ONLY
-                """
-            )
-            engine = _dw_engine()
-            with engine.begin() as conn:
-                rows = [dict(r) for r in conn.execute(sql).mappings().all()]
-            return jsonify(status="answered", rows=rows, sql=str(sql)), 200
+        return jsonify(result)
 
-        return (
-            jsonify(
-                status="needs_clarification",
-                questions=[
-                    "Which time window or filter (e.g., next 30 days, this quarter)?",
-                    "Aggregate by what (stakeholder, owner_department, entity_no)?",
-                    "Return which columns?",
-                ],
-            ),
-            200,
-        )
+    @bp.route("/metrics", methods=["GET"])
+    def metrics():
+        ns = request.args.get("namespace") or "dw::common"
+        mem = get_mem_engine(settings)
+        rows = mem.execute(text("""
+            SELECT metric_key, metric_name, calculation_sql, description
+              FROM mem_metrics
+             WHERE namespace = :ns AND is_active = true
+             ORDER BY metric_key
+        """), {"ns": ns}).mappings().all()
+        return jsonify({"ok": True, "namespace": ns, "metrics": rows})
 
     return bp

--- a/apps/dw/hints.py
+++ b/apps/dw/hints.py
@@ -1,28 +1,41 @@
-"""DocuWare hint helpers used by the pipeline."""
-
-DOCUWARE_DEFAULT_TABLE = '"Contract"'
-PREFERRED_DATE_COLUMNS = ["START_DATE", "END_DATE", "REQUEST_DATE"]
-
-METRIC_SQL = {
-    "contract_value_net": "NVL(CONTRACT_VALUE_NET_OF_VAT, 0)",
-    "contract_value_vat": "NVL(VAT, 0)",
-    "contract_value_gross": "NVL(CONTRACT_VALUE_NET_OF_VAT, 0) + NVL(VAT, 0)",
-}
+"""Minimal DocuWare hint helpers used by the pipeline."""
 
 
-def default_table() -> str:
-    """Return the default DocuWare table name."""
-
-    return DOCUWARE_DEFAULT_TABLE
-
-
-def preferred_dates() -> list[str]:
-    """Return preferred date column names for DocuWare tables."""
-
-    return PREFERRED_DATE_COLUMNS
+def get_join_hints(namespace: str = "dw::common"):
+    """Return join hints for the DocuWare namespace."""
+    # Single-table for now; no joins required.
+    return []
 
 
-def metric_sql_map() -> dict[str, str]:
-    """Return metric-key to SQL-expression mapping."""
+def get_metric_hints(namespace: str = "dw::common"):
+    """Return metric key to SQL expression mappings."""
+    return {
+        "contract_value_gross": "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)",
+        "contract_value_net": "NVL(CONTRACT_VALUE_NET_OF_VAT,0)",
+        "vat": "NVL(VAT,0)",
+    }
 
-    return METRIC_SQL
+
+def get_reserved_terms(namespace: str = "dw::common"):
+    """Return reserved terms to help the planner map synonyms."""
+    return {
+        "contract": "Contract",
+        "contracts": "Contract",
+        "owner": "CONTRACT_OWNER",
+        "stakeholder": "contract_stakeholder",
+        "department": "department",
+    }
+
+
+def get_date_columns(namespace: str = "dw::common"):
+    """Return date columns for the DocuWare Contract table."""
+    return {
+        "Contract": [
+            "START_DATE",
+            "END_DATE",
+            "REQUEST_DATE",
+            "EXPIERY_30",
+            "EXPIERY_60",
+            "EXPIERY_90",
+        ]
+    }

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -6,6 +6,26 @@ from core.settings import Settings
 from core.sql_exec import get_mem_engine
 from core.datasources import DatasourceRegistry
 
+try:  # pragma: no cover - optional hints module
+    from apps.dw.hints import (
+        get_join_hints,
+        get_metric_hints,
+        get_reserved_terms,
+        get_date_columns,
+    )
+except Exception:  # pragma: no cover - fallback if hints unavailable
+    def get_join_hints(*args, **kwargs):
+        return []
+
+    def get_metric_hints(*args, **kwargs):
+        return {}
+
+    def get_reserved_terms(*args, **kwargs):
+        return {}
+
+    def get_date_columns(*args, **kwargs):
+        return {}
+
 
 class Pipeline:
     """Lightweight pipeline wrapper for DocuWare flows."""

--- a/main.py
+++ b/main.py
@@ -1,26 +1,47 @@
-from flask import Flask
-
+from flask import Flask, jsonify
 from core.settings import Settings
 from core.pipeline import Pipeline
-from core.routes import register_common_routes
-from core.admin_api import create_admin_blueprint
-from apps.dw.app import create_dw_blueprint
 
 
-def create_app() -> Flask:
+def create_app():
+    app = Flask(__name__)
     settings = Settings()
 
-    app = Flask(__name__)
+    # Register Admin API (bulk settings, etc.)
+    admin_blueprint = None
+    try:
+        from core.admin_api import admin_bp as _admin_bp
+        admin_blueprint = _admin_bp
+    except Exception:
+        try:
+            from core.admin_api import create_admin_blueprint as _create_admin_blueprint
+        except Exception:
+            _create_admin_blueprint = None
+        if _create_admin_blueprint is not None:
+            admin_blueprint = _create_admin_blueprint(settings)
 
-    # Health and route inspection endpoints
-    register_common_routes(app)
+    if admin_blueprint is not None:
+        app.register_blueprint(admin_blueprint, url_prefix=getattr(admin_blueprint, "url_prefix", None) or "/admin")
 
-    # Build pipeline with DocuWare namespace by default
-    active_ns = settings.get("ACTIVE_NAMESPACE", "dw::common")
-    pipeline = Pipeline(settings=settings, namespace=active_ns)
+    # Build pipeline for DW
+    pipeline = Pipeline(settings=settings, namespace="dw::common")
+    app.config["pipeline"] = pipeline
 
-    # Register blueprints
-    app.register_blueprint(create_admin_blueprint(settings), url_prefix="/admin")
-    app.register_blueprint(create_dw_blueprint(pipeline), url_prefix="/dw")
+    # Register DW app
+    from apps.dw import create_dw_blueprint
+    app.register_blueprint(create_dw_blueprint(settings))
+
+    # Diagnostics
+    @app.get("/health")
+    def health():
+        return jsonify({"ok": True})
+
+    @app.get("/__routes")
+    def routes():
+        return jsonify(sorted([str(r) for r in app.url_map.iter_rules()]))
 
     return app
+
+
+# For flask CLI
+app = create_app()


### PR DESCRIPTION
## Summary
- expose `create_dw_blueprint` from `apps.dw` and rebuild the DW blueprint with seed, answer, and metrics endpoints that avoid FA imports
- update the Flask app factory to register the admin and DW blueprints, stash the pipeline on the app config, and add `/health` plus `/__routes`
- add resilient DW hint imports to the pipeline and provide minimal DocuWare hint helpers

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c9ed56b87883238a2e8a2beed66ed2