### PR TITLE
Improve DW SQL generation reliability and logging

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -5,18 +5,52 @@ import json
 import logging
 import os
 import pathlib
-import re
-from datetime import date, datetime, timedelta
-from logging.handlers import TimedRotatingFileHandler
+from datetime import datetime
 
-from flask import Blueprint, jsonify, current_app, request
+from flask import Blueprint, current_app, jsonify, request
 from sqlalchemy import text
-from core.settings import Settings
-from core.datasources import DatasourceRegistry
-from core.sql_exec import get_mem_engine
-from .llm import ALLOWED_BINDS, nl_to_sql_with_llm, repair_sql
-from .validator import validate_sql
 
+from core.datasources import DatasourceRegistry
+from core.settings import Settings
+from core.sql_exec import get_mem_engine
+from .llm import clarify_intent, derive_bind_values, nl_to_sql_with_llm
+from .validator import WHITELIST_BINDS, basic_checks
+
+
+ALLOWED_COLUMNS = [
+    "CONTRACT_ID",
+    "CONTRACT_OWNER",
+    "CONTRACT_STAKEHOLDER_1",
+    "CONTRACT_STAKEHOLDER_2",
+    "CONTRACT_STAKEHOLDER_3",
+    "CONTRACT_STAKEHOLDER_4",
+    "CONTRACT_STAKEHOLDER_5",
+    "CONTRACT_STAKEHOLDER_6",
+    "CONTRACT_STAKEHOLDER_7",
+    "CONTRACT_STAKEHOLDER_8",
+    "DEPARTMENT_1",
+    "DEPARTMENT_2",
+    "DEPARTMENT_3",
+    "DEPARTMENT_4",
+    "DEPARTMENT_5",
+    "DEPARTMENT_6",
+    "DEPARTMENT_7",
+    "DEPARTMENT_8",
+    "OWNER_DEPARTMENT",
+    "CONTRACT_VALUE_NET_OF_VAT",
+    "VAT",
+    "CONTRACT_PURPOSE",
+    "CONTRACT_SUBJECT",
+    "START_DATE",
+    "END_DATE",
+    "REQUEST_DATE",
+    "REQUEST_TYPE",
+    "CONTRACT_STATUS",
+    "ENTITY_NO",
+    "REQUESTER",
+]
+
+ALLOWED_BINDS = sorted(WHITELIST_BINDS)
 
 dw_bp = Blueprint("dw", __name__, url_prefix="/dw")
 
@@ -37,35 +71,29 @@ def _settings():
     return Settings()
 
 
-def _ensure_log_dir_and_handler(app):
-    """Create logs/ and attach a daily rotating file handler once."""
+def _ensure_file_logger(app):
+    """Attach a daily log file handler writing to logs/dw-YYYYMMDD.log."""
 
     try:
         log_dir = os.environ.get("DW_LOG_DIR", "logs")
         os.makedirs(log_dir, exist_ok=True)
-        log_path = os.path.join(log_dir, "dw.log")
+        today = datetime.now().strftime("%Y%m%d")
+        log_path = os.path.join(log_dir, f"dw-{today}.log")
 
-        existing = [h for h in app.logger.handlers if getattr(h, "_dw_handler", False)]
-        if existing:
-            return
+        for handler in app.logger.handlers:
+            if isinstance(handler, logging.FileHandler) and getattr(handler, "_dw_path", "") == log_path:
+                return
 
-        debug_level = logging.DEBUG if DW_DEBUG else logging.INFO
-
-        console = logging.StreamHandler()
-        console.setLevel(debug_level)
-        console.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s"))
-
-        fileh = TimedRotatingFileHandler(log_path, when="midnight", backupCount=14, encoding="utf-8")
-        fileh.setLevel(debug_level)
+        fileh = logging.FileHandler(log_path, encoding="utf-8")
+        fileh.setLevel(logging.DEBUG if DW_DEBUG else logging.INFO)
         fileh.setFormatter(logging.Formatter("%(asctime)s %(levelname)s [%(name)s] %(message)s"))
