### PR TITLE
Restore DocuWare pipeline with SQLCoder

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,11 +1,21 @@
 from flask import Flask
 
-from apps.dw.app import dw_bp
+from apps.dw.app import create_dw_blueprint
 from core.admin_api import admin_bp
+from core.pipeline import Pipeline
+from core.settings import Settings
 
 
 def create_app():
     app = Flask(__name__)
+
+    settings = Settings()
+    pipeline = Pipeline(settings=settings, namespace="dw::common")
+
+    app.config["SETTINGS"] = settings
+    app.config["pipeline"] = pipeline
+
+    dw_bp = create_dw_blueprint(settings=settings, pipeline=pipeline)
 
     app.register_blueprint(dw_bp, url_prefix="/dw")
     app.register_blueprint(admin_bp, url_prefix="/admin")
@@ -16,10 +26,11 @@ def create_app():
 
     @app.get("/model/info")
     def model_info():
+        llm_meta = pipeline.llm.meta if getattr(pipeline, "llm", None) else {}
         return {
-            "llm": "disabled",
+            "llm": llm_meta.get("model_name") or llm_meta.get("path") or "unknown",
             "clarifier": "disabled",
-            "mode": "dw-simplified",
+            "mode": "dw-pipeline",
         }
 
     @app.get("/__routes")


### PR DESCRIPTION
## Summary
- instantiate the DocuWare SQL pipeline at startup so SQLCoder loads and share the handle with the blueprint
- update the DocuWare blueprint to create itself on demand, call the pipeline for /dw/answer, and fall back to the deterministic responder when needed
- rebuild the pipeline with schema/context discovery, SQL planning and execution, empty-result auto retry, and run/snippet logging

## Testing
- python -m compileall apps/dw/app.py core/pipeline.py main.py

------
https://chatgpt.com/codex/tasks/task_e_68cac654e03483238521b557f9467af3