### PR TITLE
Update ExLlama wrapper and SQL logging

### DIFF
--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -199,21 +199,21 @@ def nl_to_sql_with_llm(question: str, ctx: dict) -> dict:
     # --- PASS 1: fenced prompt
     prompt1 = _build_prompt_fenced(question, intent, allow_binds)
     logger("sql_prompt_pass1", {"preview": prompt1[:400]})
-    raw1 = sql_mdl.generate(prompt1, max_new_tokens=max_new_tokens)
+    raw1 = sql_mdl.generate(prompt1, max_new_tokens=max_new_tokens, stop=["```"])
     sql1 = extract_sql(raw1)
     logger(
         "llm_raw_pass1",
         {
             "size": len(raw1 or ""),
-            "head": (raw1 or "")[:120],
-            "tail": (raw1 or "")[-120:],
+            "head": (raw1 or "")[:40],
+            "tail": (raw1 or "")[-40:],
         },
     )
     logger(
         "llm_sql_pass1",
         {
             "size": len(sql1 or ""),
-            "preview": (sql1 or "")[:200],
+            "preview": (sql1 or "")[:80],
         },
     )
     ok1, errs1, binds1 = validate_sql(sql1, allow_tables=("Contract",), allow_binds=allow_binds)
@@ -234,21 +234,21 @@ def nl_to_sql_with_llm(question: str, ctx: dict) -> dict:
     # --- PASS 2: plain prompt
     prompt2 = _build_prompt_plain(question, intent, allow_binds)
     logger("sql_prompt_pass2", {"preview": prompt2[:400]})
-    raw2 = sql_mdl.generate(prompt2, max_new_tokens=max_new_tokens)
+    raw2 = sql_mdl.generate(prompt2, max_new_tokens=max_new_tokens, stop=["```"])
     sql2 = extract_sql(raw2)
     logger(
         "llm_raw_pass2",
         {
             "size": len(raw2 or ""),
-            "head": (raw2 or "")[:120],
-            "tail": (raw2 or "")[-120:],
+            "head": (raw2 or "")[:40],
+            "tail": (raw2 or "")[-40:],
         },
     )
     logger(
         "llm_sql_pass2",
         {
             "size": len(sql2 or ""),
-            "preview": (sql2 or "")[:200],
+            "preview": (sql2 or "")[:80],
         },
     )
     ok2, errs2, binds2 = validate_sql(sql2, allow_tables=("Contract",), allow_binds=allow_binds)

--- a/core/model_loader.py
+++ b/core/model_loader.py
@@ -49,12 +49,10 @@ def _load_sql_model() -> Optional[Dict[str, Any]]:
     cfg = {
         "max_seq_len": _env_int("MODEL_MAX_SEQ_LEN", 4096),
         "max_new_tokens": _env_int("GENERATION_MAX_NEW_TOKENS", 256),
-        "temperature": float(os.getenv("GENERATION_TEMPERATURE", "0.2")),
-        "top_p": float(os.getenv("GENERATION_TOP_P", "0.9")),
         "stop": stop_tokens,
     }
 
-    handle = load_exllama_generator(model_path=path, config=cfg)
+    handle = load_exllama_generator(path)
     _log("SQL model (SQLCoder/ExLlamaV2) ready")
     return {
         "role": "sql",


### PR DESCRIPTION
## Summary
- replace the ExLlama SQLCoder wrapper with a robust version that configures sampler settings, truncates prompts, and trims outputs on stop strings
- update the SQL model loader for the new wrapper signature and remove generator-level stop configuration
- adjust DW SQL generation logging to use shorter previews while requesting manual stop trimming from the wrapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cf2ec9cb58832385c93b49a0b9797a