### PR TITLE
Improve ExLlamaV2 integration

### DIFF
--- a/core/sqlcoder_exllama.py
+++ b/core/sqlcoder_exllama.py
@@ -1,206 +1,163 @@
-# core/sqlcoder_exllama.py
-# Adapter for SQLCoder (EXL2 4-bit) on ExLlamaV2 – API-compatible with recent exllamav2
-
-from __future__ import annotations
 import os
-import logging
-from typing import List, Optional
+import inspect
+from types import SimpleNamespace
 
 import torch
 
-from exllamav2 import (
-    ExLlamaV2,
-    ExLlamaV2Cache,
-    ExLlamaV2Config,
-    ExLlamaV2Tokenizer,
-)
-from exllamav2.generator import (
-    ExLlamaV2BaseGenerator,
-    ExLlamaV2SamplingSettings,
-)
+from exllamav2 import ExLlamaV2, ExLlamaV2Config, ExLlamaV2Cache
 
-log = logging.getLogger("core.sqlcoder_exllama")
+# Tokenizer import changed across versions; try both
+try:
+    from exllamav2.tokenizer import ExLlamaV2Tokenizer
+except Exception:
+    # some wheels expose tokenizer at top-level
+    from exllamav2 import ExLlamaV2Tokenizer  # type: ignore
 
+# Generator import: prefer the higher-level class if available
+try:
+    from exllamav2.generator import ExLlamaV2Generator as GenClass
+except Exception:
+    from exllamav2.generator import ExLlamaV2BaseGenerator as GenClass  # type: ignore
 
-# ---------- Utilities ----------
-
-def _parse_gpu_split(env_val: Optional[str]) -> Optional[List[float]]:
-    """
-    Parse EXL2_GPU_SPLIT_GB like "29,2" into [29.0, 2.0].
-    Return None if empty/unset.
-    """
-    if not env_val:
-        return None
-    parts = [p.strip() for p in env_val.split(",") if p.strip()]
-    if not parts:
-        return None
+# Sampler + Settings: prefer Sampler.Settings; fall back to a dummy
+try:
+    from exllamav2.generator import ExLlamaV2Sampler  # newer layout
+except Exception:
     try:
-        return [float(p) for p in parts]
+        from exllamav2.generator.sampler import ExLlamaV2Sampler  # older layout
     except Exception:
-        log.warning("[exl2] Could not parse EXL2_GPU_SPLIT_GB=%r; ignoring.", env_val)
-        return None
+        ExLlamaV2Sampler = None  # type: ignore
 
 
-def _cut_at_first(text: str, stops: List[str]) -> str:
-    if not text:
-        return text
-    first = len(text)
-    for s in stops:
-        i = text.find(s)
-        if i != -1 and i < first:
-            first = i
-    return text[:first]
-
-
-def _extract_sql_fenced(text: str) -> str:
+def _build_settings(temperature: float, top_p: float):
     """
-    Try to extract the first ```sql ... ``` or ``` ... ``` block.
-    If none, return raw text (caller may decide it’s invalid).
+    Build a sampling settings object compatible with the installed exllamav2.
+    If the official Settings class is missing, return a SimpleNamespace with needed attrs.
     """
-    if not text:
-        return ""
-
-    # Prefer ```sql fenced block
-    start = text.find("```sql")
-    fence_len = 6
-    if start == -1:
-        # fallback: any ```
-        start = text.find("```")
-        fence_len = 3
-
-    if start == -1:
-        return text.strip()
-
-    start += fence_len
-    end = text.find("```", start)
-    if end == -1:
-        return text[start:].strip()
-    return text[start:end].strip()
-
-
-# ---------- Main loader & wrapper ----------
-
-class SQLCoderExL2:
-    """
-    Thin wrapper exposing .generate(prompt, max_new_tokens=..., stop=...), as expected by model_loader.get_model("sql").
-    """
-
-    def __init__(
-        self,
-        generator: ExLlamaV2BaseGenerator,
-        tokenizer: ExLlamaV2Tokenizer,
-        cache: ExLlamaV2Cache,
-        input_reserve_tokens: int = 64,
-        model_name: str = "sqlcoder-exl2",
-    ):
-        self._generator = generator
-        self._tokenizer = tokenizer
-        self._cache = cache
-        self._input_reserve = max(0, int(input_reserve_tokens))
-        self.name = f"{model_name} (exllama)"
-
-        # Default sampling settings – deterministic but not pathological
-        self._temperature = float(os.getenv("GENERATION_TEMPERATURE", "0.2"))
-        self._top_p = float(os.getenv("GENERATION_TOP_P", "0.9"))
-
-    # --- internal helpers ---
-
-    def _truncate_prompt_to_fit(self, prompt: str, max_new: int) -> str:
-        """
-        Ensure total tokens <= cache.max_seq_len - small_safety.
-        We keep the last part of the prompt if it is too long (most important instructions are usually near the end).
-        """
+    # Try official Settings
+    settings = None
+    if ExLlamaV2Sampler is not None:
         try:
