### PR TITLE
Fix ExLlama loader compatibility and logging

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -133,6 +133,8 @@ def answer():
         binds["date_end"] = datetime.combine(date_end, datetime.min.time())
 
     exec_binds = {k: (v.isoformat() if hasattr(v, "isoformat") else v) for k, v in binds.items()}
+    _log("sql_final", {"sql": sql})
+    _log("sql_binds", exec_binds)
     _log("choose_sql", {"pass": out.get("pass"), "preview": (sql or "")[:240], "binds": exec_binds})
 
     engine = get_oracle_engine()

--- a/apps/dw/llm.py
+++ b/apps/dw/llm.py
@@ -209,12 +209,15 @@ def nl_to_sql_with_llm(question: str, ctx: dict) -> dict:
     logger("clarifier_intent", intent)
 
     max_new_tokens = int(os.getenv("SQL_MAX_NEW_TOKENS", "384"))
-    stop_list = [s for s in os.getenv("STOP", "</s>,```").split(",") if s]
 
     # --- PASS 1: fenced prompt
     prompt1 = _build_prompt_fenced(question, intent, allow_binds)
     logger("sql_prompt_pass1", {"preview": prompt1[:400]})
-    raw1 = sql_mdl.generate(prompt1, max_new_tokens=max_new_tokens, stop=stop_list)
+    raw1 = sql_mdl.generate(
+        prompt1,
+        max_new_tokens=max_new_tokens,
+        stop=["```"],
+    )
     sql1 = _extract_sql(raw1)
     logger(
         "llm_raw_pass1",
@@ -249,7 +252,11 @@ def nl_to_sql_with_llm(question: str, ctx: dict) -> dict:
     # --- PASS 2: plain prompt
     prompt2 = _build_prompt_plain(question, intent, allow_binds)
     logger("sql_prompt_pass2", {"preview": prompt2[:400]})
-    raw2 = sql_mdl.generate(prompt2, max_new_tokens=max_new_tokens, stop=stop_list)
+    raw2 = sql_mdl.generate(
+        prompt2,
+        max_new_tokens=max_new_tokens,
+        stop=["```"],
+    )
     sql2 = _extract_sql(raw2)
     logger(
         "llm_raw_pass2",

--- a/core/sqlcoder_exllama.py
+++ b/core/sqlcoder_exllama.py
@@ -1,190 +1,140 @@
-import importlib
+import inspect
 import logging
 import os
 from typing import List, Optional
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("core.sqlcoder_exllama")
 
-try:  # pragma: no cover - depends on exllamav2 install
-    from exllamav2.generator import ExLlamaV2BaseGenerator  # type: ignore[attr-defined]
+try:
+    from exllamav2 import ExLlamaV2, ExLlamaV2Cache, ExLlamaV2Config
+except Exception as exc:  # pragma: no cover - propagate import failure
+    raise
+
+try:
+    from exllamav2 import ExLlamaV2Tokenizer
 except Exception:  # pragma: no cover - fallback for older builds
-    ExLlamaV2BaseGenerator = None  # type: ignore[assignment]
+    from exllamav2.tokenizer import ExLlamaV2Tokenizer  # type: ignore[attr-defined]
 
-try:  # pragma: no cover - prefer modern sampler location
-    from exllamav2.generator import ExLlamaV2Sampler  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover - fallback to legacy path or absence
-    try:
-        from exllamav2.generator.sampler import ExLlamaV2Sampler  # type: ignore[attr-defined]
-    except Exception:  # pragma: no cover - sampler missing entirely
-        ExLlamaV2Sampler = None  # type: ignore[assignment]
-
-try:  # pragma: no cover - legacy generator alias
-    from exllamav2.generator import ExLlamaV2Generator as _LegacyGenerator  # type: ignore[attr-defined]
-except Exception:  # pragma: no cover - not available on newer builds
-    _LegacyGenerator = None  # type: ignore[assignment]
+try:
+    from exllamav2.generator.base import ExLlamaV2BaseGenerator
+except Exception:  # pragma: no cover - fallback for alternate layout
+    from exllamav2.generator import ExLlamaV2BaseGenerator  # type: ignore[attr-defined]
 
 
-class ExLlamaSqlGenerator:
-    """Version-tolerant SQL generator wrapper for ExLlamaV2."""
+def _make_sampler_settings(temperature: float, top_p: float):
+    """Return a sampler/settings object compatible with installed exllamav2."""
 
-    def __init__(self, generator: "ExLlamaV2BaseGenerator") -> None:
+    settings = None
+    try:  # pragma: no cover - new sampler location
+        from exllamav2.generator.sampler import SamplerSettings
+
+        settings = SamplerSettings()
+    except Exception:
+        try:  # pragma: no cover - legacy sampler location
+            from exllamav2.generator.settings import (  # type: ignore[attr-defined]
+                ExLlamaV2SamplerSettings as SamplerSettings,
+            )
+
+            settings = SamplerSettings()
+        except Exception:
+            settings = None
+    if settings is not None:
+        try:
+            if hasattr(settings, "temperature"):
+                settings.temperature = float(temperature)
+            if hasattr(settings, "top_p"):
+                settings.top_p = float(top_p)
+        except Exception:  # pragma: no cover - tolerate exotic sampler APIs
+            pass
+    return settings
+
+
+class SQLCoderExLlama:
+    """Wrapper ensuring stable ExLlamaV2 generation behaviour across versions."""
+
+    def __init__(self, model, tokenizer, generator, cache, cfg) -> None:
+        self._model = model
+        self._tokenizer = tokenizer
         self._generator = generator
-        self.temperature = float(os.getenv("GENERATION_TEMPERATURE", "0.2"))
-        self.top_p = float(os.getenv("GENERATION_TOP_P", "0.9"))
-        self.max_seq_env = int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048"))
-        self.reserve_env = int(os.getenv("EXL2_INPUT_RESERVE_TOKENS", "64"))
-
-    # ------------------------ internal helpers ------------------------
-
-    def _truncate_prompt(self, prompt: str, max_new_tokens: int) -> str:
-        """Approximate prompt truncation to avoid cache overflows."""
-        max_in_tokens = max(64, self.max_seq_env - self.reserve_env - max_new_tokens)
-        max_chars = max(1024, max_in_tokens * 4)
-        if len(prompt) > max_chars:
-            return prompt[-max_chars:]
-        return prompt
-
-    def _make_settings(self):
-        if ExLlamaV2Sampler is None:
-            return None
-        try:
-            settings = ExLlamaV2Sampler.Settings()
-        except Exception:  # pragma: no cover - sampler lacks Settings
-            return None
-        if hasattr(settings, "temperature"):
-            settings.temperature = self.temperature
-        if hasattr(settings, "top_p"):
-            settings.top_p = self.top_p
-        return settings
-
-    @staticmethod
-    def _apply_stops(text: str, stops: Optional[List[str]]) -> str:
-        if not stops:
-            return text
-        cut = len(text)
-        for stop in stops:
-            if not stop:
-                continue
-            idx = text.find(stop)
-            if idx != -1:
-                cut = min(cut, idx)
-        return text[:cut]
-
-    def _call_generate(self, prompt: str, settings, max_new_tokens: int) -> str:
-        # Prefer modern (prompt, settings, num_tokens) signature
-        if settings is not None:
-            try:
-                return self._generator.generate_simple(prompt, settings, max_new_tokens)
-            except TypeError:
-                pass
-        # Try two-argument signature (prompt, num_tokens)
-        try:
-            return self._generator.generate_simple(prompt, max_new_tokens)
-        except TypeError:
-            # Final fallback for legacy (prompt, None, num_tokens)
-            return self._generator.generate_simple(prompt, None, max_new_tokens)
-
-    # ----------------------------- public -----------------------------
+        self._cache = cache
+        self._cfg = cfg
 
     def generate(
         self,
         prompt: str,
         max_new_tokens: int = 256,
         stop: Optional[List[str]] = None,
+        temperature: Optional[float] = None,
+        top_p: Optional[float] = None,
+        **_ignored,
     ) -> str:
-        prompt = self._truncate_prompt(prompt, max_new_tokens)
-        settings = self._make_settings()
+        # Build sampler/settings (if supported by installed version)
+        temp_val = float(temperature) if temperature is not None else float(os.getenv("GENERATION_TEMPERATURE", "0.2"))
+        top_p_val = float(top_p) if top_p is not None else float(os.getenv("GENERATION_TOP_P", "0.9"))
+        settings = _make_sampler_settings(temp_val, top_p_val)
 
-        if os.getenv("DW_DEBUG", "0") == "1":
-            logger.info(
-                "[sql] exllamav2.generate start max_new=%s prompt_len=%s",
-                max_new_tokens,
-                len(prompt),
-            )
-
-        out = self._call_generate(prompt, settings, max_new_tokens)
-        text = out if isinstance(out, str) else str(out)
-        text = self._apply_stops(text, stop)
-
-        if os.getenv("DW_DEBUG", "0") == "1":
-            logger.info("[sql] exllamav2.generate end out_len=%s", len(text))
-
-        return text
-
-
-# ------------------------------- loader -------------------------------
-
-
-def _resolve_tokenizer(cfg):
-    tok_mod = importlib.import_module("exllamav2.tokenizer")
-    candidates = [
-        "ExLlamaV2Tokenizer",
-        "ExLlamaV2TokenizerHF",
-        "Tokenizer",
-    ]
-    last_exc: Exception | None = None
-    for name in candidates:
-        tok_cls = getattr(tok_mod, name, None)
-        if tok_cls is None:
-            continue
+        # Respect cache length and keep an input reserve
+        reserve = int(os.getenv("EXL2_INPUT_RESERVE_TOKENS", "64"))
         try:
-            return tok_cls(cfg)
-        except Exception as exc:  # pragma: no cover - signature mismatch
-            last_exc = exc
-            continue
-    if last_exc is not None:
-        raise RuntimeError("No compatible tokenizer class available") from last_exc
-    raise RuntimeError("No tokenizer class found in exllamav2.tokenizer")
-
-
-def _build_generator(model, tokenizer, cache_len: int):
-    if ExLlamaV2BaseGenerator is not None:
+            max_seq = getattr(self._cache, "max_seq_len", int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048")))
+        except Exception:
+            max_seq = int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048"))
         try:
-            gen = ExLlamaV2BaseGenerator(model, tokenizer, max_seq_len=cache_len)
-        except TypeError:  # pragma: no cover - signature differences
-            gen = ExLlamaV2BaseGenerator(model, tokenizer)
-            if hasattr(gen, "set_max_seq_len"):
-                try:
-                    gen.set_max_seq_len(cache_len)
-                except Exception:
-                    pass
-            elif hasattr(gen, "max_seq_len") and not getattr(gen, "max_seq_len", None):
-                try:
-                    setattr(gen, "max_seq_len", cache_len)
-                except Exception:
-                    pass
-        return gen
-    if _LegacyGenerator is not None:
+            token_ids = self._tokenizer.encode(prompt)
+            prompt_tokens = len(token_ids)
+        except Exception:
+            prompt_tokens = max(1, len(prompt) // 4)
+        budget = max_seq - prompt_tokens - reserve
+        if budget < 1:
+            safe_new = 1
+        else:
+            safe_new = max(1, min(int(max_new_tokens), budget))
+
+        # Call generate_simple with signature detection
+        gen_simple = getattr(self._generator, "generate_simple")
+        sig = inspect.signature(gen_simple)
         try:
-            return _LegacyGenerator(model, tokenizer, max_seq_len=cache_len)
-        except TypeError:  # pragma: no cover - old signature without kwarg
-            return _LegacyGenerator(model, tokenizer, cache_len)
-    raise RuntimeError("No compatible ExLlama generator class available")
+            if len(sig.parameters) == 2:
+                text = gen_simple(prompt, safe_new)
+            else:
+                if settings is None:
+                    settings = _make_sampler_settings(temp_val, top_p_val)
+                text = gen_simple(prompt, settings, safe_new)
+        except TypeError:
+            text = gen_simple(prompt, settings or None, safe_new)
+
+        text = text or ""
+
+        # Local stop-string enforcement independent of generator implementation
+        stop_list = list(stop or [])
+        stop_list.extend(["```", "</s>"])
+        cut = len(text)
+        for marker in stop_list:
+            idx = text.find(marker)
+            if idx != -1:
+                cut = min(cut, idx)
+        return text[:cut].strip()
 
 
-def load_exllama_generator(model_path: str) -> ExLlamaSqlGenerator:
-    """Create a base generator and wrap it in :class:`ExLlamaSqlGenerator`."""
-    logger.info("Loading ExLlamaV2 model: %s", model_path)
-
-    from exllamav2 import ExLlamaV2, ExLlamaV2Config  # type: ignore import
+def load_exllama_generator(model_path: str) -> SQLCoderExLlama:
+    logger.info("[core.sqlcoder_exllama] Loading ExLlamaV2 model: %s", model_path)
 
     cfg = ExLlamaV2Config()
-    cfg.model_path = model_path
+    cfg.model_dir = os.path.abspath(model_path)
+    if hasattr(cfg, "model_path"):
+        cfg.model_path = cfg.model_dir
 
-    cache_len = int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048"))
-    if hasattr(cfg, "max_input_len"):
-        cfg.max_input_len = cache_len
+    try:  # pragma: no cover - helper not present everywhere
+        split = os.getenv("EXL2_GPU_SPLIT_GB")
+        if split:
+            cfg.set_auto_map(split)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
     cfg.prepare()
 
     model = ExLlamaV2(cfg)
-    tokenizer = _resolve_tokenizer(cfg)
-    generator = _build_generator(model, tokenizer, cache_len)
-
-    if hasattr(generator, "warmup"):
-        try:
-            generator.warmup()
-        except Exception:  # pragma: no cover - warmup optional
-            pass
-
-    logger.info("ExLlamaV2 generator ready (cache_len=%s)", cache_len)
-    return ExLlamaSqlGenerator(generator)
+    tokenizer = ExLlamaV2Tokenizer(cfg)
+    cache = ExLlamaV2Cache(model, max_seq_len=int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048")))
+    generator = ExLlamaV2BaseGenerator(model, cache, tokenizer)
+    return SQLCoderExLlama(model, tokenizer, generator, cache, cfg)


### PR DESCRIPTION
## Summary
- harden the ExLlama SQL loader to set model paths, create sampler settings, respect cache limits, and crop stop strings locally
- update the DW SQL generation calls to rely on the wrapper for stop handling
- log the final SQL text and binds selected for execution for easier debugging

## Testing
- python -m compileall core/sqlcoder_exllama.py apps/dw/llm.py apps/dw/app.py

------
https://chatgpt.com/codex/tasks/task_e_68cf37f2caa48323a409040518145dc7