### PR TITLE
Add SQL cleaning and validation pipeline for DW answer route

### DIFF
--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -1,101 +1,58 @@
 import re
-from typing import Any, Dict, Optional, Tuple
+from typing import Dict, List, Tuple
 
 from core.model_loader import get_model
 
-# Allowed binds for Oracle in this app
-ALLOWED_BINDS = {"date_start", "date_end"}
+_ALLOWED_BINDS = {
+    "date_start",
+    "date_end",
+    "top_n",
+    "owner_name",
+    "dept",
+    "entity_no",
+    "contract_id_pattern",
+    "request_type",
+}
 
-# System prompt for SQLCoder (DW)
-SQL_SYSTEM_PROMPT = """You write ONLY Oracle SQL for a DocuWare table named \"Contract\".
-Rules:
-- Output must be a single SELECT or WITH...SELECT statement. No comments, no prose, no prefixes/suffixes.
-- Use ONLY these columns when relevant:
-  CONTRACT_ID, CONTRACT_OWNER,
-  CONTRACT_STAKEHOLDER_1, CONTRACT_STAKEHOLDER_2, CONTRACT_STAKEHOLDER_3, CONTRACT_STAKEHOLDER_4,
-  CONTRACT_STAKEHOLDER_5, CONTRACT_STAKEHOLDER_6, CONTRACT_STAKEHOLDER_7, CONTRACT_STAKEHOLDER_8,
-  DEPARTMENT_1, DEPARTMENT_2, DEPARTMENT_3, DEPARTMENT_4,
-  DEPARTMENT_5, DEPARTMENT_6, DEPARTMENT_7, DEPARTMENT_8,
-  OWNER_DEPARTMENT,
-  CONTRACT_VALUE_NET_OF_VAT, VAT,
-  CONTRACT_PURPOSE, CONTRACT_SUBJECT,
-  START_DATE, END_DATE, REQUEST_DATE, REQUEST_TYPE, CONTRACT_STATUS,
-  ENTITY_NO, REQUESTER.
-- Oracle syntax: NVL(), LISTAGG(... WITHIN GROUP (...)), TRIM(), UPPER(), FETCH FIRST N ROWS ONLY.
-- DO NOT create any bind variables unless the question explicitly asks for a time window and names a date column
-  (e.g. \"END_DATE in next 30 days\"). Only then use :date_start and :date_end. NEVER invent other binds.
-- If no time window is asked: do NOT use binds at all; write direct predicates.
-- Never write DML/DDL; SELECT/CTE only.
+_SYSTEM_TMPL = """You are an Oracle SQL generator.
+Return ONLY a single Oracle SELECT or WITH query. No prose. No comments. No 'SQL:' prefix.
+Use only table "Contract".
+Use only these columns: {cols}.
+Do NOT add a date filter unless the user explicitly asks (e.g., 'next 30 days', 'last month', 'between', 'since').
+If you use binds, they MUST be from this whitelist only: :date_start, :date_end, :top_n, :owner_name, :dept, :entity_no, :contract_id_pattern, :request_type.
+Never bind obvious literals like 0, 1, 'ACTIVE'—write them as literals.
+Use Oracle syntax: NVL(), TRIM(), UPPER(), LISTAGG(... WITHIN GROUP (...)), FETCH FIRST N ROWS ONLY.
 """
 
 
-def _extract_select(sql_text: str) -> Optional[str]:
-    """Return only the first SELECT/WITH statement; strip fences/prose."""
-    if not sql_text:
-        return None
-    # remove code fences
-    trimmed = re.sub(r"^```(?:sql)?\\s*|\\s*```$", "", sql_text, flags=re.IGNORECASE | re.MULTILINE)
-    # find first SELECT or WITH
-    match = re.search(r"(?is)\\b(SELECT|WITH)\\b.*", trimmed)
+def _extract_sql(text: str) -> str:
+    """Return the first SELECT/WITH block, strip comments/fences; empty if not found."""
+
+    if not text:
+        return ""
+
+    cleaned = re.sub(r"```sql|```", "", text, flags=re.IGNORECASE)
+    match = re.search(r"\b(SELECT|WITH)\b", cleaned, flags=re.IGNORECASE | re.DOTALL)
     if not match:
-        return None
-    cleaned = match.group(0).strip()
-    cleaned = re.split(r"\n\\s*SQL\\s*:\\s*\n", cleaned, maxsplit=1)[0].strip()
-    cleaned = cleaned.rstrip(";")
-    return cleaned if cleaned.upper().startswith(("SELECT", "WITH")) else None
+        return ""
+
+    sql = cleaned[match.start() :].strip()
+    lines = [line for line in sql.splitlines() if not line.strip().startswith("--")]
+    sql = "\n".join(lines).strip()
+    if sql.endswith(";"):
+        sql = sql[:-1].strip()
+    return sql
 
 
-def _unexpected_binds(sql: str) -> set[str]:
-    """Return set of bind names that are not allowed (:date_start/:date_end)."""
-    binds = set(re.findall(r":([A-Za-z_]\\w*)", sql or ""))
-    return {bind for bind in binds if bind not in ALLOWED_BINDS}
+def nl_to_sql_with_llm(question: str, allowed_columns: List[str]) -> Tuple[str, Dict]:
+    """Generate Oracle SQL from NL, then extract/clean it."""
+
+    mdl = get_model("sql")
+    sys_prompt = _SYSTEM_TMPL.format(cols=", ".join(allowed_columns))
+    prompt = f"{sys_prompt}\n\nQuestion:\n{question}\nSQL:"
+    raw = mdl.generate(prompt, stop=["</s>", "<|im_end|>"])
+    sql = _extract_sql(raw)
+    return sql, {"raw": raw}
 
 
-def nl_to_sql_with_llm(question: str, force_time_window: bool = False) -> Tuple[Optional[str], Dict[str, Any]]:
-    """Generate Oracle SQL from natural language with strict bind/shape discipline."""
-    model = get_model("sql")
-    if model is None:
-        return None, {"reason": "no_model"}
-
-    meta: Dict[str, Any] = {"retries": 0}
-
-    def _ask(system_prompt: str, user_prompt: str) -> Optional[str]:
-        try:
-            output = model.generate(system=system_prompt, user=user_prompt)
-        except Exception as exc:  # pragma: no cover - model transport errors
-            meta["reason"] = "error"
-            meta["error"] = str(exc)
-            return None
-        return _extract_select(output)
-
-    user_prompt = f"Question:\n{question}\nReturn ONLY the SQL."
-
-    sql = _ask(SQL_SYSTEM_PROMPT, user_prompt)
-    if not sql:
-        meta.setdefault("reason", "not_select")
-        return None, meta
-
-    bad_binds = _unexpected_binds(sql)
-    if bad_binds:
-        meta["retries"] = 1
-        strict_prompt = (
-            SQL_SYSTEM_PROMPT
-            + "\nABSOLUTE RULE: Do NOT invent binds. Only :date_start/:date_end are permitted and only if the question asks "
-            "a time window on a named date column."
-        )
-        retry_sql = _ask(strict_prompt, user_prompt)
-        if retry_sql:
-            retry_bad = _unexpected_binds(retry_sql)
-            if not retry_bad:
-                meta["unexpected_binds_first_try"] = sorted(bad_binds)
-                return retry_sql, meta
-            sql = retry_sql
-            bad_binds = retry_bad
-        meta["reason"] = "unexpected_binds"
-        meta["bad_binds"] = sorted(bad_binds)
-        return None, meta
-
-    return sql, meta
-
-
-__all__ = ["ALLOWED_BINDS", "SQL_SYSTEM_PROMPT", "_extract_select", "_unexpected_binds", "nl_to_sql_with_llm"]
+__all__ = ["_ALLOWED_BINDS", "_SYSTEM_TMPL", "_extract_sql", "nl_to_sql_with_llm"]

--- a/apps/dw/sql_validate.py
+++ b/apps/dw/sql_validate.py
@@ -1,0 +1,62 @@
+import re
+
+_ALLOWED_BINDS = {
+    "date_start",
+    "date_end",
+    "top_n",
+    "owner_name",
+    "dept",
+    "entity_no",
+    "contract_id_pattern",
+    "request_type",
+}
+
+
+def ensure_select_only(sql: str) -> str:
+    s = (sql or "").strip()
+    if not re.match(r"^(SELECT|WITH)\b", s, flags=re.IGNORECASE):
+        raise ValueError("not_select")
+    if re.search(
+        r"\b(INSERT|UPDATE|DELETE|MERGE|TRUNCATE|ALTER|DROP|CREATE)\b",
+        s,
+        flags=re.IGNORECASE,
+    ):
+        raise ValueError("not_select")
+    return s
+
+
+def ensure_allowed_binds(sql: str) -> set[str]:
+    binds = set(re.findall(r":([A-Za-z_][A-Za-z0-9_]*)", sql or ""))
+    bad = [b for b in binds if b not in _ALLOWED_BINDS]
+    if bad:
+        raise ValueError(f"bad_binds:{','.join(bad)}")
+    return binds
+
+
+_TIMEWORDS = re.compile(
+    r"\b(last|next|between|since|before|after|today|yesterday|month|months|year|years|week|weeks|day|days)\b",
+    re.IGNORECASE,
+)
+
+
+def forbid_implicit_date_window(sql: str, question: str) -> str:
+    """If query uses :date_* but the question didn't ask for time, strip the window."""
+
+    if ":date_start" in (sql or "") or ":date_end" in (sql or ""):
+        if not _TIMEWORDS.search(question or ""):
+            sql = re.sub(
+                r"\s+(AND|WHERE)\s+[^)]*\b(REQUEST_DATE|START_DATE|END_DATE)\s*(?:BETWEEN|>=|>|<=|<).+?:date_end",
+                " ",
+                sql,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            sql = re.sub(r"\bWHERE\s+AND\b", " WHERE ", sql, flags=re.IGNORECASE)
+            sql = re.sub(r"\bWHERE\s*$", "", sql, flags=re.IGNORECASE)
+    return sql.strip()
+
+
+__all__ = [
+    "ensure_select_only",
+    "ensure_allowed_binds",
+    "forbid_implicit_date_window",
+]


### PR DESCRIPTION
## Summary
- add a dedicated Oracle SQL extractor that builds a focused prompt and strips extraneous output
- introduce SQL validation helpers to enforce SELECT-only queries, allowlisted binds, and implicit date window removal
- wire the extractor and validator into the /dw/answer flow so date binds are resolved only when requested

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cde4baa39483238dff2fc0596abc8d