### PR TITLE
Handle VAT rate and top-N logic for DW fallback

### DIFF
--- a/apps/dw/tests/test_dw_golden.py
+++ b/apps/dw/tests/test_dw_golden.py
@@ -114,9 +114,25 @@ def test_maybe_rewrite_sql_for_top_n():
         "top_n": 10,
         "sort_by": "CONTRACT_VALUE_NET_OF_VAT",
         "sort_desc": True,
+        "user_requested_top_n": True,
     }
     rewritten, meta, _ = app_module._maybe_rewrite_sql_for_intent(sql, intent)
     assert "ORDER BY CONTRACT_VALUE_NET_OF_VAT DESC" in rewritten
     assert "FETCH FIRST :top_n ROWS ONLY" in rewritten
     assert meta["used_limit_inject"] is True
+    assert meta["used_order_inject"] is True
+
+
+def test_maybe_rewrite_sql_skips_limit_when_not_requested():
+    sql = 'SELECT * FROM "Contract"'
+    intent = {
+        "top_n": 10,
+        "sort_by": "CONTRACT_VALUE_NET_OF_VAT",
+        "sort_desc": True,
+        "user_requested_top_n": False,
+    }
+    rewritten, meta, _ = app_module._maybe_rewrite_sql_for_intent(sql, intent)
+    assert "ORDER BY CONTRACT_VALUE_NET_OF_VAT DESC" in rewritten
+    assert "FETCH FIRST :top_n ROWS ONLY" not in rewritten
+    assert meta["used_limit_inject"] is False
     assert meta["used_order_inject"] is True


### PR DESCRIPTION
## Summary
- update DW gross value calculations to treat VAT as either an amount or a rate on a per-row basis
- guard DW fallback SQL to only apply top-N limits when explicitly requested and to normalize date columns and owner department grouping
- adjust DW SQL rewrite logic and tests to respect the explicit top-N requirement

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d16bc598a48323a94c8589832a5805