### PR TITLE
Improve DW SQL generation pipeline

### DIFF
--- a/apps/dw/clarifier.py
+++ b/apps/dw/clarifier.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import List
+import re
+from datetime import date, datetime, time, timedelta
+from typing import Dict, List, Optional
 
 from core.model_loader import load_llm
 
@@ -80,3 +82,138 @@ def propose_clarifying_questions(user_question: str) -> List[str]:
         "Do you need gross contract value (net + VAT)?",
     ]
 
+
+_TEXT_TOP = {
+    "ten": 10,
+    "five": 5,
+    "three": 3,
+    "twenty": 20,
+    "twenty five": 25,
+    "thirty": 30,
+}
+
+_TOP_RE = re.compile(r"\btop\s+(\d+)\b", re.IGNORECASE)
+_NEXT_DAYS_RE = re.compile(r"\bnext\s+(\d+)\s+day", re.IGNORECASE)
+_YEAR_RE = re.compile(r"\bin\s+(20\d{2})\b", re.IGNORECASE)
+_REQUEST_TYPE_RE = re.compile(
+    r"request\s*type\s*(?:=|is|:)?\s*['\"]?\s*([A-Za-z0-9_ /-]+)['\"]?",
+    re.IGNORECASE,
+)
+
+
+def _default_date_column(question: str, fallback: str) -> str:
+    q = (question or "").lower()
+    if "end date" in q or "expiry" in q or "expires" in q:
+        return "END_DATE"
+    if "start date" in q or "begin date" in q:
+        return "START_DATE"
+    if "request date" in q:
+        return "REQUEST_DATE"
+    return fallback or "REQUEST_DATE"
+
+
+def _as_datetime(value: date | datetime) -> datetime:
+    if isinstance(value, datetime):
+        return value
+    return datetime.combine(value, time.min)
+
+
+def _window_next_days(today: date, days: int) -> Dict[str, datetime]:
+    start = _as_datetime(today)
+    end = _as_datetime(today + timedelta(days=days))
+    return {"start": start, "end": end, "label": f"next {days} days"}
+
+
+def _window_last_month(today: date) -> Dict[str, datetime]:
+    first_this = today.replace(day=1)
+    last_month_end = first_this
+    last_month_start = (first_this - timedelta(days=1)).replace(day=1)
+    return {
+        "start": _as_datetime(last_month_start),
+        "end": _as_datetime(last_month_end),
+        "label": "last month",
+    }
+
+
+def _window_year(year: int) -> Dict[str, datetime]:
+    start = datetime(year, 1, 1)
+    end = datetime(year + 1, 1, 1)
+    return {"start": start, "end": end, "label": f"in {year}"}
+
+
+def _detect_window(question: str) -> Optional[Dict[str, datetime]]:
+    today = datetime.utcnow().date()
+    lowered = (question or "").lower()
+
+    if "last month" in lowered or "previous month" in lowered:
+        return _window_last_month(today)
+
+    match = _NEXT_DAYS_RE.search(lowered)
+    if match:
+        try:
+            days = int(match.group(1))
+        except ValueError:
+            days = 0
+        if days > 0:
+            return _window_next_days(today, days)
+
+    match = _YEAR_RE.search(lowered)
+    if match:
+        year = int(match.group(1))
+        if 2000 <= year <= 2100:
+            return _window_year(year)
+
+    return None
+
+
+def _extract_top_n(question: str) -> Optional[int]:
+    lowered = (question or "").lower()
+    match = _TOP_RE.search(lowered)
+    if match:
+        try:
+            return max(1, min(int(match.group(1)), 500))
+        except ValueError:
+            pass
+    for text_value, number in _TEXT_TOP.items():
+        if f"top {text_value}" in lowered:
+            return number
+    return None
+
+
+def _extract_request_type(question: str) -> Optional[str]:
+    match = _REQUEST_TYPE_RE.search(question or "")
+    if match:
+        value = match.group(1).strip()
+        return value if value else None
+    return None
+
+
+def analyze_question_intent(question: str, *, default_date_column: str = "REQUEST_DATE") -> Dict[str, object]:
+    """Return a deterministic context dict for downstream SQL generation."""
+
+    intent: Dict[str, object] = {
+        "date_column": _default_date_column(question, default_date_column),
+        "filters": {},
+        "hints": [],
+    }
+
+    window = _detect_window(question)
+    if window:
+        intent["date_window"] = {"start": window["start"], "end": window["end"]}
+        intent["window_label"] = window.get("label")
+
+    top_n = _extract_top_n(question)
+    if top_n is not None:
+        intent["top_n"] = top_n
+
+    req_type = _extract_request_type(question)
+    if req_type:
+        filters = intent.get("filters") or {}
+        filters["request_type"] = req_type
+        intent["filters"] = filters
+
+    lowered = (question or "").lower()
+    if "stakeholder" in lowered:
+        intent.setdefault("hints", []).append("stakeholder_unpivot")
+
+    return intent

