### PR TITLE
Improve DW SQL sanitization and validation

### DIFF
--- a/offline-reqs.txt
+++ b/offline-reqs.txt
@@ -35,6 +35,7 @@ PyMySQL==1.1.1
 python-dotenv==1.1.1
 numpy==2.3.2
 pandas==2.3.1
+sqlglot==26.12.1
 pillow==11.3.0
 pyarrow==21.0.0
 PyYAML==6.0.2


### PR DESCRIPTION
## Summary
- add Oracle-oriented SQL sanitization, parsing, and clarifier JSON helpers in `core.sql_utils`
- apply the sanitizer/validator in the DW answer pipeline with a strict retry and clarifier heuristics
- add sqlglot as a dependency for Oracle SQL parsing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfcc9ffa4c8323a3aaa5f769c45245