-            # encode returns a tensor of token ids
-            ids = self._tokenizer.encode(prompt)
-            max_allowed = max(16, self._cache.max_seq_len - max_new - self._input_reserve)
-            if ids.numel() > max_allowed:
-                ids = ids[-max_allowed:]
-                # decode back to text
-                prompt = self._tokenizer.decode(ids)
-        except Exception as e:
-            # If anything goes wrong, don't kill the run – just return original text.
-            log.warning("[exl2] prompt truncation skipped: %s", e)
-        return prompt
+            SettingsClass = getattr(ExLlamaV2Sampler, "Settings", None)
+            if SettingsClass is not None:
+                settings = SettingsClass()
+                # common knobs
+                if hasattr(settings, "temperature"): settings.temperature = float(temperature)
+                if hasattr(settings, "top_p"):       settings.top_p = float(top_p)
+                # ensure fields accessed by sampler exist
+                if hasattr(settings, "cfg_scale"):   settings.cfg_scale = None
+                if hasattr(settings, "top_k"):       settings.top_k = 0
+                return settings
+        except Exception:
+            settings = None
 
-    # --- public API expected by the rest of the app ---
+    # Fallback dummy with the fields the sampler touches
+    settings = SimpleNamespace()
+    # fields the sampler often reads:
+    settings.temperature = float(temperature)
+    settings.top_p = float(top_p)
+    settings.top_k = 0
+    settings.min_p = 0.0
+    settings.typical = None
+    settings.tfs = None
+    settings.repetition_penalty = 1.0
+    settings.penalty_range = 64
+    settings.presence_penalty = 0.0
+    settings.frequency_penalty = 0.0
+    settings.mirostat = None
+    settings.cfg_scale = None
+    return settings
 
-    def generate(
-        self,
-        prompt: str,
-        max_new_tokens: int = 256,
-        stop: Optional[List[str]] = None,
-        temperature: Optional[float] = None,
-        top_p: Optional[float] = None,
-    ) -> str:
+
+class SQLCoderExLlama:
+    def __init__(self, model_dir: str):
+        if not model_dir or not os.path.isdir(model_dir):
+            raise RuntimeError(f"[exllama] model path not found: {model_dir}")
+
+        self.model_dir = model_dir
+        self.max_seq_len = int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048"))
+
+        # Build config
+        self.config = ExLlamaV2Config()
+        self.config.model_dir = model_dir
+
+        # Optional speed knobs
+        if os.getenv("EXL2_FORCE_BASE") == "1":
+            # just a hint env; ExLlamaV2 reads config for core toggles
+            pass
+
+        # Prepare config and model
+        self.config.prepare()
+        self.model = ExLlamaV2(self.config)
+
+        # Tokenizer
+        self.tokenizer = ExLlamaV2Tokenizer(self.config)
+
+        # Cache
+        self.cache = ExLlamaV2Cache(self.model, max_seq_len=self.max_seq_len, batch_size=1)
+        # Generator
+        self.generator = GenClass(self.model, self.tokenizer, self.cache)
+
+    def generate(self, prompt: str, max_new_tokens: int = 192, stop=None, temperature=0.2, top_p=0.9) -> str:
         """
-        Generate raw model text. We *do not* call removed/unstable generator APIs like set_stop_strings.
-        We post-trim in Python using `stop` markers (e.g., "```").
+        Version-tolerant generation:
+        - Builds compatible sampling settings
+        - Calls generate_simple() with correct signature
+        - Applies client-side stop strings
         """
-        max_new = int(max_new_tokens)
-        prompt = self._truncate_prompt_to_fit(prompt, max_new)
+        # defensive crop: prevent overlong prompts w.r.t. cache
+        # (ExLlamaV2 caches KV; we ensure prompt tokens fit)
+        # Tokenize to check length
+        ids = self.tokenizer.encode(prompt)
+        if ids.shape[-1] > self.max_seq_len - 64:
+            # trim tokens to leave headroom for generation
+            ids = ids[:, -(self.max_seq_len - 64):]
+            prompt = self.tokenizer.decode(ids)
 
