### PR TITLE
Integrate SQLCoder Oracle pipeline for DocuWare

### DIFF
--- a/apps/common/admin.py
+++ b/apps/common/admin.py
@@ -1,0 +1,71 @@
+"""Common admin endpoints for teaching synonyms and snippets."""
+
+from __future__ import annotations
+
+import json
+
+from flask import Blueprint, jsonify, request
+from sqlalchemy import create_engine, text
+
+from core.settings import Settings
+
+admin_bp = Blueprint("admin_common", __name__, url_prefix="/admin")
+
+
+@admin_bp.post("/teach")
+def teach():
+    data = request.get_json(force=True) or {}
+    namespace = data.get("namespace", "dw::common")
+    updated_by = data.get("updated_by", "teacher")
+    synonyms = data.get("synonyms") or []
+    qna = data.get("qna") or []
+
+    settings = Settings()
+    mem = create_engine(settings.get("MEMORY_DB_URL", scope="global"), pool_pre_ping=True, future=True)
+
+    ins_map = text(
+        """
+      INSERT INTO mem_mappings(namespace, alias, canonical, mapping_type, scope, source, confidence, created_at, updated_at)
+      VALUES (:ns, :alias, :canon, :mtype, :scope, 'user', :conf, NOW(), NOW())
+      ON CONFLICT (namespace, alias, mapping_type, scope)
+      DO UPDATE SET canonical = EXCLUDED.canonical, confidence = EXCLUDED.confidence, updated_at = NOW()
+    """
+    )
+
+    ins_snip = text(
+        """
+      INSERT INTO mem_snippets(namespace, title, description, sql_template, sql_raw, input_tables, tags, created_at, updated_at, is_verified, verified_by)
+      VALUES (:ns, :title, :desc, :tmpl, :raw, CAST(:tables AS jsonb), CAST(:tags AS jsonb), NOW(), NOW(), true, :by)
+      RETURNING id
+    """
+    )
+
+    with mem.begin() as con:
+        for mapping in synonyms:
+            con.execute(
+                ins_map,
+                {
+                    "ns": namespace,
+                    "alias": mapping["alias"],
+                    "canon": mapping["canonical"],
+                    "mtype": mapping.get("mapping_type", "term"),
+                    "scope": mapping.get("scope", "global"),
+                    "conf": float(mapping.get("confidence", 0.9)),
+                },
+            )
+        for item in qna:
+            con.execute(
+                ins_snip,
+                {
+                    "ns": namespace,
+                    "title": item.get("question", "taught-sql"),
+                    "desc": item.get("description", ""),
+                    "tmpl": item.get("sql"),
+                    "raw": item.get("sql"),
+                    "tables": json.dumps(["Contract"]),
+                    "tags": json.dumps(item.get("tags", ["dw", "teach"])),
+                    "by": updated_by,
+                },
+            )
+
+    return jsonify({"ok": True, "synonyms": len(synonyms), "snippets": len(qna)})

--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -1,208 +1,71 @@
+"""Lightweight DocuWare LLM wrapper for Oracle-focused SQL generation."""
+
 from __future__ import annotations
 
 import os
 import re
-import textwrap
-from typing import Any, Dict, Optional, Tuple
+from typing import Optional
 
+from core.settings import Settings
+from core.model_loader import load_llm as _load_llm
 
-def _load_sql_generator(settings: Optional[Any] = None):
-    """Load the SQL generation model regardless of loader name variations."""
-    try:
-        import core.model_loader as model_loader
-    except Exception as exc:  # pragma: no cover - critical import
-        raise ImportError(f"Cannot import core.model_loader: {exc}") from exc
+from .prompts import FEWSHOTS, SYSTEM_INSTRUCTIONS
 
