### PR TITLE
Refactor DocuWare pipeline for rule-based answering

### DIFF
--- a/apps/dw/answerer.py
+++ b/apps/dw/answerer.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from sqlalchemy import text
+
+
+class AnswerError(Exception):
+    """Raised when a question cannot be handled by the rule-based answerer."""
+
+
+@dataclass
+class AnswerResult:
+    sql: str
+    rows: List[Dict[str, Any]]
+    top_n: int
+    date_start: datetime
+    date_end: datetime
+    tags: List[str]
+    run_id: Optional[int] = None
+
+
+_TOP_RE = re.compile(r"top\s+(?P<n>\d+)", re.IGNORECASE)
+_SLOT_RE = re.compile(r"(\d+)$")
+
+
+class StakeholderAnswerer:
+    """Rule-based interpreter for DocuWare stakeholder aggregations."""
+
+    METRIC_KEY = "contract_value_gross"
+
+    def __init__(self, settings, mem_engine, registry) -> None:
+        self.settings = settings
+        self.namespace = getattr(settings, "namespace", "dw::common")
+        self.mem = mem_engine
+        self.registry = registry
+
+    # ------------------------------------------------------------------
+    def answer(self, question: str) -> AnswerResult:
+        plan = self._interpret(question)
+        if not plan:
+            raise AnswerError("Question not recognised for DocuWare stakeholder metrics.")
+
+        metric_expr = self._metric_expression()
+        date_column = self._date_column()
+        table_name = self._table_name()
+        column_pairs = self._column_pairs()
+        if not column_pairs:
+            raise AnswerError("No stakeholder column mappings available for DocuWare.")
+
+        sql_text = self._build_sql(metric_expr, date_column, table_name, column_pairs, plan["top_n"])
+        rows = self._execute(sql_text, plan["start"], plan["end"])
+        run_id = self._record_run(question, sql_text, rows)
+        self._store_snippet(sql_text, plan["tags"])
+
+        return AnswerResult(
+            sql=sql_text,
+            rows=rows,
+            top_n=plan["top_n"],
+            date_start=plan["start"],
+            date_end=plan["end"],
+            tags=plan["tags"],
+            run_id=run_id,
+        )
+
+    # ------------------------------------------------------------------
+    def _interpret(self, question: str) -> Optional[Dict[str, Any]]:
+        text_q = question.lower()
+        if "stakeholder" not in text_q:
+            return None
+        if not any(token in text_q for token in ("contract value", "gross", "value")):
+            return None
+
+        if "last month" in text_q or "previous month" in text_q:
+            start, end = self._last_month_bounds()
+            tags = ["dw", "contracts", "stakeholder", "last_month"]
+        else:
+            return None
+
+        top_n = self._parse_top_n(text_q)
+        tags.append(f"top_{top_n}")
+        return {"top_n": top_n, "start": start, "end": end, "tags": tags}
+
+    # ------------------------------------------------------------------
+    def _parse_top_n(self, question: str) -> int:
+        match = _TOP_RE.search(question)
+        if match:
+            try:
+                value = int(match.group("n"))
+                return max(1, min(value, 100))
+            except Exception:
+                pass
+        if "top ten" in question:
+            return 10
+        return 10
+
+    # ------------------------------------------------------------------
+    def _last_month_bounds(self, today: Optional[date] = None) -> Tuple[datetime, datetime]:
+        today = today or date.today()
+        first_of_month = today.replace(day=1)
+        last_month_end = first_of_month
+        last_month_start = (first_of_month - timedelta(days=1)).replace(day=1)
+        return (
+            datetime.combine(last_month_start, time.min),
+            datetime.combine(last_month_end, time.min),
+        )
+
+    # ------------------------------------------------------------------
+    def _metric_expression(self) -> str:
+        sql = text(
+            """
+            SELECT calculation_sql
+              FROM mem_metrics
+             WHERE namespace = :ns
+               AND metric_key = :metric
+          ORDER BY version DESC
+             LIMIT 1
+            """
+        )
+        with self.mem.connect() as conn:
+            row = conn.execute(sql, {"ns": self.namespace, "metric": self.METRIC_KEY}).fetchone()
+        if row and row[0]:
+            return str(row[0])
+        return "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)"
+
+    # ------------------------------------------------------------------
+    def _date_column(self) -> str:
+        column = self.settings.get_string("DW_DEFAULT_DATE_COLUMN", default="REQUEST_DATE")
+        if column:
+            return column
+        return "REQUEST_DATE"
+
+    # ------------------------------------------------------------------
+    def _table_name(self) -> str:
+        table_name = self.settings.get_string("DW_CONTRACT_TABLE", default="Contract")
+        if not table_name:
+            table_name = "Contract"
+        if "." in table_name:
+            return table_name
+        if table_name.isupper() and table_name.replace("_", "").isalnum():
+            return table_name
+        return f'"{table_name}"'
+
+    # ------------------------------------------------------------------
+    def _column_pairs(self) -> List[Tuple[str, Optional[str]]]:
+        stakeholders = self._fetch_column_aliases("stakeholder")
+        departments = self._fetch_column_aliases("department")
+
+        if not stakeholders:
+            stakeholders = [f"CONTRACT_STAKEHOLDER_{idx}" for idx in range(1, 9)]
+        if not departments:
+            departments = [f"DEPARTMENT_{idx}" for idx in range(1, 9)]
+
+        pairs: List[Tuple[str, Optional[str]]] = []
+        for idx, stake_col in enumerate(stakeholders):
+            dept_col = departments[idx] if idx < len(departments) else None
+            pairs.append((stake_col, dept_col))
+        return pairs
+
+    # ------------------------------------------------------------------
+    def _fetch_column_aliases(self, canonical: str) -> List[str]:
+        sql = text(
+            """
+            SELECT alias
+              FROM mem_mappings
+             WHERE namespace = :ns
+               AND canonical = :canon
+               AND mapping_type = 'column'
+          ORDER BY alias
+            """
+        )
+        with self.mem.connect() as conn:
+            rows = conn.execute(sql, {"ns": self.namespace, "canon": canonical}).fetchall()
+        aliases = [str(row[0]) for row in rows if row and row[0]]
+        return self._sort_by_slot(aliases)
+
+    # ------------------------------------------------------------------
+    def _sort_by_slot(self, columns: Sequence[str]) -> List[str]:
+        def slot_key(name: str) -> int:
+            match = _SLOT_RE.search(name or "")
+            return int(match.group(1)) if match else 0
+
+        return sorted(columns, key=slot_key)
+
+    # ------------------------------------------------------------------
+    def _build_sql(
+        self,
+        metric_expr: str,
+        date_column: str,
+        table_name: str,
+        column_pairs: Sequence[Tuple[str, Optional[str]]],
+        top_n: int,
+    ) -> str:
+        selects = []
+        for stakeholder_col, dept_col in column_pairs:
+            department_expr = dept_col if dept_col else "NULL"
+            selects.append(
+                """
+                SELECT
+                  CONTRACT_ID,
+                  {metric} AS CONTRACT_VALUE_GROSS,
+                  {stake} AS STAKEHOLDER,
+                  {dept} AS DEPARTMENT,
+                  {date_col} AS REF_DATE
+                FROM {table}
+                """.format(
+                    metric=metric_expr,
+                    stake=stakeholder_col,
+                    dept=department_expr,
+                    date_col=date_column,
+                    table=table_name,
+                ).strip()
+            )
+
+        union_sql = "\nUNION ALL\n".join(selects)
+        limit_clause = f"FETCH FIRST {top_n} ROWS ONLY"
+
+        return (
+            """
+            WITH stakeholders AS (
+            {union}
+            )
+            SELECT
+              TRIM(STAKEHOLDER) AS stakeholder,
+              SUM(CONTRACT_VALUE_GROSS) AS total_gross_value,
+              COUNT(DISTINCT CONTRACT_ID) AS contract_count,
+              LISTAGG(DISTINCT TRIM(DEPARTMENT), ', ') WITHIN GROUP (ORDER BY TRIM(DEPARTMENT)) AS departments
+            FROM stakeholders
+            WHERE STAKEHOLDER IS NOT NULL
+              AND TRIM(STAKEHOLDER) <> ''
+              AND REF_DATE >= :date_start
+              AND REF_DATE < :date_end
+            GROUP BY TRIM(STAKEHOLDER)
+            ORDER BY total_gross_value DESC
+            {limit}
+            """
+        ).format(union=union_sql, limit=limit_clause).strip()
+
+    # ------------------------------------------------------------------
+    def _execute(self, sql_text: str, start: datetime, end: datetime) -> List[Dict[str, Any]]:
+        engine = self.registry.engine(None)
+        with engine.connect() as conn:
+            result = conn.execute(
+                text(sql_text),
+                {"date_start": start, "date_end": end},
+            ).mappings().all()
+        return [dict(row) for row in result]
+
+    # ------------------------------------------------------------------
+    def _record_run(self, question: str, sql_text: str, rows: List[Dict[str, Any]]) -> Optional[int]:
+        sample_json = json.dumps(rows[:5], default=str)
+        attempts = [
+            (
+                """
+                INSERT INTO mem_runs(namespace, run_type, input_query, sql_text, row_count, result_sample)
+                VALUES (:ns, :rtype, :query, :sql, :count, CAST(:sample AS jsonb))
+                RETURNING id
+                """.strip(),
+                {
+                    "ns": self.namespace,
+                    "rtype": "dw_rule",
+                    "query": question,
+                    "sql": sql_text,
+                    "count": len(rows),
+                    "sample": sample_json,
+                },
+            ),
+            (
+                """
+                INSERT INTO mem_runs(namespace, input_query, sql_text, row_count)
+                VALUES (:ns, :query, :sql, :count)
+                RETURNING id
+                """.strip(),
+                {
+                    "ns": self.namespace,
+                    "query": question,
+                    "sql": sql_text,
+                    "count": len(rows),
+                },
+            ),
+            (
+                """
+                INSERT INTO mem_runs(namespace, input_query, sql_text)
+                VALUES (:ns, :query, :sql)
+                RETURNING id
+                """.strip(),
+                {
+                    "ns": self.namespace,
+                    "query": question,
+                    "sql": sql_text,
+                },
+            ),
+        ]
+
+        for stmt_text, params in attempts:
+            try:
+                with self.mem.begin() as conn:
+                    row = conn.execute(text(stmt_text), params).fetchone()
+                if row and row[0] is not None:
+                    return int(row[0])
+            except Exception:
+                continue
+        return None
+
+    # ------------------------------------------------------------------
+    def _store_snippet(self, sql_text: str, tags: Sequence[str]) -> None:
+        table_label = self.settings.get_string("DW_CONTRACT_TABLE", default="Contract") or "Contract"
+        payload = {
+            "ns": self.namespace,
+            "title": "Top stakeholders by gross contract value (last month)",
+            "desc": "Rule-based DocuWare aggregation without LLM.",
+            "tmpl": sql_text,
+            "raw": sql_text,
+            "input_tables": json.dumps([{"table": table_label}], default=str),
+            "output_columns": json.dumps(
+                ["stakeholder", "total_gross_value", "contract_count", "departments"],
+                default=str,
+            ),
+            "tags": json.dumps(sorted(set(tags)), default=str),
+            "source": "dw",
+        }
+        stmt = text(
+            """
+            INSERT INTO mem_snippets(namespace, title, description, sql_template, sql_raw,
+                                     input_tables, output_columns, tags, is_verified, source)
+            VALUES (:ns, :title, :desc, :tmpl, :raw,
+                    CAST(:input_tables AS jsonb),
+                    CAST(:output_columns AS jsonb),
+                    CAST(:tags AS jsonb),
+                    true,
+                    :source)
+            ON CONFLICT DO NOTHING
+            """
+        )
+        try:
+            with self.mem.begin() as conn:
+                conn.execute(stmt, payload)
+        except Exception:
+            pass

