### PR TITLE
Implement deterministic DW SQL fallback and add golden tests

### DIFF
--- a/tests/dw_golden.json
+++ b/tests/dw_golden.json
@@ -1,0 +1,29 @@
+[
+  {
+    "q": "Contracts with END_DATE in the next 90 days.",
+    "shape": "select_all_window",
+    "date_col": "END_DATE"
+  },
+  {
+    "q": "contracts expiring in 30 days (count)",
+    "shape": "count_window",
+    "date_col": "END_DATE"
+  },
+  {
+    "q": "top 10 stakeholders by contract value last 3 months",
+    "shape": "group_topn",
+    "group_dim": "CONTRACT_STAKEHOLDER_1",
+    "value": "net"
+  },
+  {
+    "q": "Total gross value of contracts per owner department last quarter",
+    "shape": "group_sum",
+    "group_dim": "OWNER_DEPARTMENT",
+    "value": "gross"
+  },
+  {
+    "q": "contracts last month",
+    "shape": "select_all_window",
+    "date_col": "REQUEST_DATE"
+  }
+]


### PR DESCRIPTION
## Summary
- add reusable helpers to detect DW intents, sanitize raw SQL, and build deterministic fallback queries
- update the /dw/answer route to sanitize LLM output, enforce the fallback generator, and surface new debugging metadata
- capture representative DW prompts in a dw_golden.json fixture for future regression checks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1696c2e6c8323a1112ba518e970a1