-        fileh._dw_handler = True  # type: ignore[attr-defined]
+        fileh._dw_path = log_path  # type: ignore[attr-defined]
 
-        app.logger.setLevel(debug_level)
-        app.logger.addHandler(console)
         app.logger.addHandler(fileh)
+        app.logger.setLevel(logging.DEBUG if DW_DEBUG else logging.INFO)
         app.logger.info("[dw] logging initialized")
-    except Exception as exc:  # pragma: no cover - defensive logging setup
-        print(f"[dw] log init failed: {exc}")
+    except Exception as exc:  # pragma: no cover
+        print(f"Failed to init dw logger: {exc}")
 
 
 def _log(tag, payload):
@@ -81,45 +109,7 @@ def _log(tag, payload):
 
 @dw_bp.record_once
 def _init_dw_logging(setup_state):
-    app = setup_state.app
-    _ensure_log_dir_and_handler(app)
-
-
-def _question_has_window(q: str) -> bool:
-    ql = (q or "").lower()
-    return any(k in ql for k in [
-        "last month", "next ", "last ", "between ", "in ", "since ", "days", "months", "year", "quarter"
-    ])
-
-def _derive_dates_for_question(q: str) -> dict:
-    """Compute :date_start/:date_end for common phrases. Return {} if not applicable."""
-    ql = (q or "").lower()
-    today = date.today()
-    if "next 30 days" in ql:
-        return {"date_start": datetime.combine(today, datetime.min.time()),
-                "date_end":   datetime.combine(today + timedelta(days=30), datetime.min.time())}
-    if "last month" in ql:
-        first_of_this = date(today.year, today.month, 1)
-        last_month_end = first_of_this - timedelta(days=1)
-        last_month_start = date(last_month_end.year, last_month_end.month, 1)
-        return {
-            "date_start": datetime.combine(last_month_start, datetime.min.time()),
-            "date_end":   datetime.combine(first_of_this, datetime.min.time()),
-        }
-    m = re.search(r"last\s+(\d+)\s+days", ql)
-    if m:
-        n = int(m.group(1))
-        return {"date_start": datetime.combine(today - timedelta(days=n), datetime.min.time()),
-                "date_end":   datetime.combine(today, datetime.min.time())}
-    m = re.search(r"in\s+(20\d{2})", ql)
-    if m:
-        yr = int(m.group(1))
-        return {"date_start": datetime(yr,1,1), "date_end": datetime(yr+1,1,1)}
-    m = re.search(r"between\s+(\d{4}-\d{2}-\d{2})\s+and\s+(\d{4}-\d{2}-\d{2})", ql)
-    if m:
-        a,b = m.group(1), m.group(2)
-        return {"date_start": datetime.fromisoformat(a), "date_end": datetime.fromisoformat(b)}
-    return {}
+    _ensure_file_logger(setup_state.app)
 
 
 def _write_csv(rows, headers) -> str:
@@ -139,82 +129,89 @@ def _write_csv(rows, headers) -> str:
 
 @dw_bp.route("/answer", methods=["POST"])
 def answer():
-    s = _settings()
-    ds_registry = DatasourceRegistry(settings=s, namespace=NAMESPACE)
-    mem = get_mem_engine(s)
+    settings = _settings()
+    ds_registry = DatasourceRegistry(settings=settings, namespace=NAMESPACE)
+    mem = get_mem_engine(settings)
+
     body = request.get_json(force=True, silent=False) or {}
-    q = body.get("question","").strip()
+    q = (body.get("question") or "").strip()
     auth_email = body.get("auth_email")
     prefixes = body.get("prefixes") or []
     include_debug = DW_INCLUDE_DEBUG or (request.args.get("debug") == "true")
 
-    table_name = s.get("DW_CONTRACT_TABLE", scope="namespace") or "Contract"
-    default_date_col = s.get("DW_DATE_COLUMN", scope="namespace") or "REQUEST_DATE"
-    bind_whitelist = set(ALLOWED_BINDS)
+    table_name = settings.get("DW_CONTRACT_TABLE", scope="namespace") or "Contract"
+    default_date_col = settings.get("DW_DATE_COLUMN", scope="namespace") or "REQUEST_DATE"
 