-    candidates = [
-        "load_llm",
-        "load_primary",
-        "load_base_generator",
-        "load_base",
-        "load_sql_model",
-    ]
-
-    for name in candidates:
-        if hasattr(model_loader, name):
-            loader = getattr(model_loader, name)
-            try:
-                return loader(settings=settings)
-            except TypeError:
-                return loader()
-
-    raise ImportError(
-        "No compatible loader function found in core.model_loader. "
-        "Expected one of: " + ", ".join(candidates)
-    )
-
-
-def _gen_text(
-    generator: Any,
-    prompt: str,
-    *,
-    stop: Optional[list[str]] = None,
-    max_new_tokens: Optional[int] = None,
-    temperature: Optional[float] = None,
-    top_p: Optional[float] = None,
-) -> str:
-    params: Dict[str, Any] = {}
-    if stop is not None:
-        params["stop"] = stop
-    if max_new_tokens is not None:
-        params["max_new_tokens"] = max_new_tokens
-    if temperature is not None:
-        params["temperature"] = temperature
-    if top_p is not None:
-        params["top_p"] = top_p
-
-    if hasattr(generator, "generate") and callable(generator.generate):
-        return generator.generate(prompt, **params)
-    if callable(generator):
-        return generator(prompt, **params)
-    raise RuntimeError("LLM generator object is not callable and has no .generate().")
-
-
-_ORACLE_RULES = """
-Rules:
-- SQL dialect: Oracle (LISTAGG, NVL, TRUNC, FETCH FIRST ... ROWS ONLY).
-- Output ONLY a single CTE/SELECT statement. No DML/DDL. No comments. No semicolon.
-- Prefer REQUEST_DATE as the default date if user says “last month/last 90 days”.
-- If user asks “next N days” for END_DATE, filter on END_DATE with CURRENT_DATE + N.
-- When aggregating stakeholder/department, normalize the 8 slots (1..8) with UNION ALL.
-- Gross value = NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0).
-- Only reference existing columns; if a field is ambiguous, pick the closest match.
-"""
-
-_CONTRACT_COLUMNS = """
-Table "Contract" (DocuWare):
-- CONTRACT_ID (text): contract identifier (human-friendly).
-- CONTRACT_OWNER (text): owner of the contract.
-- CONTRACT_STAKEHOLDER_1..8 (text): stakeholder names per slot.
-- DEPARTMENT_1..8 (text): department mapped 1:1 with each stakeholder slot.
-- OWNER_DEPARTMENT (text): owner’s department.
-- CONTRACT_VALUE_NET_OF_VAT (number): net value.
-- VAT (number): VAT amount.
-- CONTRACT_PURPOSE, CONTRACT_SUBJECT (text): descriptors.
-- START_DATE, END_DATE, REQUEST_DATE (date): key dates.
-- DURATION (text), ENTITY, BUILDING_AND_FLOOR_DESCRIPTION, LEGAL_NAME_OF_THE_COMPANY,
-  REPRESENTATIVE_NAME/PHONE/EMAIL (text): contextual fields.
-- CONTRACT_STATUS (text), REQUEST_TYPE (text), REQUESTER (text).
-- DEPARTMENT_OUL (text): lead/manager of the departments.
-- EXPIERY_30/60/90 (date): expiry thresholds.
-- ENTITY_NO (text): entity reference.
-"""
-
-_FEWSHOTS = """
-Q: top 10 stakeholders by contract value last month
-SQL:
-WITH base AS (
-  SELECT
-    CONTRACT_ID,
-    NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS,
-    REQUEST_DATE
-  FROM "Contract"
-  WHERE REQUEST_DATE >= ADD_MONTHS(TRUNC(CURRENT_DATE, 'MM'), -1)
-    AND REQUEST_DATE <  TRUNC(CURRENT_DATE, 'MM')
-), stakeholders AS (
-  SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_1 AS STAKEHOLDER FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_2 FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_3 FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_4 FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_5 FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_6 FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_7 FROM "Contract"
-  UNION ALL SELECT CONTRACT_ID, CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_8 FROM "Contract"
-)
-SELECT
-  TRIM(STAKEHOLDER) AS stakeholder,
-  SUM(CONTRACT_VALUE_GROSS) AS total_gross_value,
-  COUNT(DISTINCT CONTRACT_ID) AS contract_count
-FROM stakeholders
-WHERE STAKEHOLDER IS NOT NULL AND TRIM(STAKEHOLDER) <> ''
-GROUP BY TRIM(STAKEHOLDER)
-ORDER BY total_gross_value DESC
-FETCH FIRST 10 ROWS ONLY
-
-Q: contracts expiring in the next 30 days
-SQL:
-SELECT
-  CONTRACT_ID,
-  END_DATE,
-  CONTRACT_OWNER,
-  OWNER_DEPARTMENT,
-  NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS
-FROM "Contract"
-WHERE END_DATE >= TRUNC(CURRENT_DATE)
-  AND END_DATE <  TRUNC(CURRENT_DATE) + 30
-ORDER BY END_DATE ASC
-"""
+_SQL_ONLY = re.compile(r"(?is)^\s*(?:--.*\n|\s*)*(with|select)\b")
 
 
 def _build_prompt(question: str) -> str:
-    header = "You are a senior Oracle SQL analyst. Convert the question to a single valid Oracle SELECT (or CTE + SELECT)."
-    prompt = "\n\n".join(
-        [
-            header,
-            _ORACLE_RULES.strip(),
-            _CONTRACT_COLUMNS.strip(),
-            _FEWSHOTS.strip(),
-            f"Q: {question}\nSQL:",
-        ]
-    )
-    return textwrap.dedent(prompt).strip()
+    """Construct a prompt with optional few-shot guidance."""
+    q_low = question.lower()
+    best: Optional[tuple[str, str]] = None
+    for q, sql in FEWSHOTS:
+        tokens = q.split()
+        if tokens and all(tok in q_low for tok in tokens[:3]):
+            best = (q, sql)
+            break
+
+    shots = ""
+    if best:
+        shots = f"\n-- Example for: {best[0]}\n{best[1]}\n"
+
+    return f"{SYSTEM_INSTRUCTIONS}\n{shots}\n-- User question:\n-- {question}\n"
 
 
-_FORBIDDEN = re.compile(
-    r"\b(UPDATE|DELETE|INSERT|MERGE|CREATE|ALTER|DROP|TRUNCATE|GRANT|REVOKE)\b",
-    re.IGNORECASE,
-)
+def _enforce_select_only(sql: str) -> str:
+    """Ensure generated SQL is a safe SELECT/CTE statement."""
+    s = sql.strip().strip(";")
+    if not _SQL_ONLY.match(s):
+        raise ValueError("Generated SQL is not a SELECT/CTE.")
+    banned = ["insert ", "update ", "delete ", "merge ", "alter ", "drop ", "create "]
+    low = s.lower()
+    if any(b in low for b in banned):
+        raise ValueError("Non-SELECT statement detected.")
+    return s
 
 
-def _clean_and_validate(sql_text: str) -> str:
-    sql = sql_text.strip()
-    if "```" in sql:
-        parts = sql.split("```")
-        if len(parts) >= 2:
-            sql = parts[1]
-    sql = sql.strip()
-    if sql.endswith(";"):
-        sql = sql[:-1].strip()
+class DWLLM:
+    """Simple adapter that turns natural language into Oracle SQL."""
 
-    first_token = sql.split(None, 1)[0].upper() if sql else ""
-    if first_token not in {"SELECT", "WITH"}:
-        raise ValueError(
-            f"Generated SQL must start with SELECT/WITH, got '{first_token or '(empty)'}'."
-        )
+    def __init__(self, settings: Settings):
+        self.settings = settings
+        self.llm = _load_llm(settings)
 