--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -1,114 +1,61 @@
 from __future__ import annotations
 
 import json
+from typing import Any, Dict, List
 
-from flask import Blueprint, request
+from flask import Blueprint, jsonify, request
 from sqlalchemy import inspect, text
 
 from core.datasources import DatasourceRegistry
 from core.settings import Settings
-from core.sql_exec import get_mem_engine
 
+from .answerer import AnswerError, StakeholderAnswerer
 
-dw_bp = Blueprint("dw", __name__)
 
 NAMESPACE = "dw::common"
-TABLE = '"Contract"'
+dw_bp = Blueprint("dw", __name__, url_prefix="/dw")
 
 
-# ---------------------------------------------------------------------------
-def _dw_engine(settings: Settings):
-    return DatasourceRegistry(settings, namespace=NAMESPACE).engine(None)
+def _seed_semantic_layer(mem_engine) -> Dict[str, List[str]]:
+    """Seed baseline metrics and mappings required for DW answering."""
 
+    required_tables = ["Contract"]
+    required_columns = [
+        "CONTRACT_VALUE_NET_OF_VAT",
+        "VAT",
+        "START_DATE",
+        "END_DATE",
+        "REQUEST_DATE",
+        "CONTRACT_STAKEHOLDER_1",
+        "DEPARTMENT_1",
+        "CONTRACT_STAKEHOLDER_2",
+        "DEPARTMENT_2",
+        "CONTRACT_STAKEHOLDER_3",
+        "DEPARTMENT_3",
+        "CONTRACT_STAKEHOLDER_4",
+        "DEPARTMENT_4",
+        "CONTRACT_STAKEHOLDER_5",
+        "DEPARTMENT_5",
+        "CONTRACT_STAKEHOLDER_6",
+        "DEPARTMENT_6",
+        "CONTRACT_STAKEHOLDER_7",
+        "DEPARTMENT_7",
+        "CONTRACT_STAKEHOLDER_8",
+        "DEPARTMENT_8",
+    ]
 
