### PR TITLE
Improve DW intent parsing and overlap semantics

### DIFF
--- a/apps/dw/intent.py
+++ b/apps/dw/intent.py
@@ -13,12 +13,12 @@ from .utils import (
 )
 
 
-_TOP_N = re.compile(r"\btop\s+(\d+)\b", re.I)
+_TOP = re.compile(r"\btop\s*(\d+)\b", re.I)
 _COUNT = re.compile(r"\bcount\b|\(count\)", re.I)
 _GROSS = re.compile(r"\bgross\b", re.I)
 _NET = re.compile(r"\bnet\b|\bcontract value\b", re.I)
 _BY = re.compile(r"\bby\s+([a-zA-Z_ ]+)|\bper\s+([a-zA-Z_ ]+)", re.I)
-_EXPIRE = re.compile(r"\bexpiring?\b|\bexpire\b|\bexpires\b", re.I)
+_EXPIRE = re.compile(r"\bexpir\w*\b", re.I)
 _LAST_N_MONTHS = re.compile(r"\blast\s+(\d+)\s+months?\b", re.I)
 _LAST_MONTH = re.compile(r"\blast\s+month\b", re.I)
 _LAST_N_DAYS = re.compile(r"\blast\s+(\d+)\s+days?\b", re.I)
@@ -26,24 +26,32 @@ _THREE_MONTHS = re.compile(r"\blast\s+3\s+months?\b", re.I)
 _BY_STATUS = re.compile(r"\bby\s+status\b", re.I)
 _LIST_COLS = re.compile(r"\(([^)]+)\)\s*$")
 
+# Date / dimension cues
+_REQ_CUES = re.compile(r"\b(request(ed)?|requested|request date|submitted)\b", re.I)
+_START_CUES = re.compile(r"\b(start(s|ed|ing)?|begin(s|ning)?)\b", re.I)
+_END_CUES = re.compile(r"\b(end(s|ed|ing)?|expire(s|d|ing)?|expiry|expiring)\b", re.I)
+_CONTRACTS = re.compile(r"\bcontract(s)?\b", re.I)
+_STAKE = re.compile(r"\bstakeholder(s)?\b", re.I)
+_DEPT = re.compile(r"\b(owner\s*department|department)\b", re.I)
+_OUL = re.compile(r"\b(oul|manager|department_oul)\b", re.I)
+_ENTITY = re.compile(r"\b(entity|entity\s*no)\b", re.I)
+
 
 @dataclass
 class NLIntent:
-    # core
-    has_time_window: Optional[bool] = None
     date_column: Optional[str] = None
     explicit_dates: Optional[Dict[str, str]] = None
+    has_time_window: Optional[bool] = None
     top_n: Optional[int] = None
-    agg: Optional[str] = None
-    group_by: Optional[str] = None
     sort_by: Optional[str] = None
     sort_desc: Optional[bool] = None
+    group_by: Optional[str] = None
+    agg: Optional[str] = None
+    measure_sql: Optional[str] = None
     wants_all_columns: Optional[bool] = None
     user_requested_top_n: Optional[bool] = None
-    # semantics
-    measure_sql: Optional[str] = None
-    expire: Optional[bool] = None
     notes: Dict[str, Any] = field(default_factory=dict)
+    expire: Optional[bool] = None
 
 
 def normalize_dimension(dim: str) -> Optional[str]:
@@ -60,91 +68,105 @@ def normalize_dimension(dim: str) -> Optional[str]:
         return "CONTRACT_OWNER"
     if "status" in d:
         return "CONTRACT_STATUS"
+    if "oul" in d or "manager" in d:
+        return "DEPARTMENT_OUL"
     return None
+
+
+def _set_window(intent: NLIntent, start: str, end: str) -> None:
+    intent.has_time_window = True
+    intent.explicit_dates = {"start": start, "end": end}
 
 
 def parse_intent(q: str) -> NLIntent:
     q = (q or "").strip()
     now = today_utc()
-    it = NLIntent()
-    it.notes["q"] = q
+    intent = NLIntent(notes={"q": q})
 
-    m = _TOP_N.search(q)
+    m = _TOP.search(q)
     if m:
-        it.top_n = int(m.group(1))
-        it.user_requested_top_n = True
+        intent.top_n = int(m.group(1))
+        intent.user_requested_top_n = True
 
     if _COUNT.search(q):
