### PR TITLE
Harden DW SQL sanitization and executor safeguards

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -245,7 +245,7 @@ def answer():
     if parse_error:
         strict_raw = _strict_retry()
         if strict_raw:
-            sql_final = sanitize_oracle_sql(strict_raw, *sql_candidates)
+            sql_final = sanitize_oracle_sql(strict_raw)
             parse_error = _oracle_parse_error(sql_final)
 
     sql_payload = {"size": len(sql_final)}


### PR DESCRIPTION
## Summary
- tighten Oracle SQL extraction and validation helpers to strip instructions and reject SELECT statements without FROM clauses
- ensure DW SQL execution paths sanitize/validate model output before explaining or executing, and add a guarded executor helper
- rely on the strict retry output alone when the initial DW SQL parse fails to avoid falling back to invalid statements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cff6eba6188323b591198f3763ed0a