### PR TITLE
Improve DW date window binding

### DIFF
--- a/core/sql_utils.py
+++ b/core/sql_utils.py
@@ -49,6 +49,16 @@ _BAD_PREFIXES = (
     "SELECT (or CTE)",
 )
 
+_BIND_RE = re.compile(r":([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def extract_bind_names(sql: str) -> list[str]:
+    """Return a sorted list of distinct bind names (Oracle style :name)."""
+
+    if not sql:
+        return []
+    return sorted(set(_BIND_RE.findall(sql)))
+
 
 def extract_sql_one_stmt(text: str, dialect: str = "generic") -> str:
     """


### PR DESCRIPTION
## Summary
- add DW-side helpers to derive common date windows such as next/last N days, month, and quarter
- ensure the DW answer route inspects final SQL for bind names, derives :date_start/:date_end windows, and logs execution binds before running queries

## Testing
- python -m compileall apps/dw core

------
https://chatgpt.com/codex/tasks/task_e_68d01330c62c8323bfc278e08a6a97f9