-def _last_month_bounds_sql():
-    return (
-        "TRUNC(ADD_MONTHS(SYSDATE, -1), 'MM')",
-        "TRUNC(SYSDATE, 'MM')",
-    )
+    seeded = {"metrics": [], "mappings": []}
 
-
-def _stakeholder_union_sql():
-    unions = []
-    for i in range(1, 9):
-        unions.append(
-            f"""
-            SELECT
-              CONTRACT_ID,
-              COALESCE(REQUEST_DATE, START_DATE, END_DATE) AS REF_DATE,
-              NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS VALUE_GROSS,
-              CONTRACT_OWNER,
-              OWNER_DEPARTMENT,
-              '{i}' AS SLOT,
-              CONTRACT_STAKEHOLDER_{i} AS STAKEHOLDER,
-              DEPARTMENT_{i} AS DEPARTMENT
-            FROM {TABLE}
-            """
-        )
-    return " \nUNION ALL\n".join(unions)
-
-
-def _top10_stakeholders_sql():
-    start_sql, end_sql = _last_month_bounds_sql()
-    union_sql = _stakeholder_union_sql()
-    return f"""
-        WITH stakeholders AS (
-            {union_sql}
-        )
-        SELECT
-          TRIM(STAKEHOLDER) AS stakeholder,
-          SUM(VALUE_GROSS) AS total_value_gross,
-          COUNT(DISTINCT CONTRACT_ID) AS contract_count,
-          LISTAGG(DISTINCT TRIM(DEPARTMENT), ', ') WITHIN GROUP (ORDER BY TRIM(DEPARTMENT)) AS departments
-        FROM stakeholders
-        WHERE STAKEHOLDER IS NOT NULL AND TRIM(STAKEHOLDER) <> ''
-          AND REF_DATE >= {start_sql}
-          AND REF_DATE <  {end_sql}
-        GROUP BY TRIM(STAKEHOLDER)
-        ORDER BY total_value_gross DESC
-        FETCH FIRST 10 ROWS ONLY
-    """
-
-
-def _store_snippet(mem, sql_text: str, tags: list[str]) -> None:
-    with mem.begin() as conn:
-        conn.execute(
-            text(
-                """
-                INSERT INTO mem_snippets(namespace, title, description, sql_template, sql_raw,
-                                         input_tables, output_columns, tags, is_verified, source)
-                VALUES (:ns, :title, :desc, :tmpl, :raw, :in_tbls, :out_cols, :tags, true, 'dw')
-                """
-            ),
-            {
-                "ns": NAMESPACE,
-                "title": "Top 10 stakeholders by gross value (last month)",
-                "desc": "Union 8 stakeholder slots; sum gross value; last month.",
-                "tmpl": sql_text,
-                "raw": sql_text,
-                "in_tbls": json.dumps([{"table": "Contract"}]),
-                "out_cols": json.dumps([
-                    "stakeholder",
-                    "total_value_gross",
-                    "contract_count",
-                    "departments",
-                ]),
-                "tags": json.dumps(tags),
-            },
-        )
-
-
-def _seed_mappings_and_metrics(mem) -> None:
-    required_tables = [{"table": "Contract"}]
-    required_columns = ["CONTRACT_VALUE_NET_OF_VAT", "VAT"]
-    with mem.begin() as conn:
+    with mem_engine.begin() as conn:
         conn.execute(
             text(
                 """
                 INSERT INTO mem_metrics(namespace, metric_key, metric_name, description,
                                         calculation_sql, required_tables, required_columns,
                                         category, owner, is_active)
-                VALUES (:ns, :key, :name, :desc, :calc, :rt, :rc, 'contracts', 'dw', true)
+                VALUES (:ns, :key, :name, :desc, :calc,
+                        CAST(:rt AS jsonb), CAST(:rc AS jsonb),
+                        'contracts', 'dw', true)
                 ON CONFLICT (namespace, metric_key, version) DO UPDATE
                   SET calculation_sql = EXCLUDED.calculation_sql,
                       description      = EXCLUDED.description,
@@ -125,13 +72,14 @@ def _seed_mappings_and_metrics(mem) -> None:
                 "rc": json.dumps(required_columns),
             },
         )
+        seeded["metrics"].append("contract_value_gross")
 
-        for i in range(1, 9):
+        for slot in range(1, 9):
             conn.execute(
                 text(
                     """
                     INSERT INTO mem_mappings(namespace, alias, canonical, mapping_type, scope, source, confidence)
-                    VALUES (:ns, :alias, :canon, 'column', 'global', 'dw_seed', 0.95)
+                    VALUES (:ns, :alias, :canonical, 'column', 'global', 'dw_seed', 0.98)
                     ON CONFLICT (namespace, alias, mapping_type, scope) DO UPDATE
                       SET canonical = EXCLUDED.canonical,
                           confidence = EXCLUDED.confidence,
@@ -140,8 +88,25 @@ def _seed_mappings_and_metrics(mem) -> None:
                 ),
                 {
                     "ns": NAMESPACE,
-                    "alias": f"CONTRACT_STAKEHOLDER_{i}",
-                    "canon": "stakeholder",
+                    "alias": f"CONTRACT_STAKEHOLDER_{slot}",
+                    "canonical": "stakeholder",
+                },
+            )
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO mem_mappings(namespace, alias, canonical, mapping_type, scope, source, confidence)
+                    VALUES (:ns, :alias, :canonical, 'column', 'global', 'dw_seed', 0.95)
+                    ON CONFLICT (namespace, alias, mapping_type, scope) DO UPDATE
+                      SET canonical = EXCLUDED.canonical,
+                          confidence = EXCLUDED.confidence,
+                          updated_at = NOW()
+                    """
+                ),
+                {
+                    "ns": NAMESPACE,
+                    "alias": f"DEPARTMENT_{slot}",
+                    "canonical": "department",
                 },
             )
 
@@ -150,7 +115,7 @@ def _seed_mappings_and_metrics(mem) -> None:
                 text(
                     """
                     INSERT INTO mem_mappings(namespace, alias, canonical, mapping_type, scope, source, confidence)
