### PR TITLE
Fix ExLlama V2 usage and harden SQL extraction

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -137,6 +137,17 @@ def answer():
     _log("sql_binds", exec_binds)
     _log("choose_sql", {"pass": out.get("pass"), "preview": (sql or "")[:240], "binds": exec_binds})
 
+    try:
+        preview_sql = sql[:600] + (" ..." if len(sql) > 600 else "")
+        current_app.logger.info("[dw] exec_sql_preview: %s", preview_sql)
+        safe_binds = {
+            key: (value if isinstance(value, (str, int, float)) else str(value))
+            for key, value in (binds or {}).items()
+        }
+        current_app.logger.info("[dw] exec_binds: %s", json.dumps(safe_binds, default=str))
+    except Exception:
+        pass
+
     engine = get_oracle_engine()
     rows: list[list[object]] = []
     cols: list[str] = []


### PR DESCRIPTION
## Summary
- build ExLlama V2 sampler settings for every generation and trim prompts to cache limits
- improve SQL extraction by handling unfenced output and cutting after repeated instructions
- log final SQL and bind parameters just before executing the Oracle query

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf3b300a208323a1c3fce7b27260a3