### PR TITLE
Integrate clarifier model and DW learning pipeline

### DIFF
--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -2,17 +2,70 @@
 
 from __future__ import annotations
 
+import json
 import re
-from typing import Dict
+from typing import Any, Dict, Optional
 
-from core.model_loader import load_llm
+from core.model_loader import get_model, load_llm
 
 
 _CODE_BLOCK = re.compile(r"```(?:sql)?\s*(.*?)```", re.IGNORECASE | re.DOTALL)
 
+CLARIFIER_SYSTEM = """You are a careful analyst. 
+Return a single compact JSON object describing the user's requested intent over the DocuWare `Contract` table.
+Schema highlights:
+- Monetary: CONTRACT_VALUE_NET_OF_VAT (number), VAT (number), GROSS = NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0)
+- Dates: REQUEST_DATE, START_DATE, END_DATE, EXPIERY_30/60/90
+- Stakeholders/Departments: CONTRACT_STAKEHOLDER_1..8 paired with DEPARTMENT_1..8
+- Owner department: OWNER_DEPARTMENT, and DEPARTMENT_OUL is the org lead
 
-def nl_to_sql_with_llm(question: str, dw_table: str = "Contract") -> Dict[str, object]:
-    """Use SQLCoder to translate natural language into Oracle SQL."""
+JSON fields to output (only these):
+{
+  "intent": "select" | "rank" | "count" | "sum" | "avg",
+  "entity": "contracts" | "stakeholders" | "departments",
+  "time": {"column": "REQUEST_DATE"|"START_DATE"|"END_DATE", "range": {"type": "last_month"|"last_90_days"|"...", "start": "YYYY-MM-DD", "end": "YYYY-MM-DD"}},
+  "group_by": ["stakeholder"|"department"|"owner_department"|"..."],
+  "metrics": ["gross_value","count_contracts", "..."],
+  "top_n": 10
+}
+If unclear, infer sensible defaults (REQUEST_DATE for generic “last month”, stakeholder view for stakeholder questions).
+Return ONLY the JSON, no prose.
+"""
+
+
+def clarify_intent(question: str, context: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    mdl = get_model("clarifier")
+    if not mdl:
+        return None
+    user = f"Question: {question}\nContext: {json.dumps(context, ensure_ascii=False)}"
+    try:
+        out = mdl.generate(
+            system_prompt=CLARIFIER_SYSTEM,
+            user_prompt=user,
+            max_new_tokens=256,
+        )
+    except Exception:
+        return None
+    if not out:
+        return None
+    try:
+        start = out.find("{")
+        end = out.rfind("}")
+        if start != -1 and end != -1 and end > start:
+            return json.loads(out[start : end + 1])
+    except Exception:
+        return None
+    return None
+
+
+def nl_to_sql_with_llm(
+    question: Optional[str] = None,
+    *,
+    intent: Optional[Dict[str, Any]] = None,
+    settings: Optional[Any] = None,
+    dw_table: str = "Contract",
+) -> Dict[str, object]:
+    """Use SQLCoder to translate natural language or structured intent into Oracle SQL."""
 
     llm = load_llm("sql")
     if not llm:
@@ -22,17 +75,43 @@ def nl_to_sql_with_llm(question: str, dw_table: str = "Contract") -> Dict[str, o
     if generator is None:
         return {"sql": None, "confidence": 0.0, "why": "sql_generator_missing"}
 
-    sys_prompt = (
-        "You convert natural language to **Oracle SQL** over a single table named {tbl}.\n"
-        "Rules:\n"
-        "- Output only SQL (no comments), SELECT/CTEs only (no DML/DDL).\n"
-        "- Use NVL for null-safe arithmetic.\n"
-        "- Gross value = NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0).\n"
-        "- If time window like 'last month/90 days/next 30 days' is present, use named binds :date_start and :date_end.\n"
-        "- Use LISTAGG for aggregating text when asked.\n"
-    ).format(tbl=dw_table)
+    if not question and not intent:
+        return {"sql": None, "confidence": 0.0, "why": "missing_prompt"}
 
-    prompt = f"{sys_prompt}\nQuestion: {question}\nGenerate SQL now.\nSQL:"
+    # Baseline system instructions for SQLCoder in DocuWare/Oracle environment.
+    sys_prompt = (
+        f"You are SQLCoder generating Oracle SQL for the DocuWare `{dw_table}` table.\n"
+        "Requirements:\n"
+        "- Output SELECT statements only (CTEs allowed), never DML/DDL.\n"
+        "- Oracle dialect: use NVL, FETCH FIRST :top_n ROWS ONLY, LISTAGG ... WITHIN GROUP.\n"
+        "- Available tables: Contract.\n"
+        "- Gross value = NVL(CONTRACT_VALUE_NET_OF_VAT,0) + NVL(VAT,0).\n"
+        "- Time filters must bind :date_start and :date_end.\n"
+        "- Stakeholder/department slots 1..8 require UNION ALL across slots with matching departments.\n"
+        "- Never create or reference views.\n"
+        "Return only SQL (no commentary)."
+    )
+
+    prompt_parts = [sys_prompt]
+
+    context_hints: Dict[str, Any] = {}
+    if settings is not None:
+        try:
+            context_hints = settings.get("DW_PROMPT_HINTS", scope="namespace") or {}
+        except Exception:
+            context_hints = {}
+    if context_hints:
+        hint_text = "Additional context hints:\n" + json.dumps(
+            context_hints, ensure_ascii=False, indent=2
+        )
+        prompt_parts.append(hint_text)
+    if intent:
+        intent_json = json.dumps(intent, ensure_ascii=False, indent=2)
+        prompt_parts.append(f"Structured intent JSON:\n```json\n{intent_json}\n```")
+    if question:
+        prompt_parts.append(f"Question: {question}")
+
+    prompt = "\n\n".join(prompt_parts) + "\nGenerate Oracle SQL now.\nSQL:"
 
     try:
         raw_text = generator.generate(prompt)
@@ -51,4 +130,7 @@ def nl_to_sql_with_llm(question: str, dw_table: str = "Contract") -> Dict[str, o
     if any(word in lowered for word in (" delete ", " update ", " insert ", " drop ", " alter ", " truncate ")):
         return {"sql": None, "confidence": 0.0, "why": "unsafe_sql"}
 
-    return {"sql": candidate, "confidence": 0.72, "why": "ok"}
+    confidence = 0.72
+    if intent:
+        confidence = 0.82
+    return {"sql": candidate, "confidence": confidence, "why": "ok"}

--- a/core/pipeline.py
+++ b/core/pipeline.py
@@ -14,7 +14,7 @@ from core.inquiries import (
     set_inquiry_status,
     update_inquiry_status_run,
 )
-from core.model_loader import load_llm_from_settings
+from core.model_loader import load_llm_from_settings, model_info as loader_model_info
 from core.research import load_researcher
 from core.settings import Settings
 from core.snippets import autosave_snippet
@@ -111,18 +111,7 @@ class Pipeline:
 
     # ------------------------------------------------------------------
     def model_info(self) -> Dict[str, Any]:
-        info = self.llm_info if isinstance(self.llm_info, dict) else {}
-        name = info.get("name") or "unknown"
-        backend = info.get("backend")
-        if backend:
-            llm_desc = f"{name} ({backend})"
-        else:
-            llm_desc = name
-        return {
-            "mode": "dw-pipeline",
-            "clarifier": "disabled",
-            "llm": llm_desc,
-        }
+        return loader_model_info()
 
     # ------------------------------------------------------------------
     def answer_dw(


### PR DESCRIPTION
## Summary
- warm both SQLCoder and the clarifier during startup and surface device details in /model/info
- add a structured intent clarifier helper plus richer DocuWare-specific SQL prompt guidance
- update the DW answer loop to rebind parameters, retry with clarified intent, and persist successful runs/snippets for learning

## Testing
- python -m compileall apps/dw core main.py

------
https://chatgpt.com/codex/tasks/task_e_68cd45c82bb08323a938fccda0bc70e9