### PR TITLE
Harden ExLlama SQL loader and improve DW logging

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -45,7 +45,7 @@ def _insert_inquiry(conn, namespace: str, question: str, auth_email: str, prefix
     stmt = text(
         """
         INSERT INTO mem_inquiries(namespace, question, auth_email, prefixes, status, created_at, updated_at)
-        VALUES (:ns, :q, :auth, CAST(:pfx AS JSONB), 'open', NOW(), NOW())
+        VALUES (:ns, :q, :auth, CAST(:pfx AS jsonb), 'open', NOW(), NOW())
         RETURNING id
         """
     )
@@ -145,6 +145,8 @@ def answer():
             for key, value in (binds or {}).items()
         }
         current_app.logger.info("[dw] exec_binds: %s", json.dumps(safe_binds, default=str))
+        current_app.logger.info("[dw] final_sql: %s", sql)
+        current_app.logger.info("[dw] execution_binds: %s", safe_binds)
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- replace the SQLCoder ExLlama wrapper with a version that tolerates API shifts, budgets cache-friendly token counts, and configures sampling defaults safely
- simplify the SQL model loader to reuse the new wrapper while keeping clarifier payloads compatible with get_model consumers
- ensure DW inquiries store JSON prefixes correctly and log final SQL text/binds, and tighten SQL prompting/generation limits for the data warehouse app

## Testing
- python -m compileall core apps/dw

------
https://chatgpt.com/codex/tasks/task_e_68cfa12b3d1c8323b8a541b8ea7e9052