### PR TITLE
Refine logging to single configuration and structured events

### DIFF
--- a/core/logging_setup.py
+++ b/core/logging_setup.py
@@ -1,22 +1,29 @@
+from __future__ import annotations
 import json
 import logging
+from typing import Any, Optional
 
-from core.logging_utils import setup_root_logging
+from core.logging_utils import log_event, setup_logging
 
 
-def init_logging(app=None):
+def init_logging(app=None, settings: Optional[Any] = None) -> None:
     """Ensure the root logger is configured and Flask logs propagate once."""
 
-    setup_root_logging()
+    setup_logging(settings)
 
     if app is not None:
-        app.logger.handlers = []
-        app.logger.setLevel(logging.getLogger().level)
-        app.logger.propagate = True
+        try:
+            app.logger.handlers.clear()
+            app.logger.setLevel(logging.getLogger().level)
+            app.logger.propagate = True
+        except Exception:  # pragma: no cover - defensive
+            pass
 
 
-def log_kv(logger, tag, payload):
+def log_kv(logger, tag, payload) -> None:
+    data = payload if isinstance(payload, dict) else {"value": payload}
     try:
-        logger.info("%s: %s", tag, json.dumps(payload, default=str)[:4000])
-    except Exception:
+        # Preserve legacy behaviour but route through structured logging
+        log_event(logger, "kv", tag, json.loads(json.dumps(data, default=str)))
+    except Exception:  # pragma: no cover - defensive
         logger.info("%s: %r", tag, payload)


### PR DESCRIPTION
## Summary
- centralize logging setup so stdout and date-stamped file handlers are registered exactly once via `core/logging_utils`
- ensure Flask bootstrap and legacy helpers rely on the shared logging configuration and emit boot diagnostics with channels
- instrument the DocuWare route, LLM helpers, and pipeline with `log_event` milestones covering clarifier, prompt, validation, execution, and status transitions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cffc5c42c48323a8fda4e041928540