-    if _FORBIDDEN.search(sql):
-        raise ValueError("Generated SQL contains forbidden statements.")
-
-    return sql
-
-
-def nl_to_sql_with_llm(
-    question: str,
-    *,
-    max_new_tokens: Optional[int] = None,
-) -> Tuple[str, str]:
-    generator = _load_sql_generator()
-
-    stop_env = os.getenv("STOP")
-    stop_list = [item.strip() for item in stop_env.split(",") if item.strip()] if stop_env else None
-
-    default_max_new_tokens = int(os.getenv("GENERATION_MAX_NEW_TOKENS", "256"))
-    temperature = float(os.getenv("GENERATION_TEMPERATURE", "0.2"))
-    top_p = float(os.getenv("GENERATION_TOP_P", "0.9"))
-
-    prompt = _build_prompt(question)
-    raw_output = _gen_text(
-        generator,
-        prompt,
-        stop=stop_list,
-        max_new_tokens=max_new_tokens or default_max_new_tokens,
-        temperature=temperature,
-        top_p=top_p,
-    )
-
-    sql = _clean_and_validate(str(raw_output or ""))
-    rationale = "Generated via SQLCoder with Oracle rules and Contract schema context."
-    return sql, rationale
+    def nl_to_sql(self, question: str) -> str:
+        prompt = _build_prompt(question)
+        stop = os.getenv("STOP", "</s>,<|im_end|>").split(",")
+        gen_kwargs = {
+            "max_new_tokens": int(os.getenv("GENERATION_MAX_NEW_TOKENS", "256")),
+            "temperature": float(os.getenv("GENERATION_TEMPERATURE", "0.2")),
+            "top_p": float(os.getenv("GENERATION_TOP_P", "0.9")),
+            "stop": stop,
+        }
+        out = self.llm.generate(prompt, **gen_kwargs)
+        code = out
+        if "```" in out:
+            parts = out.split("```")
+            for i in range(1, len(parts), 2):
+                cand = parts[i]
+                if "select" in cand.lower() or "with" in cand.lower():
+                    code = cand
+                    break
+        return _enforce_select_only(code)