-    # Create inquiry row (status open)
+    ctx = {
+        "table": table_name,
+        "allowed_columns": ALLOWED_COLUMNS,
+        "allowed_binds": ALLOWED_BINDS,
+        "default_date_col": default_date_col,
+    }
+
     with mem.begin() as conn:
-        inq_id = conn.execute(text("""
+        inq_id = conn.execute(
+            text(
+                """
             INSERT INTO mem_inquiries(namespace, question, auth_email, prefixes, status, created_at, updated_at)
             VALUES (:ns, :q, :email, CAST(:pfx AS jsonb), 'open', NOW(), NOW())
             RETURNING id
-        """), {"ns": NAMESPACE, "q": q, "email": auth_email, "pfx": json.dumps(prefixes)}).scalar_one()
+        """
+            ),
+            {"ns": NAMESPACE, "q": q, "email": auth_email, "pfx": json.dumps(prefixes)},
+        ).scalar_one()
 
     _log("inquiry_start", {"id": inq_id, "q": q, "email": auth_email})
 
-    # ---------- LLM first pass ----------
-    llm_context = {
-        "contract_table": table_name,
-        "default_date_col": default_date_col,
-    }
-    llm_out = nl_to_sql_with_llm(q, llm_context)
-    intent_bundle = llm_out.get("intent") or {}
-    _log("clarifier_intent", intent_bundle)
+    clarifier = clarify_intent(q, ctx)
+    intent = clarifier.get("intent", {}) if isinstance(clarifier, dict) else {}
+    _log("clarifier_intent", intent)
+    if clarifier.get("raw"):
+        payload = {"size": len(clarifier["raw"])}
+        if include_debug:
+            payload["text"] = clarifier["raw"][:900]
+        _log("clarifier_raw", payload)
+
+    llm_out = nl_to_sql_with_llm(q, ctx, intent=intent)
     prompt_text = llm_out.get("prompt") or ""
-    _log("sql_prompt", {"prompt": prompt_text[:900]})
+    _log("sql_prompt", {"prompt": prompt_text if include_debug else "<hidden>"})
     raw1 = llm_out.get("raw1") or ""
-    _log("llm_raw_pass1", {"text": raw1[:900]})
-    sql1 = (llm_out.get("sql1") or "").strip()
-    _log("llm_sql_pass1", {"sql": sql1[:900]})
-    intent = intent_bundle.get("intent", {}) if isinstance(intent_bundle, dict) else {}
+    _log("llm_raw_pass1", {"size": len(raw1)})
+    if llm_out.get("used_repair"):
+        raw2 = llm_out.get("raw2") or ""
+        _log("llm_raw_pass2", {"size": len(raw2)})
 
-    # ---------- Validate ----------
-    v1 = validate_sql(sql1, allow_tables=[table_name], bind_whitelist=bind_whitelist)
-    _log("validation_pass1", v1)
+    sql_final = (llm_out.get("sql") or "").strip()
+    sql_payload = {"size": len(sql_final)}
+    sql_payload["sql"] = sql_final[:900] if include_debug else "<hidden>"
+    _log("final_sql", sql_payload)
+    validation = llm_out.get("validation") or basic_checks(sql_final, allowed_binds=ALLOWED_BINDS)
+    _log("validation", validation)
 
-    # ---------- Repair pass if needed ----------
-    sql_final = sql1
-    v_final = v1
-    used_repair = False
-    if not v1["ok"]:
-        repair_out = repair_sql(sql1, prompt_text, q)
-        raw2 = repair_out.get("raw2") or ""
-        sql2 = (repair_out.get("sql2") or "").strip()
-        _log("llm_raw_pass2", {"text": raw2[:900]})
-        _log("llm_sql_pass2", {"sql": sql2[:900]})
-        v2 = validate_sql(sql2, allow_tables=[table_name], bind_whitelist=bind_whitelist)
-        _log("validation_pass2", v2)
-        if v2["ok"]:
-            sql_final = sql2
-            v_final = v2
-            used_repair = True
-
-    # ---------- If still not ok → needs clarification ----------
-    if not v_final["ok"]:
+    if not validation.get("ok"):
         with mem.begin() as conn:
