### PR TITLE
Enable clarifier model and dual loader for DocuWare pipeline

### DIFF
--- a/apps/dw/clarifier.py
+++ b/apps/dw/clarifier.py
@@ -1,0 +1,69 @@
+"""DocuWare-specific clarifier helper for follow-up questions."""
+
+from __future__ import annotations
+
+from typing import List
+
+from core.model_loader import load_llm
+
+SYS = (
+    "You're a concise assistant that writes at most 2 short clarifying questions "
+    "to help convert a business request into SQL over a single table named Contract. "
+    "Prefer asking about date range, filters, and which people fields to use. "
+    "Return plain text bullet points, no extra prose."
+)
+
+EXAMPLE = (
+    "User: top stakeholders by contract value\n"
+    "Assistant:\n"
+    "- Do you mean gross value (net + VAT) and which date field (REQUEST_DATE vs END_DATE)?\n"
+    "- What time window (last month, this quarter, or a specific range)?"
+)
+
+
+def propose_clarifying_questions(user_question: str) -> List[str]:
+    clar = load_llm("clarifier")
+    if not clar:
+        return [
+            "Which date field should we use (REQUEST_DATE or END_DATE) and what time window?",
+            "Should value be NET, VAT, or NET+VAT (gross)?",
+        ]
+
+    handle = clar.get("handle")
+
+    prompt = f"{SYS}\n\n{EXAMPLE}\n\nUser: {user_question}\nAssistant:\n"
+    if handle is not None:
+        text = handle.generate(prompt, max_new_tokens=96, temperature=0.0, top_p=1.0)
+    else:
+        tokenizer = clar.get("tokenizer")
+        model = clar.get("model")
+        if tokenizer is None or model is None:
+            text = ""
+        else:
+            import torch
+
+            device = getattr(model, "device", None)
+            if device is None:
+                try:
+                    device = next(model.parameters()).device
+                except Exception:
+                    device = None
+            inputs = tokenizer(prompt, return_tensors="pt")
+            if device is not None:
+                inputs = {k: v.to(device) for k, v in inputs.items()}
+            with torch.inference_mode():
+                outputs = model.generate(
+                    **inputs,
+                    max_new_tokens=96,
+                    do_sample=False,
+                    temperature=0.0,
+                    pad_token_id=tokenizer.eos_token_id,
+                )
+            text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+    tail = text.split("Assistant:")[-1].strip()
+    lines = [ln.strip("-• ").strip() for ln in tail.splitlines() if ln.strip()]
+    return lines[:2] if lines else [
+        "Which date field should we use (REQUEST_DATE or END_DATE) and what time window?"
+    ]
+

--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -1,87 +1,54 @@
-"""Lightweight DocuWare LLM wrapper for Oracle-focused SQL generation."""
+"""DocuWare SQL generation helper using the shared SQLCoder model."""
 
 from __future__ import annotations
 
-import os
 import re
-from typing import Iterable, List, Sequence, Tuple
+from typing import Dict
 
-from core.model_loader import load_llm as _load_llm
-from core.settings import Settings
+from core.model_loader import load_llm
 
-from .sql_kit import build_nl2sql_prompt
 
