### PR TITLE
Add DocuWare ingestion endpoints and SQLAlchemy 2.x fixes

### DIFF
--- a/apps/dw/__init__.py
+++ b/apps/dw/__init__.py
@@ -1,3 +1,3 @@
-from .app import create_dw_blueprint
+from .app import create_dw_blueprint, dw_bp
 
-__all__ = ["create_dw_blueprint"]
+__all__ = ["dw_bp", "create_dw_blueprint"]

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from flask import Flask, jsonify
-from core.settings import Settings
+
 from core.pipeline import Pipeline
+from core.settings import Settings
+from apps.dw import dw_bp
 
 
 def create_app():
@@ -21,15 +23,17 @@ def create_app():
             admin_blueprint = _create_admin_blueprint(settings)
 
     if admin_blueprint is not None:
-        app.register_blueprint(admin_blueprint, url_prefix=getattr(admin_blueprint, "url_prefix", None) or "/admin")
+        app.register_blueprint(
+            admin_blueprint,
+            url_prefix=getattr(admin_blueprint, "url_prefix", None) or "/admin",
+        )
 
     # Build pipeline for DW
     pipeline = Pipeline(settings=settings, namespace="dw::common")
     app.config["pipeline"] = pipeline
 
     # Register DW app
-    from apps.dw import create_dw_blueprint
-    app.register_blueprint(create_dw_blueprint(settings))
+    app.register_blueprint(dw_bp)
 
     # Diagnostics
     @app.get("/health")


### PR DESCRIPTION
## Summary
- replace the DocuWare blueprint with dedicated /dw routes for seeding, ingestion, metrics, and answering requests
- pull the Contract table schema into the memory database and seed the first metric using JSONB casts compatible with PostgreSQL
- register the blueprint directly in the app factory and expose an admin settings summary helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9fdc7aa848323a1319560c9f3e8ca