### PR TITLE
Fix ExLlama sampler usage and improve DW SQL prompting

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -81,6 +81,12 @@ def answer():
     out = nl_to_sql_with_llm(question, llm_context)
     intent = out.get("intent") or {}
     sql = out.get("sql") or ""
+    final_pass = f"pass{out.get('pass')}" if out.get("pass") else "unknown"
+    trunc_sql = (sql[:600] + "...") if len(sql) > 600 else sql
+    current_app.logger.info(
+        "[dw] chosen_sql",
+        extra={"payload": {"pass": final_pass, "sql": trunc_sql}},
+    )
 
     if not out.get("ok") or not sql:
         _log(


### PR DESCRIPTION
## Summary
- make the ExLlama wrapper resilient to different sampler module layouts and generate_simple signatures
- adjust DW SQL prompts to keep fenced output, add stakeholder guidance, and parse results locally
- log the final SQL pass and text before executing DW queries for easier debugging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf32fd50f48323a769eda29ece79ad