### PR TITLE
feat(dw): deterministic grouping and projection planner

### DIFF
--- a/apps/dw/lexicon.py
+++ b/apps/dw/lexicon.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import re
+
+# Dimension synonyms → column names (DW "Contract" table)
+DIMENSION_MAP = {
+    "owner department": "OWNER_DEPARTMENT",
+    "department": "OWNER_DEPARTMENT",
+    "entity": "ENTITY_NO",
+    "owner": "CONTRACT_OWNER",
+    "stakeholder": "CONTRACT_STAKEHOLDER_1",
+    "status": "CONTRACT_STATUS",
+}
+
+# Natural language → selectable columns
+PROJECTION_MAP = {
+    "contract id": "CONTRACT_ID",
+    "id": "CONTRACT_ID",
+    "owner": "CONTRACT_OWNER",
+    "owner department": "OWNER_DEPARTMENT",
+    "request date": "REQUEST_DATE",
+    "start date": "START_DATE",
+    "end date": "END_DATE",
+    "status": "CONTRACT_STATUS",
+    "net value": "CONTRACT_VALUE_NET_OF_VAT",
+    "contract value": "CONTRACT_VALUE_NET_OF_VAT",
+    "vat": "VAT",
+    # special token; expanded into expression when building SQL
+    "gross value": "__GROSS__",
+}
+
+EXPIRE_WORDS = re.compile(r"\b(expire|expiring)\b", re.I)
+REQUESTED_WORDS = re.compile(r"\b(requested|request date)\b", re.I)

--- a/core/nlu/projection.py
+++ b/core/nlu/projection.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, List
+
+
+def extract_projection(question: str, mapping: Dict[str, str]) -> List[str]:
+    """
+    Heuristically extract an ordered list of requested columns from a question.
+    Looks for parentheses "(a, b, c)" and phrases like "columns/fields/show/select a, b".
+    Returns uppercase column names using `mapping` (unknown tokens are ignored).
+    """
+    q = (question or "").strip()
+    wanted: List[str] = []
+    parts: List[str] = []
+
+    # (1) Parentheses e.g. "... (contract id, owner, request date)"
+    m = re.search(r"\(([^()]+)\)", q)
+    if m:
+        parts += re.split(r"[,\|/]+", m.group(1))
+
+    # (2) After cue words
+    cue = re.search(r"\b(columns?|fields?|include|show|select)\b[:\- ]+(.+)$", q, re.I)
+    if cue:
+        parts += re.split(r"[,\|/]+", cue.group(2))
+
+    for p in parts:
+        t = re.sub(r"\s+", " ", p.strip().lower())
+        if not t:
+            continue
+        col = mapping.get(t)
+        if col:
+            wanted.append(col)
+
+    # Deduplicate preserving order
+    seen, ordered = set(), []
+    for c in wanted:
+        if c not in seen:
+            seen.add(c)
+            ordered.append(c)
+    return ordered


### PR DESCRIPTION
## Summary
- add a DW lexicon of dimension synonyms and natural-language projection mappings
- introduce a projection extractor that pulls ordered column requests from questions
- wire a deterministic DW SQL planner that honors the lexicon, projection hints, and refined date semantics before falling back to the LLM path

## Testing
- pytest tests/apps/dw -q *(fails: file or directory not found)*
- pytest -q *(fails: ModuleNotFoundError: No module named 'dateutil')*


------
https://chatgpt.com/codex/tasks/task_e_68d320fe16d883239dce562019224ca7