### PR TITLE
Fix ExLlama stop handling and harden DW SQL generation

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -195,6 +195,9 @@ def answer():
         "allowed_columns": ALLOWED_COLUMNS,
         "allowed_binds": ALLOWED_BINDS,
         "default_date_col": default_date_col,
+        "allowed_columns_clause": ", ".join(ALLOWED_COLUMNS),
+        "binds_whitelist": ", ".join(ALLOWED_BINDS),
+        "unpivot_hint": "SELECT CONTRACT_ID, NVL(CONTRACT_VALUE_NET_OF_VAT,0)+NVL(VAT,0) AS CONTRACT_VALUE_GROSS, CONTRACT_STAKEHOLDER_i AS STAKEHOLDER, REQUEST_DATE AS REF_DATE (UNION ALL slots 1..8)",
     }
 
     with mem.begin() as conn:


### PR DESCRIPTION
## Summary
- post-process ExLlama outputs to honour stop strings without calling the missing `set_stop_strings` API and trim prompts safely
- strengthen DocuWare SQL prompting with explicit `<<SQL>>` fences, resilient extraction, intent normalisation, and two-pass repair logic
- feed the SQL generator richer context hints, including allowed-column and bind clauses plus an unpivot pattern reminder

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce91a3fa7c8323bcb7d433bccc0368