### PR TITLE
Restore DocuWare pipeline LLM flow and fallbacks

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -53,6 +53,7 @@ def _fallback_rule_answer(question: str) -> Dict[str, Any] | None:
 
     response: Dict[str, Any] = {
         "ok": True,
+        "status": "ok",
         "sql": result.sql,
         "rows": result.rows,
         "meta": {
@@ -443,22 +444,20 @@ def answer():
     if not question:
         return jsonify({"ok": False, "error": "Question text is required."}), 400
 
-    prefixes = payload.get("prefixes") or []
+    prefixes = list(payload.get("prefixes") or [])
     auth_email = payload.get("auth_email")
+    datasource = payload.get("datasource") or "docuware"
 
     pipeline = _PIPELINE_HANDLE or current_app.config.get("pipeline")
     if pipeline is None:
         return jsonify({"ok": False, "error": "Pipeline not initialized"}), 500
 
     try:
-        result = pipeline.answer(
-            question=question,
+        result = pipeline.answer_dw(
+            question,
             prefixes=prefixes,
             auth_email=auth_email,
-            namespace=NAMESPACE,
-            datasource="docuware",
-            dialect="oracle",
-            app_tag="dw",
+            datasource=datasource,
         )
     except Exception as exc:
         fallback = _fallback_rule_answer(question)

--- a/main.py
+++ b/main.py
@@ -26,12 +26,7 @@ def create_app():
 
     @app.get("/model/info")
     def model_info():
-        llm_meta = pipeline.llm.meta if getattr(pipeline, "llm", None) else {}
-        return {
-            "llm": llm_meta.get("model_name") or llm_meta.get("path") or "unknown",
-            "clarifier": "disabled",
-            "mode": "dw-pipeline",
-        }
+        return pipeline.model_info()
 
     @app.get("/__routes")
     def list_routes():


### PR DESCRIPTION
## Summary
- add a helper to load the base SQLCoder model and expose model metadata through the pipeline
- restore the DocuWare pipeline flow with inquiry tracking, deterministic fallbacks, and model info reporting
- update the DW blueprint and /model/info endpoint to use the reinstated pipeline logic

## Testing
- python -m compileall core apps main.py

------
https://chatgpt.com/codex/tasks/task_e_68cacfe15c9883239d64685e57b1abf8