-            conn.execute(text("""
+            conn.execute(
+                text(
+                    """
                 UPDATE mem_inquiries
                    SET status = 'needs_clarification',
                        last_sql = :sql,
                        last_error = :err,
                        updated_at = NOW()
                  WHERE id = :id
-            """), {"sql": sql_final, "err": ",".join(v_final["errors"]), "id": inq_id})
+            """
+                ),
+                {
+                    "sql": sql_final,
+                    "err": ",".join(validation.get("errors") or []),
+                    "id": inq_id,
+                },
+            )
         res = {
             "ok": False,
             "status": "needs_clarification",
             "inquiry_id": inq_id,
-            "error": v_final["errors"][0] if v_final["errors"] else "error",
+            "error": (validation.get("errors") or ["error"])[0],
             "sql": sql_final,
             "questions": [
                 "I couldn't derive a clean SELECT. Can you rephrase or specify filters (stakeholders, departments, date columns)?"
@@ -222,91 +219,20 @@ def answer():
         }
         if include_debug:
             res["debug"] = {
-                "clarifier": intent_bundle,
+                "intent": intent,
                 "prompt": prompt_text,
                 "raw1": raw1,
-                "sql1": sql1,
-                "validation1": v1,
-                "used_repair": used_repair,
+                "validation": validation,
             }
         return jsonify(res)
 
-    # ---------- Prepare binds ----------
-    binds_used = set(v_final["binds"])
-    binds = {}
-    phrase_window_hint = _question_has_window(q)
-    explicit_dates = intent.get("explicit_dates") if isinstance(intent.get("explicit_dates"), dict) else None
-    needs_window = {"date_start", "date_end"} & binds_used
-    wants_window = bool(intent.get("has_time_window")) or phrase_window_hint
-    question_has_window = wants_window
+    used_binds = validation.get("binds") or []
+    actual_bind_names = validation.get("bind_names") or []
+    bind_name_map = {canon: actual for canon, actual in zip(used_binds, actual_bind_names)}
 
-    if needs_window or wants_window:
-        candidate_window = {}
-        if explicit_dates and explicit_dates.get("start") and explicit_dates.get("end"):
-            try:
-                candidate_window = {
-                    "date_start": datetime.fromisoformat(explicit_dates["start"]),
-                    "date_end": datetime.fromisoformat(explicit_dates["end"]),
-                }
-            except Exception:
-                candidate_window = {}
-        if not candidate_window:
-            candidate_window = _derive_dates_for_question(q) if wants_window else {}
-        if not candidate_window and needs_window:
-            today = date.today()
-            candidate_window = {
-                "date_start": datetime.combine(today - timedelta(days=30), datetime.min.time()),
-                "date_end": datetime.combine(today, datetime.min.time()),
-            }
-        if candidate_window.get("date_start") and candidate_window.get("date_end"):
-            binds["date_start"] = candidate_window["date_start"]
-            binds["date_end"] = candidate_window["date_end"]
-        elif needs_window:
-            with mem.begin() as conn:
-                conn.execute(
-                    text(
-                        """
-                    UPDATE mem_inquiries
-                       SET status='needs_clarification', last_sql=:sql, last_error='missing_window_values', updated_at=NOW()
-                     WHERE id=:id
-                """
-                    ),
-                    {"sql": sql_final, "id": inq_id},
-                )
-            res = {
-                "ok": False,
-                "status": "needs_clarification",
-                "inquiry_id": inq_id,
-                "error": "missing_window_values",
-                "sql": sql_final,
-                "questions": [
-                    "I couldn't determine the time window values. Please specify start and end dates explicitly."
-                ],
-            }
-            if include_debug:
-                res["debug"] = {
-                    "clarifier": intent_bundle,
-                    "prompt": prompt_text,
-                    "raw1": raw1,
-                    "sql1": sql1,
-                    "validation1": v1,
-                    "used_repair": used_repair,
-                }
-            return jsonify(res)
-
-    if "top_n" in binds_used:
-        top_n_val = intent.get("top_n")
-        if not isinstance(top_n_val, int):
-            m_top = re.search(r"top\s+(\d+)", q.lower())
-            if m_top:
-                try:
-                    top_n_val = int(m_top.group(1))
-                except Exception:
-                    top_n_val = None
-        binds["top_n"] = top_n_val or 10
-
-    missing_binds = [b for b in binds_used if b not in binds]
-    if missing_binds:
+    bind_values = derive_bind_values(q, used_binds, intent)
+    missing = [b for b in used_binds if b not in bind_values]
+    if missing:
         with mem.begin() as conn:
             conn.execute(
                 text(
@@ -318,30 +244,28 @@ def answer():
                 ),
                 {"sql": sql_final, "id": inq_id},
             )
-        res = {
+        resp = {
             "ok": False,
             "status": "needs_clarification",
             "inquiry_id": inq_id,
             "error": "missing_bind_values",
             "sql": sql_final,
             "questions": [
-                f"Provide values for: {', '.join(missing_binds)} or rephrase with explicit filters."
+                f"Provide values for: {', '.join(sorted(missing))} or rephrase with explicit filters."
             ],
         }
         if include_debug:
-            res["debug"] = {
-                "clarifier": intent_bundle,
+            resp["debug"] = {
+                "intent": intent,
                 "prompt": prompt_text,
                 "raw1": raw1,
-                "sql1": sql1,
-                "validation1": v1,
-                "used_repair": used_repair,
+                "validation": validation,
             }
-        return jsonify(res)
+        return jsonify(resp)
 
-    _log("execution_binds", {k: str(v) for k, v in binds.items()})
+    exec_binds = {bind_name_map.get(k, k): v for k, v in bind_values.items()}
+    _log("execution_binds", {k: str(v) for k, v in exec_binds.items()})
 
-    # ---------- Execute on Oracle ----------
     oracle_engine = ds_registry.engine(None)
     rows = []
     headers = []
@@ -349,103 +273,115 @@ def answer():
     started = datetime.utcnow()
     try:
         with oracle_engine.begin() as oc:
-            rs = oc.execute(text(sql_final), binds)
+            rs = oc.execute(text(sql_final), exec_binds)
             headers = list(rs.keys())
             rows = rs.fetchall()
-    except Exception as ex:
-        error = str(ex)
-        _log(
-            "oracle_error",
-            {
-                "error": error,
-                "sql": sql_final[:4000],
-                "binds": {k: str(v) for k, v in binds.items()},
-            },
-        )
+    except Exception as exc:
+        error = str(exc)
+        _log("oracle_error", {"error": error})
 
     duration_ms = int((datetime.utcnow() - started).total_seconds() * 1000)
     _log("execution_result", {"rows": len(rows), "cols": headers, "ms": duration_ms})
 
     if error:
         with mem.begin() as conn:
-            conn.execute(text("""
+            conn.execute(
+                text(
+                    """
                 UPDATE mem_inquiries
                    SET status = 'failed',
                        last_sql = :sql,
                        last_error = :err,
                        updated_at = NOW()
                  WHERE id = :id
-            """), {"sql": sql_final, "err": error, "id": inq_id})
+            """
+                ),
+                {"sql": sql_final, "err": error, "id": inq_id},
+            )
         return jsonify({"ok": False, "error": error, "inquiry_id": inq_id, "status": "failed"})
 
-    # ---------- CSV export ----------
     csv_path = None
     if rows:
         csv_path = _write_csv(rows, headers)
-        _log("csv_export", {"path": csv_path})
+        if csv_path:
+            _log("csv_export", {"path": str(csv_path)})
 
-    # ---------- Auto-save snippet (if enabled) ----------
-    autosave = bool(s.get("SNIPPETS_AUTOSAVE", scope="namespace", default=True))
+    autosave = bool(settings.get("SNIPPETS_AUTOSAVE", scope="namespace", default=True))
     snippet_id = None
     if autosave and rows:
         with mem.begin() as conn:
-            snippet_id = conn.execute(text("""
+            snippet_id = conn.execute(
+                text(
+                    """
                 INSERT INTO mem_snippets(namespace, title, description, sql_template, sql_raw,
                                          input_tables, output_columns, tags, is_verified, created_at, updated_at)
                 VALUES (:ns, :title, :desc, :tmpl, :raw, CAST(:inputs AS jsonb), CAST(:cols AS jsonb),
                         CAST(:tags AS jsonb), :verified, NOW(), NOW())
                 RETURNING id
-            """), {
-                "ns": NAMESPACE,
-                "title": f"dw auto: {q[:60]}",
-                "desc": "Auto-saved by DW pipeline",
-                "tmpl": sql_final,
-                "raw": sql_final,
-                "inputs": json.dumps([table_name]),
-                "cols": json.dumps(headers),
-                "tags": json.dumps(["dw","contracts","auto"]),
-                "verified": False,
-            }).scalar_one()
+            """
+                ),
+                {
+                    "ns": NAMESPACE,
+                    "title": f"dw auto: {q[:60]}",
+                    "desc": "Auto-saved by DW pipeline",
+                    "tmpl": sql_final,
+                    "raw": sql_final,
+                    "inputs": json.dumps([table_name]),
+                    "cols": json.dumps(headers),
+                    "tags": json.dumps(["dw", "contracts", "auto"]),
+                    "verified": False,
+                },
+            ).scalar_one()
         _log("snippet_saved", {"id": snippet_id})
 
-    # ---------- Mark inquiry answered ----------
     with mem.begin() as conn:
-        conn.execute(text("""
+        conn.execute(
+            text(
+                """
             UPDATE mem_inquiries
                SET status='answered', answered_by=:by, answered_at=NOW(), updated_at=NOW(),
                    last_sql=:sql, last_error=NULL
              WHERE id=:id
-        """), {"by": auth_email, "sql": sql_final, "id": inq_id})
+        """
+            ),
+            {"by": auth_email, "sql": sql_final, "id": inq_id},
+        )
 
-    # ---------- Response ----------
+    binds_public = {
+        bind_name_map.get(k, k): (
+            v.isoformat() if hasattr(v, "isoformat") else v
+        )
+        for k, v in bind_values.items()
+    }
     meta = {
         "rowcount": len(rows),
         "columns": headers,
         "duration_ms": duration_ms,
-        "used_repair": used_repair,
-        "question_has_window": question_has_window,
+        "used_repair": bool(llm_out.get("used_repair")),
         "suggested_date_column": intent.get("date_column") or default_date_col,
-        "clarifier": intent_bundle,
-        "binds": {k: str(v) for k, v in binds.items()},
+        "clarifier_intent": intent,
+        "binds": binds_public,
     }
-    csv_path_str = str(csv_path) if csv_path else None
+
     resp = {
         "ok": True,
         "inquiry_id": inq_id,
         "sql": sql_final,
-        "rows": [list(r) for r in rows[:200]],  # cap preview
-        "csv_path": csv_path_str,
+        "rows": [list(r) for r in rows[:200]],
+        "csv_path": str(csv_path) if csv_path else None,
         "meta": meta,
     }
     if include_debug:
-        resp["debug"] = {
-            "clarifier": intent_bundle,
+        debug_payload = {
+            "intent": intent,
             "prompt": prompt_text,
             "raw1": raw1,
-            "sql1": sql1,
-            "validation1": v1,
-            "used_repair": used_repair,
+            "validation": validation,
+            "clarifier_raw": clarifier.get("raw"),
         }
+        if llm_out.get("used_repair"):
+            debug_payload["raw2"] = llm_out.get("raw2")
+        resp["debug"] = debug_payload
     return jsonify(resp)
 
 


### PR DESCRIPTION
## Summary
- trim ExLlama prompts against cache limits and add safer stop sequences to avoid overflow errors
- harden DW SQL validation/extraction plus add deterministic bind and time-window fallbacks in the LLM pipeline
- rework the DW answer endpoint to log every stage to daily files while executing with validated binds and preserving exports

## Testing
- python -m compileall apps/dw core

------
https://chatgpt.com/codex/tasks/task_e_68ce7a27308c8323a6927973eeb417f7