-                    VALUES (:ns, :alias, 'stakeholder', 'term', 'global', 'dw_seed', 0.98)
+                    VALUES (:ns, :alias, 'stakeholder', 'term', 'global', 'dw_seed', 0.99)
                     ON CONFLICT (namespace, alias, mapping_type, scope) DO UPDATE
                       SET canonical = EXCLUDED.canonical,
                           confidence = EXCLUDED.confidence,
@@ -160,23 +125,78 @@ def _seed_mappings_and_metrics(mem) -> None:
                 {"ns": NAMESPACE, "alias": alias},
             )
 
+        for alias in ("department", "departments"):
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO mem_mappings(namespace, alias, canonical, mapping_type, scope, source, confidence)
+                    VALUES (:ns, :alias, 'department', 'term', 'global', 'dw_seed', 0.95)
+                    ON CONFLICT (namespace, alias, mapping_type, scope) DO UPDATE
+                      SET canonical = EXCLUDED.canonical,
+                          confidence = EXCLUDED.confidence,
+                          updated_at = NOW()
+                    """
+                ),
+                {"ns": NAMESPACE, "alias": alias},
+            )
 
-# ---------------------------------------------------------------------------
-@dw_bp.route("/dw/ingest", methods=["POST"])
+        seeded["mappings"].extend(
+            [
+                "stakeholder_columns",
+                "department_columns",
+                "stakeholder_terms",
+                "department_terms",
+            ]
+        )
+
+    return seeded
+
+
+def _upsert_namespace_setting(conn, key: str, value: Any, *, value_type: str = "string", updated_by: str = "dw") -> None:
+    stmt = text(
+        """
+        INSERT INTO mem_settings(namespace, key, value, value_type, scope, scope_id,
+                                 overridable, updated_by, created_at, updated_at, is_secret)
+        VALUES (:ns, :key, CAST(:val AS jsonb), :vtype, 'namespace', NULL,
+                true, :upd, NOW(), NOW(), false)
+        ON CONFLICT ON CONSTRAINT ux_settings_ns_key_scope_null
+        DO UPDATE SET
+          value      = EXCLUDED.value,
+          value_type = EXCLUDED.value_type,
+          updated_by = EXCLUDED.updated_by,
+          updated_at = NOW(),
+          is_secret  = EXCLUDED.is_secret
+        """
+    )
+    conn.execute(
+        stmt,
+        {
+            "ns": NAMESPACE,
+            "key": key,
+            "val": json.dumps(value),
+            "vtype": value_type,
+            "upd": updated_by,
+        },
+    )
+
+
+@dw_bp.route("/ingest", methods=["POST"])
 def ingest():
-    settings = Settings(NAMESPACE)
-    mem = get_mem_engine(settings)
-    eng = _dw_engine(settings)
+    settings = Settings(namespace=NAMESPACE)
+    mem = settings.mem_engine()
+    registry = DatasourceRegistry(settings, namespace=NAMESPACE)
+    engine = registry.engine(None)
 
-    inspector = inspect(eng)
-    table_names = {t.upper(): t for t in inspector.get_table_names()}
-    if "CONTRACT" not in table_names:
-        return {"ok": False, "error": "Contract table not found in Oracle."}, 400
+    inspector = inspect(engine)
+    table_lookup = {name.upper(): name for name in inspector.get_table_names()}
+    if "CONTRACT" not in table_lookup:
+        return jsonify({"ok": False, "error": "Contract table not found in datasource."}), 400
 
-    actual_name = table_names["CONTRACT"]
+    actual_name = table_lookup["CONTRACT"]
+    columns = inspector.get_columns(actual_name)
 
     with mem.begin() as conn:
-        snap_id = conn.execute(
+        snapshot_id = conn.execute(
             text(
                 """
                 INSERT INTO mem_snapshots(namespace, schema_hash)
