### PR TITLE
Fix DW admin routes and ingestion support

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,35 @@
 from flask import Flask
 
 from apps.dw.app import dw_bp
+from core.admin_api import admin_bp
 
 
 def create_app():
     app = Flask(__name__)
-    app.register_blueprint(dw_bp)
+
+    app.register_blueprint(dw_bp, url_prefix="/dw")
+    app.register_blueprint(admin_bp, url_prefix="/admin")
+
+    @app.get("/health")
+    def health():
+        return {"ok": True}
+
+    @app.get("/model/info")
+    def model_info():
+        return {"backend": "simplified", "llm": "disabled", "apps": ["dw"]}
+
+    @app.get("/__routes")
+    def list_routes():
+        rows = []
+        for rule in app.url_map.iter_rules():
+            rows.append(
+                {
+                    "rule": str(rule),
+                    "methods": sorted(list(rule.methods - {"HEAD", "OPTIONS"})),
+                }
+            )
+        return {"routes": rows}
+
     return app
 
 


### PR DESCRIPTION
## Summary
- register the DW and admin blueprints with health/model info helper endpoints
- ensure DW ingest seeds run with an `updated_at` column on mem_snapshots and consistent payload binds
- refresh DW metrics querying to use SQLAlchemy 2.0 connection patterns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab15744ac8323abc277197c5e2ac7