-        it.agg = "count"
+        intent.agg = "count"
 
     if _GROSS.search(q):
-        it.measure_sql = (
-            "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + "
-            "CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
-            "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0) * NVL(VAT,0) "
-            "ELSE NVL(VAT,0) END"
+        intent.measure_sql = (
+            "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
+            "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0) * NVL(VAT,0) ELSE NVL(VAT,0) END"
         )
-    elif _NET.search(q):
-        it.measure_sql = "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
+    else:
+        intent.measure_sql = "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
 
-    m = _BY.search(q)
-    if m:
-        dim = m.group(1) or m.group(2) or ""
-        it.group_by = normalize_dimension(dim)
-    elif _BY_STATUS.search(q):
-        it.group_by = "CONTRACT_STATUS"
-        if it.agg is None:
-            it.agg = "count"
+    if _STAKE.search(q):
+        intent.group_by = "CONTRACT_STAKEHOLDER_1"
+    elif _DEPT.search(q):
+        intent.group_by = "OWNER_DEPARTMENT"
+    elif _OUL.search(q):
+        intent.group_by = "DEPARTMENT_OUL"
+    elif _ENTITY.search(q):
+        intent.group_by = "ENTITY_NO"
+    else:
+        m = _BY.search(q)
+        if m:
+            dim = (m.group(1) or m.group(2) or "").strip()
+            gb = normalize_dimension(dim)
+            if gb:
+                intent.group_by = gb
+        elif _BY_STATUS.search(q):
+            intent.group_by = "CONTRACT_STATUS"
+            if intent.agg is None:
+                intent.agg = "count"
+
+    intent.sort_by = intent.measure_sql
+    intent.sort_desc = True
 
     if _EXPIRE.search(q):
-        it.expire = True
-        it.has_time_window = True
-        start, end = last_n_days(30, now)
-        it.explicit_dates = {"start": start, "end": end}
-        it.date_column = "END_DATE"
+        intent.expire = True
 
     if _LAST_MONTH.search(q):
-        it.has_time_window = True
         start, end = last_month(now)
-        it.explicit_dates = {"start": start, "end": end}
+        _set_window(intent, start, end)
     elif _THREE_MONTHS.search(q):
-        it.has_time_window = True
         start, end = last_n_months(3, now)
-        it.explicit_dates = {"start": start, "end": end}
+        _set_window(intent, start, end)
     else:
         m = _LAST_N_MONTHS.search(q)
         if m:
-            it.has_time_window = True
             n = int(m.group(1))
             start, end = last_n_months(n, now)
-            it.explicit_dates = {"start": start, "end": end}
+            _set_window(intent, start, end)
         m = _LAST_N_DAYS.search(q)
         if m:
-            it.has_time_window = True
             n = int(m.group(1))
             start, end = last_n_days(n, now)
-            it.explicit_dates = {"start": start, "end": end}
+            _set_window(intent, start, end)
 
-    if mentions_requested(q):
-        it.date_column = it.date_column or "REQUEST_DATE"
+    if intent.expire and not intent.explicit_dates:
+        start, end = last_n_days(30, now)
+        _set_window(intent, start, end)
+
+    if mentions_requested(q) or _REQ_CUES.search(q):
+        intent.date_column = "REQUEST_DATE"
+    elif _START_CUES.search(q):
+        intent.date_column = "START_DATE"
+    elif intent.expire or _END_CUES.search(q):
+        intent.date_column = "END_DATE"
     else:
-        if it.has_time_window and not it.expire:
-            it.date_column = it.date_column or None
+        intent.date_column = "OVERLAP"
 
-    if it.wants_all_columns is None:
-        it.wants_all_columns = True
-    if it.sort_desc is None:
-        it.sort_desc = True
-    if (it.measure_sql is None and it.agg in ("sum", "avg")) or ("top" in q.lower()):
-        it.measure_sql = "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
+    if intent.expire:
+        intent.has_time_window = True
 
-    if it.user_requested_top_n and not it.group_by:
-        it.group_by = "CONTRACT_STAKEHOLDER_1"
+    if intent.wants_all_columns is None:
+        intent.wants_all_columns = intent.group_by is None
 
     m = _LIST_COLS.search(q)
     if m:
-        cols = [c.strip().upper().replace(" ", "_") for c in m.group(1).split(",")]
-        it.notes["projection"] = cols
-        it.wants_all_columns = False
+        cols = [c.strip().upper().replace(" ", "_") for c in m.group(1).split(",") if c.strip()]
+        if cols:
+            intent.notes["projection"] = cols
+            intent.wants_all_columns = False
 
-    return it
+    return intent

--- a/apps/dw/sql_builders.py
+++ b/apps/dw/sql_builders.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+import os
+
+
+STRICT_OVERLAP = os.getenv("DW_STRICT_OVERLAP", "0").lower() in {"1", "true", "yes"}
+
+
+def overlap_predicate() -> str:
+    """Return the contract/activity window overlap predicate."""
+    if STRICT_OVERLAP:
+        return "(START_DATE <= :date_end AND END_DATE >= :date_start)"
+    return (
+        "((START_DATE IS NULL OR START_DATE <= :date_end) "
+        "AND (END_DATE IS NULL OR END_DATE >= :date_start))"
+    )
+
+
+def window_predicate(date_column: str) -> str:
+    col = (date_column or "").upper()
+    if col == "REQUEST_DATE":
+        return "REQUEST_DATE BETWEEN :date_start AND :date_end"
+    if col == "START_DATE":
+        return "START_DATE BETWEEN :date_start AND :date_end"
+    if col == "END_DATE":
+        return "END_DATE BETWEEN :date_start AND :date_end"
+    return overlap_predicate()
+
+
+def build_top_contracts_sql(measure_sql: str, date_semantics: str, select_all: bool) -> str:
+    where = window_predicate(date_semantics)
+    if select_all:
+        select = "*"
+    else:
+        select = (
+            "CONTRACT_ID, CONTRACT_OWNER, OWNER_DEPARTMENT, DEPARTMENT_OUL, "
+            "ENTITY_NO, {measure} AS MEASURE, START_DATE, END_DATE"
+        ).format(measure=measure_sql)
+    return (
+        f'SELECT {select} FROM "Contract"\n'
+        f'WHERE {where}\n'
+        f'ORDER BY {measure_sql} DESC\n'
+        f'FETCH FIRST :top_n ROWS ONLY'
+    )
+
+
+def build_grouped_sql(
+    group_by: str,
+    agg: str,
+    measure_sql: str,
+    date_semantics: str,
+    top_n: int | None,
+) -> str:
+    where = window_predicate(date_semantics)
+    agg = (agg or "sum").lower()
+    if agg == "count":
+        agg_expr = "COUNT(*)"
+        metric = "CNT"
+    else:
+        agg_expr = f"SUM({measure_sql})"
+        metric = "MEASURE"
+    limit = "\nFETCH FIRST :top_n ROWS ONLY" if top_n else ""
+    return (
+        f"SELECT NVL({group_by}, '(Unknown)') AS GROUP_KEY, {agg_expr} AS {metric}\n"
+        f'FROM "Contract"\n'
+        f"WHERE {where}\n"
+        f"GROUP BY NVL({group_by}, '(Unknown)')\n"
+        f"ORDER BY {metric} DESC{limit}"
+    )
+
+
+def build_count_expiring_soon(days: int) -> Tuple[str, Dict[str, int]]:
+    sql = (
+        'SELECT COUNT(*) AS CNT\n'
+        'FROM "Contract"\n'
+        "WHERE END_DATE BETWEEN TRUNC(SYSDATE) AND TRUNC(SYSDATE) + :days"
+    )
+    return sql, {"days": days}
+
+
+def build_scan_all_sql(text_columns: List[str]) -> str:
+    if not text_columns:
+        raise ValueError("text_columns required for scan")
+    ors = " OR ".join([f"UPPER({col}) LIKE UPPER(:scan_pat)" for col in text_columns])
+    return (
+        f'SELECT * FROM "Contract"\n'
+        f"WHERE {ors}\n"
+        f"ORDER BY REQUEST_DATE DESC\n"
+        f"FETCH FIRST 200 ROWS ONLY"
+    )
+


### PR DESCRIPTION
## Summary
- enhance DocuWare intent parsing to recognise explicit date cues, grouping synonyms, and default overlap semantics while keeping projection handling intact
- add shared SQL builder utilities for overlap predicates, grouped aggregation, top-contract queries, and safety-checked scan helpers
- update SQL builder to reuse the new overlap window logic and ensure top-N contract queries order by the requested measure

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d4ebf2445c8323ac69994ed5333314