@@ -185,10 +205,10 @@ def ingest():
                 RETURNING id
                 """
             ),
-            {"ns": NAMESPACE, "hash": "dw-oracle-v1"},
+            {"ns": NAMESPACE, "hash": "dw-oracle-contract-v1"},
         ).scalar_one()
 
-        tbl_id = conn.execute(
+        table_id = conn.execute(
             text(
                 """
                 INSERT INTO mem_tables(namespace, snapshot_id, table_name, schema_name, table_comment)
@@ -200,52 +220,64 @@ def ingest():
             ),
             {
                 "ns": NAMESPACE,
-                "sid": snap_id,
+                "sid": snapshot_id,
                 "tname": actual_name,
                 "sname": None,
-                "comment": "DocuWare contracts",
+                "comment": "DocuWare Contract base table",
             },
         ).scalar_one()
 
-        columns = inspector.get_columns(actual_name)
-        for col in columns:
+        for column in columns:
             conn.execute(
                 text(
                     """
                     INSERT INTO mem_columns(namespace, table_id, column_name, data_type, is_nullable)
-                    VALUES (:ns, :tid, :cname, :dtype, :nullable)
+                    VALUES (:ns, :tid, :cname, :ctype, :nullable)
                     ON CONFLICT (namespace, table_id, column_name)
                     DO UPDATE SET data_type = EXCLUDED.data_type, updated_at = NOW()
                     """
                 ),
                 {
                     "ns": NAMESPACE,
-                    "tid": tbl_id,
-                    "cname": col["name"],
-                    "dtype": str(col.get("type")),
-                    "nullable": bool(col.get("nullable", True)),
+                    "tid": table_id,
+                    "cname": column.get("name"),
+                    "ctype": str(column.get("type")),
+                    "nullable": bool(column.get("nullable", True)),
                 },
             )
 
