### PR TITLE
Add blueprint factory for DocuWare routes

### DIFF
--- a/apps/dw/__init__.py
+++ b/apps/dw/__init__.py
@@ -1,3 +1,3 @@
-from .app import NAMESPACE, dw_bp
+from .app import NAMESPACE, create_dw_blueprint, dw_bp
 
-__all__ = ["dw_bp", "NAMESPACE"]
+__all__ = ["dw_bp", "create_dw_blueprint", "NAMESPACE"]

--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -422,3 +422,8 @@ def answer():
             "used_repair": used_repair,
         }
     return jsonify(resp)
+
+
+def create_dw_blueprint(*args, **kwargs):
+    """Factory function returning the DocuWare blueprint."""
+    return dw_bp


### PR DESCRIPTION
## Summary
- add a `create_dw_blueprint` factory that returns the existing DocuWare blueprint
- re-export the blueprint factory from `apps.dw` for consistent imports

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce379147488323b29db0994f5626fb