### PR TITLE
Fix DW seeding JSON bindings and settings upsert index

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -132,7 +132,11 @@ def create_dw_blueprint(settings: Settings) -> Blueprint:
                 c.execute(text("""
                     INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
                                             calculation_sql, required_tables, required_columns, category, owner, is_active)
-                    VALUES(:ns, :key, :name, :desc, :calc, :rt::jsonb, :rc::jsonb, 'contracts','dw', true)
+                    VALUES(
+                        :ns, :key, :name, :desc, :calc,
+                        CAST(:rt AS jsonb), CAST(:rc AS jsonb),
+                        'contracts', 'dw', true
+                    )
                     ON CONFLICT (namespace, metric_key, version) DO UPDATE
                       SET calculation_sql = EXCLUDED.calculation_sql,
                           description      = EXCLUDED.description,


### PR DESCRIPTION
## Summary
- use consistent named bind parameters in the DocuWare seed metrics insert and cast JSON payloads to jsonb
- ensure a plain unique index on mem_settings(namespace, key, scope) exists to satisfy the bulk settings upsert conflict target

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f76b3ef083238793b99e28b57b75