### PR TITLE
Add rating flow with rerun logging and planner tweaks

### DIFF
--- a/apps/dw/intent.py
+++ b/apps/dw/intent.py
@@ -227,6 +227,15 @@ def parse_intent(q: str, default_date_col: str = "START_DATE") -> DWIntent:
     elif intent.window_kind == "overlap" and not intent.has_time_window and default_date_col:
         intent.date_column = default_date_col
 
+    # Group-by heuristics: default to aggregates to avoid projecting every column.
+    if intent.group_by and not intent.agg:
+        if RE_COUNT.search(t):
+            intent.agg = "count"
+        elif intent.group_by == "CONTRACT_STATUS":
+            intent.agg = "count"
+        else:
+            intent.agg = "sum"
+
     # wants_all_columns only when not aggregated
     if intent.group_by or intent.agg in ("count", "sum", "avg"):
         intent.wants_all_columns = False


### PR DESCRIPTION
## Summary
- add reusable inquiry helpers for rating persistence, alerting, and run logging
- log DocuWare runs with attempt metadata, expose run_id/attempt info in responses, and add a /dw/rate endpoint that triggers low-rating retries with optional alerts
- tune DW intent heuristics and date-window helpers to prefer grouped aggregates and remain robust when dateutil is unavailable

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d329f71bf883239dd11e34bf223102