-    return {"ok": True, "namespace": NAMESPACE, "ingested": actual_name}
+        _upsert_namespace_setting(
+            conn,
+            key="DW_CONTRACT_TABLE",
+            value=actual_name,
+            updated_by="dw_ingest",
+        )
+
+    seeded = _seed_semantic_layer(mem)
+
+    return jsonify(
+        {
+            "ok": True,
+            "namespace": NAMESPACE,
+            "table": actual_name,
+            "columns": len(columns),
+            "seeded": seeded,
+        }
+    )
 
 
-@dw_bp.route("/dw/seed", methods=["POST"])
+@dw_bp.route("/seed", methods=["POST"])
 def seed():
-    settings = Settings(NAMESPACE)
-    mem = get_mem_engine(settings)
-    _seed_mappings_and_metrics(mem)
-    return {
-        "ok": True,
-        "namespace": NAMESPACE,
-        "seeded": ["metrics:contract_value_gross", "mappings:stakeholder"],
-    }
+    settings = Settings(namespace=NAMESPACE)
+    mem = settings.mem_engine()
+    seeded = _seed_semantic_layer(mem)
+    return jsonify({"ok": True, "namespace": NAMESPACE, "seeded": seeded})
 
 
-@dw_bp.route("/dw/metrics", methods=["GET"])
+@dw_bp.route("/metrics", methods=["GET"])
 def metrics():
