### PR TITLE
Fix ExLlama prompt handling and logging

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -126,17 +126,14 @@ def answer():
         binds["date_start"] = datetime.combine(date_start, datetime.min.time())
         binds["date_end"] = datetime.combine(date_end, datetime.min.time())
 
-    _log("final_sql", {"size": len(sql), "sql": sql[:1200]})
-    _log(
-        "execution_binds",
-        {k: (v.isoformat() if hasattr(v, "isoformat") else v) for k, v in binds.items()},
-    )
-
     engine = get_oracle_engine()
     rows: list[list[object]] = []
     cols: list[str] = []
     started = datetime.utcnow()
     try:
+        bind_params_log = {k: (v.isoformat() if hasattr(v, "isoformat") else v) for k, v in binds.items()}
+        _log("execution_sql", {"sql": sql[:1800]})
+        _log("execution_binds", bind_params_log)
         with engine.begin() as conn:
             result = conn.exec_driver_sql(sql, binds)
             cols = list(result.keys())

--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -84,15 +84,17 @@ def build_sql_prompt(question: str, intent: dict) -> str:
     top_n = intent.get("top_n")
 
     head = (
-        "Return Oracle SQL only inside ```sql fenced block.\n"
+        "Return Oracle SQL only inside a fenced block:\n"
+        "```sql\n"
+        "-- SQL starts on next line\n"
         'Table: "Contract"\n'
         f"Allowed columns: {_ALLOWED_COLS}\n"
         "Oracle syntax only (NVL, TRIM, LISTAGG WITHIN GROUP, FETCH FIRST N ROWS ONLY). SELECT/CTE only.\n"
         f"Allowed binds: {_WHITELIST_BINDS}\n"
         "Add date filter ONLY if user asks. For windows use :date_start and :date_end.\n"
         f"Default window column: {date_col}.\n"
-        "No prose, comments, or explanations.\n\n"
-        f"Question:\n{question}\n\n```sql\n"
+        "No prose, comments, or explanations.\n"
+        f"Question:\n{question}\n```sql\n"
     )
 
     tail_hint = ""


### PR DESCRIPTION
## Summary
- drop the ExLlamaV2Sampler dependency and add cache-aware prompt/stopping logic so SQLCoder works with older exllamav2 builds
- tighten the SQL prompting to always open a fenced block and hint at where the SQL should begin
- log the final SQL text and bind parameters immediately before execution for easier debugging

## Testing
- python -m compileall core apps

------
https://chatgpt.com/codex/tasks/task_e_68cea03ac2748323b1d445cf575dd2e1