--- a/apps/dw/prompts.py
+++ b/apps/dw/prompts.py
@@ -1,0 +1,125 @@
+"""Prompt utilities for DocuWare SQL generation."""
+
+CONTRACT_SCHEMA_SUMMARY = """
+You are converting natural language to **Oracle SQL** for a single table "Contract".
+Table: "Contract"
+Important columns (only these matter for now):
+- CONTRACT_ID (NVARCHAR2)
+- CONTRACT_OWNER (NVARCHAR2)
+- CONTRACT_STAKEHOLDER_1..8 (NVARCHAR2)
+- DEPARTMENT_1..8 (NVARCHAR2)   -- DEPARTMENT_i corresponds to CONTRACT_STAKEHOLDER_i
+- OWNER_DEPARTMENT (NVARCHAR2)
+- CONTRACT_VALUE_NET_OF_VAT (NUMBER(27,2))
+- VAT (NUMBER(27,2))
+- START_DATE (DATE)
+- END_DATE (DATE)
+- REQUEST_DATE (DATE)
+- CONTRACT_STATUS (NVARCHAR2)
+- REQUEST_TYPE (NVARCHAR2)
+- DEPARTMENT_OUL (NVARCHAR2) -- lead / manager department
+- CONTRACTOR_ID (NVARCHAR2)
+- REQUESTER (NVARCHAR2)
+- ENTITY_NO (NVARCHAR2)
+
+Derived:
+- CONTRACT_VALUE_GROSS = NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)
+
+Date windows (don’t use sysdate literals directly in SQL; caller binds :date_start, :date_end):
+- last month: [:date_start, :date_end) == previous calendar month
+- last 90 days: [:date_start, :date_end) rolling
+- next 30 days: (today, today+30]
+
+General rules:
+- Output **SQL only** (no commentary). Valid Oracle SQL. SELECT/CTE only.
+- Use **LISTAGG(..., ', ') WITHIN GROUP (ORDER BY ...)** to combine departments when needed.
+- Use **FETCH FIRST :top_n ROWS ONLY** for top-N.
+- Use bind names the caller sets: :date_start, :date_end, :top_n (when needed).
+- Trim whitespace around NVARCHAR2 when grouping/displaying names.
+
+Stakeholders unpivot rule (no views available):
+Produce a CTE that UNION ALLs the 8 slots, e.g.
+WITH stakeholders AS (
+  SELECT CONTRACT_ID,
+         NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS,
+         CONTRACT_STAKEHOLDER_1 AS STAKEHOLDER,
+         DEPARTMENT_1          AS DEPARTMENT,
+         REQUEST_DATE          AS REF_DATE
+  FROM "Contract"
+  UNION ALL
+  ...
+  SELECT ..._8 ...
+)
+Then aggregate on TRIM(STAKEHOLDER) where needed.
+"""
+
+FEWSHOTS = [
+    (
+        "top 10 stakeholders by contract value last month",
+        """WITH stakeholders AS (
+  SELECT CONTRACT_ID,
+         NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS,
+         CONTRACT_STAKEHOLDER_1 AS STAKEHOLDER,
+         DEPARTMENT_1 AS DEPARTMENT,
+         REQUEST_DATE AS REF_DATE
+  FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_2, DEPARTMENT_2, REQUEST_DATE FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_3, DEPARTMENT_3, REQUEST_DATE FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_4, DEPARTMENT_4, REQUEST_DATE FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_5, DEPARTMENT_5, REQUEST_DATE FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_6, DEPARTMENT_6, REQUEST_DATE FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_7, DEPARTMENT_7, REQUEST_DATE FROM "Contract"
+  UNION ALL
+  SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0), CONTRACT_STAKEHOLDER_8, DEPARTMENT_8, REQUEST_DATE FROM "Contract"
+)
+SELECT
+  TRIM(STAKEHOLDER) AS stakeholder,
+  SUM(CONTRACT_VALUE_GROSS) AS total_gross_value,
+  COUNT(DISTINCT CONTRACT_ID) AS contract_count,
+  LISTAGG(DISTINCT TRIM(DEPARTMENT), ', ') WITHIN GROUP (ORDER BY TRIM(DEPARTMENT)) AS departments
+FROM stakeholders
+WHERE STAKEHOLDER IS NOT NULL
+  AND TRIM(STAKEHOLDER) <> ''
+  AND REF_DATE >= :date_start
+  AND REF_DATE <  :date_end
+GROUP BY TRIM(STAKEHOLDER)
+ORDER BY total_gross_value DESC
+FETCH FIRST :top_n ROWS ONLY"""
+    ),
+    (
+        "contracts expiring in the next 30 days",
+        """SELECT
+  CONTRACT_ID,
+  CONTRACT_OWNER,
+  OWNER_DEPARTMENT,
+  END_DATE,
+  CONTRACT_STATUS,
+  NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0) AS CONTRACT_VALUE_GROSS
+FROM "Contract"
+WHERE END_DATE >= :date_start
+  AND END_DATE <  :date_end
+ORDER BY END_DATE ASC"""
+    ),
+    (
+        "total gross contract value by owner department last 90 days",
+        """SELECT
+  TRIM(OWNER_DEPARTMENT) AS owner_department,
+  SUM(NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0)) AS total_gross_value,
+  COUNT(*) AS contract_count
+FROM "Contract"
+WHERE REQUEST_DATE >= :date_start
+  AND REQUEST_DATE <  :date_end
+GROUP BY TRIM(OWNER_DEPARTMENT)
+ORDER BY total_gross_value DESC"""
+    ),
+]
+
+SYSTEM_INSTRUCTIONS = (
+    CONTRACT_SCHEMA_SUMMARY
+    + "\nRespond with **SQL only**. No explanations. Use only the listed columns."
+)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,8 @@
 from flask import Flask
 
+from apps.common.admin import admin_bp as admin_common_bp
 from apps.dw.app import create_dw_blueprint
-from core.admin_api import admin_bp
+from core.admin_api import admin_bp as core_admin_bp
 from core.pipeline import Pipeline
 from core.settings import Settings
 
@@ -18,7 +19,8 @@ def create_app():
     dw_bp = create_dw_blueprint(settings=settings, pipeline=pipeline)
 
     app.register_blueprint(dw_bp, url_prefix="/dw")
-    app.register_blueprint(admin_bp, url_prefix="/admin")
+    app.register_blueprint(core_admin_bp, url_prefix="/admin")
+    app.register_blueprint(admin_common_bp)
 
     @app.get("/health")
     def health():


### PR DESCRIPTION
## Summary
- add Oracle-focused prompting utilities and a DWLLM wrapper for SQL generation
- expose a load_llm helper that reads model configuration from environment variables
- refactor the DocuWare answer route to use the new LLM, record runs/inquiries, export CSVs, and register an admin teaching endpoint

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc75a0bbac8323a48ae1612391cb04