-    settings = Settings(NAMESPACE)
-    mem = get_mem_engine(settings)
+    settings = Settings(namespace=NAMESPACE)
+    mem = settings.mem_engine()
     with mem.connect() as conn:
         rows = conn.execute(
             text(
@@ -253,42 +285,44 @@ def metrics():
                 SELECT metric_key, metric_name, description, calculation_sql, category, is_active
                   FROM mem_metrics
                  WHERE namespace = :ns
+                   AND is_active = true
               ORDER BY metric_key
                 """
             ),
             {"ns": NAMESPACE},
         ).mappings().all()
-    return {"ok": True, "metrics": [dict(r) for r in rows]}
+    return jsonify({"ok": True, "metrics": [dict(row) for row in rows]})
 
 
-@dw_bp.route("/dw/answer", methods=["POST"])
+@dw_bp.route("/answer", methods=["POST"])
 def answer():
     payload = request.get_json(force=True) or {}
-    question = (payload.get("question") or "").lower().strip()
+    question = str(payload.get("question") or "").strip()
+    if not question:
+        return jsonify({"ok": False, "error": "Question text is required."}), 400
 
-    is_top10 = (
-        "stakeholder" in question
-        and "top 10" in question
-        and ("last month" in question or "previous month" in question)
-        and ("value" in question or "gross" in question or "contract value" in question)
-    )
+    settings = Settings(namespace=NAMESPACE)
+    mem = settings.mem_engine()
+    registry = DatasourceRegistry(settings, namespace=NAMESPACE)
+    answerer = StakeholderAnswerer(settings, mem, registry)
 
-    if not is_top10:
-        return {
-            "ok": False,
-            "error": "Only the 'top 10 stakeholders by contract value last month' pattern is implemented right now.",
-        }, 400
+    try:
+        result = answerer.answer(question)
+    except AnswerError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
 
-    settings = Settings(NAMESPACE)
-    mem = get_mem_engine(settings)
-    eng = _dw_engine(settings)
+    response: Dict[str, Any] = {
+        "ok": True,
+        "sql": result.sql,
+        "rows": result.rows,
+        "meta": {
+            "top_n": result.top_n,
+            "date_start": result.date_start.isoformat(),
+            "date_end": result.date_end.isoformat(),
+            "tags": result.tags,
+        },
+    }
+    if result.run_id is not None:
+        response["run_id"] = result.run_id
 
-    sql_text = _top10_stakeholders_sql()
-
-    with eng.connect() as conn:
-        rows = conn.execute(text(sql_text)).mappings().all()
-
-    _seed_mappings_and_metrics(mem)
-    _store_snippet(mem, sql_text, tags=["dw", "contracts", "stakeholders", "top10", "last_month"])
-
-    return {"ok": True, "sql": sql_text, "rows": [dict(r) for r in rows]}
+    return jsonify(response)

--- a/core/admin_api.py
+++ b/core/admin_api.py
@@ -14,30 +14,25 @@ admin_bp = Blueprint("admin", __name__)
 def _ensure_mem_settings_unique_constraint(conn) -> None:
     conn.execute(
         text(
+            "DROP INDEX IF EXISTS ux_mem_settings_ns_key_scope_coalesced"
+        )
+    )
+    conn.execute(
+        text(
             """
-        DO $$
-        BEGIN
-            IF NOT EXISTS (
-                SELECT 1 FROM pg_indexes
-                 WHERE tablename = 'mem_settings'
-                   AND indexname = 'ux_settings_ns_key_scope_null'
-            ) THEN
-                CREATE UNIQUE INDEX ux_settings_ns_key_scope_null
-                  ON mem_settings (namespace, key, scope)
-                 WHERE scope_id IS NULL;
-            END IF;
-
-            IF NOT EXISTS (
-                SELECT 1 FROM pg_indexes
-                 WHERE tablename = 'mem_settings'
-                   AND indexname = 'ux_settings_ns_key_scope_id'
-            ) THEN
-                CREATE UNIQUE INDEX ux_settings_ns_key_scope_id
-                  ON mem_settings (namespace, key, scope, scope_id)
-                 WHERE scope_id IS NOT NULL;
-            END IF;
-        END$$;
-        """
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_settings_ns_key_scope_null
+              ON mem_settings (namespace, key, scope)
+             WHERE scope_id IS NULL
+            """
+        )
+    )
+    conn.execute(
+        text(
+            """
+            CREATE UNIQUE INDEX IF NOT EXISTS ux_settings_ns_key_scope_id
+              ON mem_settings (namespace, key, scope, scope_id)
+             WHERE scope_id IS NOT NULL
+            """
         )
     )
 


### PR DESCRIPTION
## Summary
- decouple the memory engine helper from Settings and update admin upsert safeguards
- tighten datasource registry fallback logic
- rebuild the DocuWare blueprint with semantic seeding, ingestion, and a rule-based answerer for stakeholder metrics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca71809fe8832396977f3c6ec03791