-_SQL_ONLY = re.compile(r"(?is)^\s*(?:--.*\n|\s*)*(with|select)\b")
-_LIMIT_END = re.compile(r"(?is)\s+limit\s+([:a-zA-Z0-9_]+)\s*$")
 _CODE_BLOCK = re.compile(r"```(?:sql)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
 
 
-def _strip_stop_tokens(text: str, stop: Sequence[str]) -> str:
-    cleaned = text
-    for token in stop:
-        if not token:
-            continue
-        idx = cleaned.find(token)
-        if idx >= 0:
-            cleaned = cleaned[:idx]
-    return cleaned
+def nl_to_sql_with_llm(question: str, dw_table: str = "Contract") -> Dict[str, object]:
+    """Use SQLCoder to translate natural language into Oracle SQL."""
 
+    llm = load_llm("sql")
+    if not llm:
+        return {"sql": None, "confidence": 0.0, "why": "sql_model_unavailable"}
 
-def _extract_sql_block(output: str) -> str:
-    for match in _CODE_BLOCK.finditer(output):
+    generator = llm.get("handle")
+    if generator is None:
+        return {"sql": None, "confidence": 0.0, "why": "sql_generator_missing"}
+
+    sys_prompt = (
+        "You convert natural language to **Oracle SQL** over a single table named {tbl}.\n"
+        "Rules:\n"
+        "- Output only SQL (no comments), SELECT/CTEs only (no DML/DDL).\n"
+        "- Use NVL for null-safe arithmetic.\n"
+        "- Gross value = NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0).\n"
+        "- If time window like 'last month/90 days/next 30 days' is present, use named binds :date_start and :date_end.\n"
+        "- Use LISTAGG for aggregating text when asked.\n"
+    ).format(tbl=dw_table)
+
+    prompt = f"{sys_prompt}\nQuestion: {question}\nGenerate SQL now.\nSQL:"
+
+    try:
+        raw_text = generator.generate(prompt)
+    except Exception as exc:
+        return {"sql": None, "confidence": 0.0, "why": f"generator_error: {exc}"}
+
+    candidate = (raw_text or "").strip()
+    match = _CODE_BLOCK.search(candidate)
+    if match:
         candidate = match.group(1).strip()
-        if candidate:
-            return candidate
-    return output
+    candidate = candidate.rstrip(";")
+    if not candidate.lower().startswith(("with", "select")):
+        return {"sql": None, "confidence": 0.2, "why": "not_select"}
 
+    lowered = candidate.lower()
+    if any(word in lowered for word in (" delete ", " update ", " insert ", " drop ", " alter ", " truncate ")):
+        return {"sql": None, "confidence": 0.0, "why": "unsafe_sql"}
 
-def _oracleize_limit(sql: str) -> str:
-    match = _LIMIT_END.search(sql)
-    if not match:
-        return sql
-    value = match.group(1)
-    replacement = f" FETCH FIRST {value} ROWS ONLY"
-    start, end = match.span()
-    return sql[: start].rstrip() + replacement
-
-
-def _enforce_select_only(sql: str) -> str:
-    cleaned = sql.strip().strip(";")
-    if not _SQL_ONLY.match(cleaned):
-        raise ValueError("Generated SQL is not a SELECT/CTE statement.")
-    lower = cleaned.lower()
-    for banned in ("insert ", "update ", "delete ", "merge ", "alter ", "drop ", "create "):
-        if banned in lower:
-            raise ValueError("Non-SELECT statement detected.")
-    return cleaned
-
-
-class DWLLM:
-    """Simple adapter that turns natural language into Oracle SQL."""
-
-    def __init__(self, settings: Settings):
-        self.settings = settings
-        self.llm = _load_llm(settings)
-        stop_tokens = os.getenv("STOP", "</s>,<|im_end|>")
-        self.stop: List[str] = [tok for tok in (stop_tokens.split(",") if stop_tokens else []) if tok]
-        self.gen_kwargs = {
-            "max_new_tokens": int(os.getenv("GENERATION_MAX_NEW_TOKENS", "256")),
-            "temperature": float(os.getenv("GENERATION_TEMPERATURE", "0.2")),
-            "top_p": float(os.getenv("GENERATION_TOP_P", "0.9")),
-        }
-
-    def nl_to_sql(
-        self,
-        question: str,
-        extra_shots: Iterable[Tuple[str, str]] | None = None,
-    ) -> str:
-        prompt = build_nl2sql_prompt(question, extra_shots)
-        generated = self.llm.generate(
-            prompt,
-            stop=self.stop if self.stop else None,
-            **self.gen_kwargs,
-        )
-        trimmed = _strip_stop_tokens(generated, self.stop)
-        sql_candidate = _extract_sql_block(trimmed)
-        sql_candidate = _oracleize_limit(sql_candidate)
-        return _enforce_select_only(sql_candidate)
+    return {"sql": candidate, "confidence": 0.72, "why": "ok"}

--- a/core/sqlcoder_exllama.py
+++ b/core/sqlcoder_exllama.py
@@ -1,0 +1,204 @@
+"""Utility for loading SQLCoder (ExLlamaV2) as a simple text generator."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, Iterable, Optional
+
+import torch
+
+
+def _parse_gpu_split(env_value: str | None) -> Optional[list[float]]:
+    if not env_value:
+        return None
+    parts = [p.strip() for p in env_value.split(",") if p.strip()]
+    if not parts:
+        return None
+    try:
+        numbers = [float(p) for p in parts]
+    except Exception:
+        return None
+    total = sum(numbers)
+    if total <= 0:
+        return None
+    if max(numbers) > 1.5:
+        return [n / total for n in numbers]
+    return [n / total for n in numbers]
+
+
+class ExLlamaGenerator:
+    def __init__(self, generator, stop_tokens: Iterable[str], defaults: Dict[str, Any], dynamic: bool) -> None:
+        self._generator = generator
+        self._stop_tokens = [tok for tok in stop_tokens if tok]
+        self._defaults = defaults
+        self._dynamic = dynamic
+
+    def generate(
+        self,
+        prompt: str,
+        max_new_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        stop: Optional[Iterable[str]] = None,
+    ) -> str:
+        from exllamav2.generator import ExLlamaV2Sampler
+
+        args = dict(self._defaults)
+        if max_new_tokens is not None:
+            args["max_new_tokens"] = int(max_new_tokens)
+        if temperature is not None:
+            args["temperature"] = float(temperature)
+        if top_p is not None:
+            args["top_p"] = float(top_p)
+
+        stop_tokens = list(stop or self._stop_tokens)
+        max_new = int(args["max_new_tokens"])
+        temp = float(args["temperature"])
+        nucleus = float(args["top_p"])
+
+        if self._dynamic:
+            try:
+                text = self._generator.generate_simple(
+                    prompt,
+                    max_new_tokens=max_new,
+                    temperature=temp,
+                    top_p=nucleus,
+                )
+            except TypeError:
+                text = None
+            else:
+                if isinstance(text, (list, tuple)):
+                    text = text[0]
+                if text is not None:
+                    for token in stop_tokens:
+                        if token and token in text:
+                            text = text.split(token, 1)[0]
+                    return text
+
+        settings = ExLlamaV2Sampler.Settings()
+        settings.temperature = temp
+        settings.top_p = nucleus
+        try:
+            output = self._generator.generate_simple(prompt, settings, max_new)
+        except TypeError:
+            try:
+                output = self._generator.generate_simple(prompt, max_new, settings)
+            except TypeError:
+                output = self._generator.generate_simple(
+                    prompt,
+                    settings=settings,
+                    max_new_tokens=max_new,
+                )
+        text = output[0] if isinstance(output, (list, tuple)) else output
+        for token in stop_tokens:
+            if token and token in text:
+                text = text.split(token, 1)[0]
+        return text
+
+
+def load_exllama_generator(model_path: str, config: Dict[str, Any]) -> ExLlamaGenerator:
+    """Load ExLlamaV2 for SQLCoder and return a lightweight generator wrapper."""
+
+    from exllamav2 import ExLlamaV2, ExLlamaV2Cache, ExLlamaV2Config, ExLlamaV2Tokenizer
+
+    force_base = str(os.getenv("EXL2_FORCE_BASE", "0")).lower() in {"1", "true", "yes", "on"}
+    if force_base:
+        try:
+            import exllamav2.attn as _attn
+
+            _attn.has_flash_attn = False
+        except Exception:
+            pass
+
+    dyn_available = False
+    if not force_base:
+        try:
+            from exllamav2.generator.dynamic import ExLlamaV2DynamicGenerator  # noqa: F401
+
+            dyn_available = True
+        except Exception:
+            dyn_available = False
+
+    cfg = ExLlamaV2Config(model_path)
+    cfg.max_seq_len = int(config.get("max_seq_len", 4096))
+    if torch.cuda.is_available():
+        cfg.set_low_mem()
+        cfg.gpu_peer_fix = True
+    cfg.prepare()
+
+    model = ExLlamaV2(cfg)
+    tokenizer = ExLlamaV2Tokenizer(cfg)
+
+    cache_len = int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", cfg.max_seq_len))
+    cache = ExLlamaV2Cache(model, lazy=True, max_seq_len=cache_len)
+
+    split = _parse_gpu_split(os.getenv("EXL2_GPU_SPLIT_GB") or os.getenv("GPU_SPLIT"))
+
+    reserve: Optional[list[int]] = None
+    try:
+        reserve_gb = float(os.getenv("RESERVE_VRAM_GB", "0") or 0)
+    except Exception:
+        reserve_gb = 0.0
+    if torch.cuda.device_count() > 1 and reserve_gb > 0:
+        reserve = [0, int(reserve_gb * (1 << 30))]
+
+    def _load_weights(split_hint: Optional[list[float]], cache_obj: ExLlamaV2Cache) -> None:
+        t0 = time.time()
+        if split_hint:
+            model.load(split_hint, cache_obj)
+        else:
+            model.load_autosplit(cache_obj, progress=True, reserve_vram=reserve)
+        print(f"ExLlamaV2 weights ready in {time.time() - t0:.2f}s")
+
+    current_cache = cache
+
+    try:
+        _load_weights(split, current_cache)
+    except Exception as exc:
+        msg = str(exc).lower()
+        flash_fail = "flashatt" in msg or "flash_attn" in msg
+        if flash_fail:
+            try:
+                import exllamav2.attn as _attn
+
+                _attn.has_flash_attn = False
+            except Exception:
+                pass
+        smaller = max(1024, cache_len // 2)
+        if smaller < cache_len:
+            current_cache = ExLlamaV2Cache(model, lazy=True, max_seq_len=smaller)
+        else:
+            current_cache = ExLlamaV2Cache(model, lazy=True, max_seq_len=cache_len)
+        if split:
+            _load_weights(None, current_cache)
+        else:
+            _load_weights(split, current_cache)
+
+    cache = current_cache
+
+    gen = None
+    gen_is_dynamic = False
+    if dyn_available and not force_base:
+        try:
+            from exllamav2.generator.dynamic import ExLlamaV2DynamicGenerator
+
+            gen = ExLlamaV2DynamicGenerator(model=model, tokenizer=tokenizer, cache=cache)
+            gen_is_dynamic = True
+        except Exception:
+            gen = None
+            gen_is_dynamic = False
+
+    if gen is None:
+        from exllamav2.generator.base import ExLlamaV2BaseGenerator
+
+        gen = ExLlamaV2BaseGenerator(model=model, tokenizer=tokenizer, cache=cache)
+        gen_is_dynamic = False
+
+    defaults = {
+        "max_new_tokens": int(config.get("max_new_tokens", 256)),
+        "temperature": float(config.get("temperature", 0.2)),
+        "top_p": float(config.get("top_p", 0.9)),
+    }
+    stop_tokens = config.get("stop") or []
+    return ExLlamaGenerator(gen, stop_tokens, defaults, gen_is_dynamic)


### PR DESCRIPTION
## Summary
- refactor the LLM loader to keep separate cached handles for SQLCoder and the clarifier, with HuggingFace helpers for the latter
- add an ExLlamaV2 utility module plus a DocuWare clarifier helper and updated SQL generation shim
- wire the DocuWare blueprint to ask clarifying follow-ups when SQL generation fails and expose combined model info

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd229361ac83239c24af03866d05e5