-        # Build sampling settings every call (cheap & side-effect free)
-        s = ExLlamaV2SamplingSettings()
-        s.temperature = float(temperature if temperature is not None else self._temperature)
-        s.top_p = float(top_p if top_p is not None else self._top_p)
-        # A couple of sensible defaults for SQL
-        s.token_repetition_penalty = 1.05
-        s.disallow_tokens = None  # keep simple
+        settings = _build_settings(temperature, top_p)
 
-        # exllamav2 >= 0.2 expects (text, settings, num_tokens)
-        text = self._generator.generate_simple(prompt, s, max_new)
+        # Inspect generate_simple signature
+        sig = inspect.signature(self.generator.generate_simple)
+        params = list(sig.parameters.keys())
 
-        # Apply simple stop trimming client-side
+        # Some versions: generate_simple(prompt, num_tokens)
+        # Others:        generate_simple(prompt, settings, num_tokens)
+        if len(params) == 3:
+            # (self, prompt, settings, num_tokens)
+            text = self.generator.generate_simple(prompt, settings, int(max_new_tokens))
+        elif len(params) == 2:
+            # (self, prompt, num_tokens)
+            text = self.generator.generate_simple(prompt, int(max_new_tokens))
+        else:
+            # unknown variant: try the 3-arg form first
+            try:
+                text = self.generator.generate_simple(prompt, settings, int(max_new_tokens))
+            except TypeError:
+                text = self.generator.generate_simple(prompt, int(max_new_tokens))
+
+        # Client-side stop handling
         if stop:
-            text = _cut_at_first(text, stop)
+            if isinstance(stop, str):
+                stop = [stop]
+            for s in stop:
+                if not s:
+                    continue
+                idx = text.find(s)
+                if idx != -1:
+                    text = text[:idx]
+                    break
 
         return text
 
 
-def load_exllama_generator(model_dir: str) -> SQLCoderExL2:
+def load_exllama_generator(path: str):
     """
-    Create and return a SQLCoderExL2 (generator+tokenizer+cache bundle).
-    Environment knobs:
-      - EXL2_GPU_SPLIT_GB="29,2"     # optional autosplit across GPUs
-      - EXL2_CACHE_MAX_SEQ_LEN=2048  # cache length
-      - EXL2_INPUT_RESERVE_TOKENS=64 # budget for system suffixes/stops
+    Factory used by model_loader.py
+    Returns a dict { 'model': SQLCoderExLlama, 'backend': 'exllama', 'path': path }
     """
-    log.info("Loading ExLlamaV2 model: %s", model_dir)
-
-    # 1) Config
-    cfg = ExLlamaV2Config()
-    cfg.model_dir = model_dir
-    cfg.prepare()
-
-    # 2) Model
-    model = ExLlamaV2(cfg)
-
-    split = _parse_gpu_split(os.getenv("EXL2_GPU_SPLIT_GB", "").strip())
-    if split:
-        model.load_autosplit(split)
-        log.info("ExLlamaV2 weights loaded (autosplit): %s", split)
-    else:
-        model.load()
-        log.info("ExLlamaV2 weights loaded (single device)")
-
-    # 3) Tokenizer
-    tokenizer = ExLlamaV2Tokenizer(cfg)
-
-    # 4) Cache + Generator
-    cache_len = int(os.getenv("EXL2_CACHE_MAX_SEQ_LEN", "2048"))
-    cache = ExLlamaV2Cache(model, cache_len)
-
-    generator = ExLlamaV2BaseGenerator(model, cache, tokenizer)
-
-    # 5) Wrap
-    reserve = int(os.getenv("EXL2_INPUT_RESERVE_TOKENS", "64"))
-    wrapper = SQLCoderExL2(
-        generator=generator,
-        tokenizer=tokenizer,
-        cache=cache,
-        input_reserve_tokens=reserve,
-        model_name=os.path.basename(model_dir.rstrip("/")),
-    )
-    log.info("ExLlamaV2 model ready (cache_len=%d, reserve=%d)", cache_len, reserve)
-    return wrapper
+    mdl = SQLCoderExLlama(path)
+    return {
+        "backend": "exllama",
+        "path": path,
+        "handle": mdl
+    }


### PR DESCRIPTION
## Summary
- replace the ExLlama adapter with a version-tolerant wrapper that inspects the installed APIs at runtime and applies client-side stop handling
- simplify the SQL model loader to delegate to the new wrapper bundle
- update the DW application to reuse shared generation defaults when calling the SQL model

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cf43d2903c8323b19e00e4af1267dd