--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -1,56 +1,116 @@
 import re
+from typing import Any, Dict, List, Optional
 
 from core.model_loader import get_model
 
-_SQL_STRIP_PATTERNS = [
-    r"(?is)^sql\s*:\s*",
-    r"(?is)^--.*?$",
-    r"(?is)^/\*.*?\*/\s*",
-]
+_BEGIN = "BEGIN_SQL"
+_END = "END_SQL"
 
+PROMPT = """You are an Oracle SQL expert.
 
-def _normalize_sql(sql_text: str) -> str:
-    if not sql_text:
-        return ""
-    s = sql_text.strip()
-    for pat in _SQL_STRIP_PATTERNS:
-        s = re.sub(pat, "", s).strip()
-    match = re.search(r"(?is)\b(with|select)\b", s)
-    if match:
-        s = s[match.start() :].strip()
-    if ";" in s:
-        s = s.split(";", 1)[0].strip()
-    return s
+Rules:
+1) Output ONLY a valid Oracle SELECT or WITH ... SELECT. No prose, no comments.
+2) Use ONLY table "Contract".
+3) Allowed columns:
+   CONTRACT_ID, CONTRACT_OWNER,
+   CONTRACT_STAKEHOLDER_1, CONTRACT_STAKEHOLDER_2, CONTRACT_STAKEHOLDER_3, CONTRACT_STAKEHOLDER_4,
+   CONTRACT_STAKEHOLDER_5, CONTRACT_STAKEHOLDER_6, CONTRACT_STAKEHOLDER_7, CONTRACT_STAKEHOLDER_8,
+   DEPARTMENT_1, DEPARTMENT_2, DEPARTMENT_3, DEPARTMENT_4, DEPARTMENT_5, DEPARTMENT_6, DEPARTMENT_7, DEPARTMENT_8,
+   OWNER_DEPARTMENT, CONTRACT_VALUE_NET_OF_VAT, VAT, CONTRACT_PURPOSE, CONTRACT_SUBJECT,
+   START_DATE, END_DATE, REQUEST_DATE, REQUEST_TYPE, CONTRACT_STATUS, ENTITY_NO, REQUESTER.
+4) Use Oracle syntax (NVL, TRIM, UPPER, LISTAGG ... WITHIN GROUP ..., FETCH FIRST N ROWS ONLY).
+5) Named binds allowed ONLY if you use them explicitly in the SQL: :date_start, :date_end, :top_n, :owner_name, :dept, :entity_no, :contract_id_pattern, :request_type.
+   - Do not invent other binds.
+   - Do not bind obvious literals like 0 or 'ACTIVE'—write literals directly.
+6) If the user explicitly asks for a time window (e.g., "last month", "next 30 days", "in 2024", "between ... and ..."):
+   - Use the specified date column; if none specified, use REQUEST_DATE by default.
+   - Use :date_start and :date_end binds for the window.
+7) Never modify data (no DML/DDL). SELECT/CTE only.
 
-_SQL_SYSTEM_PROMPT = """Return ONLY Oracle SQL. No prose. No comments. SELECT or WITH only.
-Use only table "Contract".
-Allowed columns:
-  CONTRACT_ID, CONTRACT_OWNER,
-  CONTRACT_STAKEHOLDER_1, CONTRACT_STAKEHOLDER_2, CONTRACT_STAKEHOLDER_3, CONTRACT_STAKEHOLDER_4,
-  CONTRACT_STAKEHOLDER_5, CONTRACT_STAKEHOLDER_6, CONTRACT_STAKEHOLDER_7, CONTRACT_STAKEHOLDER_8,
-  DEPARTMENT_1, DEPARTMENT_2, DEPARTMENT_3, DEPARTMENT_4, DEPARTMENT_5, DEPARTMENT_6, DEPARTMENT_7, DEPARTMENT_8,
-  OWNER_DEPARTMENT, CONTRACT_VALUE_NET_OF_VAT, VAT, CONTRACT_PURPOSE, CONTRACT_SUBJECT,
-  START_DATE, END_DATE, REQUEST_DATE, REQUEST_TYPE, CONTRACT_STATUS, ENTITY_NO, REQUESTER.
-Do NOT add any date filter unless the user explicitly asks (e.g., "next 30 days", "last month",
-"between ... and ...", "since 2024-01-01").
-If a window is asked and the user names a date column, use that column. Otherwise use REQUEST_DATE only when the user
-explicitly says "request date".
-Use named binds only from this whitelist: :date_start, :date_end, :top_n, :owner_name, :dept, :entity_no, :contract_id_pattern, :request_type.
-Never invent other binds. Never bind obvious literals like 0, 1, 'ACTIVE' — write literals directly.
-Use Oracle syntax: NVL(), TRIM(), UPPER(), LISTAGG(... WITHIN GROUP (...)), FETCH FIRST N ROWS ONLY.
+User question:
+{question}
+
+Output:
+{begin}
+<SQL HERE>
+{end}
 """
 
+_FILTER_INSTRUCTIONS = {
+    "owner_name": "Filter on CONTRACT_OWNER using bind :owner_name.",
+    "dept": "Filter on OWNER_DEPARTMENT using bind :dept.",
+    "entity_no": "Filter on ENTITY_NO using bind :entity_no.",
+    "contract_id_pattern": "Filter on CONTRACT_ID (LIKE) using bind :contract_id_pattern.",
+    "request_type": "Filter on REQUEST_TYPE using bind :request_type.",
+}
 
-def _sanitize_oracle_select(raw: str) -> str | None:
-    """Extract the first SELECT/WITH statement, strip comments/instructions, forbid DML/DDL."""
 
+def _context_notes(context: Optional[Dict[str, Any]]) -> List[str]:
+    if not context:
+        return []
+    notes: List[str] = []
+    window = context.get("date_window") if isinstance(context, dict) else None
+    date_column = context.get("date_column") if isinstance(context, dict) else None
+    if window:
+        column = date_column or "REQUEST_DATE"
+        label = context.get("window_label") or "requested window"
+        notes.append(
+            f"Apply the {label} on column {column} using binds :date_start and :date_end. Do not inline literal dates."
+        )
+    hints = context.get("hints") if isinstance(context, dict) else None
+    if hints and "stakeholder_unpivot" in hints:
+        notes.append(
+            "If aggregating by stakeholder, union the slots (CONTRACT_STAKEHOLDER_1..8 with DEPARTMENT_1..8) into rows"
+            " with columns CONTRACT_ID, STAKEHOLDER, DEPARTMENT, REQUEST_DATE AS REF_DATE, and compute gross as"
+            " NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0)."
+        )
+    top_n = context.get("top_n") if isinstance(context, dict) else None
+    if top_n:
+        notes.append(
+            "For TOP queries, order appropriately and apply FETCH FIRST :top_n ROWS ONLY (defaults to 10 if unspecified)."
+        )
+    filters = context.get("filters") if isinstance(context, dict) else None
+    if isinstance(filters, dict):
+        for key, instruction in _FILTER_INSTRUCTIONS.items():
+            if key in filters:
+                notes.append(instruction)
+    return notes
+
+
+def build_prompt(question: str, context: Optional[Dict[str, Any]] = None) -> str:
+    question = (question or "").strip()
+    notes = _context_notes(context)
+    if notes:
+        context_block = "\n\nContext:\n" + "\n".join(f"- {note}" for note in notes)
+    else:
+        context_block = ""
+    return PROMPT.format(question=f"{question}{context_block}", begin=_BEGIN, end=_END)
+
+
+def extract_sql(text: str) -> Optional[str]:
+    if not text:
+        return None
+    match = re.search(rf"{_BEGIN}\s*(.*?)\s*{_END}", text, flags=re.S | re.I)
+    if match:
+        sql = match.group(1).strip()
+    else:
+        fallback = re.search(r"(?is)\b(?:select|with)\b.*", text)
+        sql = fallback.group(0).strip() if fallback else None
+    if not sql:
+        return None
+    if not re.match(r"(?is)^(select|with)\b", sql):
+        return None
+    return sql
+
+
+def _sanitize_oracle_select(raw: str) -> Optional[str]:
     if not raw:
         return None
-    start = None
     lines = raw.splitlines()
-    for idx, ln in enumerate(lines):
-        s = ln.strip().lower()
-        if s.startswith("select") or s.startswith("with"):
+    start = None
+    for idx, line in enumerate(lines):
+        stripped = line.strip().lower()
+        if stripped.startswith("select") or stripped.startswith("with"):
             start = idx
             break
     if start is None:
@@ -64,24 +124,25 @@ def _sanitize_oracle_select(raw: str) -> str | None:
     return sql_text
 
 
-def nl_to_sql_with_llm(question: str, context: dict) -> str | None:
-    """Ask the SQL model for Oracle SQL; return sanitized SELECT/CTE or None."""
+def nl_to_sql_with_llm(question: str, context: Optional[Dict[str, Any]] = None) -> Optional[str]:
+    model = get_model("sql")
+    prompt = build_prompt(question, context=context)
+    raw = model.generate(prompt, max_new_tokens=320, stop=[])
+    sql = extract_sql(raw)
+    sql = _sanitize_oracle_select(sql) if sql else None
+    if sql:
+        return sql
 
-    mdl = get_model("sql")
-    prompt = f"{_SQL_SYSTEM_PROMPT}\n\nQuestion:\n{question}\nSQL:"
-    raw = mdl.generate(
-        prompt,
-        max_new_tokens=256,
-        stop=[],
-    )
-    normalized = _normalize_sql(raw)
-    return _sanitize_oracle_select(normalized)
+    repair_prompt = "Return only Oracle SELECT between BEGIN_SQL and END_SQL.\n\n" + prompt
+    raw_retry = model.generate(repair_prompt, max_new_tokens=320, stop=[])
+    sql_retry = extract_sql(raw_retry)
+    sql_retry = _sanitize_oracle_select(sql_retry) if sql_retry else None
+    return sql_retry
 
 
 __all__ = [
-    "_SQL_SYSTEM_PROMPT",
-    "_SQL_STRIP_PATTERNS",
-    "_normalize_sql",
-    "_sanitize_oracle_select",
+    "PROMPT",
+    "build_prompt",
+    "extract_sql",
     "nl_to_sql_with_llm",
 ]


### PR DESCRIPTION
## Summary
- enforce BEGIN_SQL/END_SQL prompt markers and context-aware hints when generating Oracle SQL
- normalize DW clarifier intent (date windows, filters, top-n, stakeholder hints) for downstream use
- build runtime binds only for placeholders actually used and persist intent metadata in /dw/answer

## Testing
- python -m compileall apps/dw

------
https://chatgpt.com/codex/tasks/task_e_68ce297c434083239dba9a77a7868810