### PR TITLE
Add configurable full text search support for DW queries

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -58,6 +58,7 @@ def answer():
     prefixes = data.get("prefixes") or []
     auth_email = (data.get("auth_email") or "").strip()
     namespace = data.get("namespace") or NAMESPACE
+    fts_requested = data.get("full_text_search")
 
     if not question:
         return jsonify({"ok": False, "error": "question required"}), 400
@@ -81,7 +82,13 @@ def answer():
         json.dumps({"id": inquiry_id, "q": question, "email": auth_email, "ns": namespace, "prefixes": prefixes}),
     )
 
-    result = run_attempt(question, namespace, attempt_no=1, strategy="deterministic")
+    result = run_attempt(
+        question,
+        namespace,
+        attempt_no=1,
+        strategy="deterministic",
+        full_text_search=fts_requested,
+    )
 
     with mem_engine.begin() as cx:
         cx.execute(

--- a/apps/dw/attempts.py
+++ b/apps/dw/attempts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 import time
 from typing import Any, Dict, Tuple
 
@@ -17,6 +18,12 @@ except Exception:  # pragma: no cover
 
 from .builder import build_sql
 from .intent import NLIntent, parse_intent
+from .search import (
+    build_fulltext_where,
+    extract_search_tokens,
+    inject_fulltext_where,
+    is_fulltext_allowed,
+)
 from .utils import env_flag
 
 
@@ -40,10 +47,20 @@ def run_attempt(
     namespace: str,
     attempt_no: int,
     strategy: str = "deterministic",
+    full_text_search: bool | None = None,
 ) -> Dict[str, Any]:
     app = current_app
-    logger = app.logger
+    logger = getattr(app, "logger", None)
     intent: NLIntent = parse_intent(question)
+    allow_fts = is_fulltext_allowed()
+    if allow_fts:
+        default_on = env_flag("DW_FTS_DEFAULT_ON", False)
+        if full_text_search is None:
+            intent.full_text_search = default_on
+        else:
+            intent.full_text_search = bool(full_text_search)
+    else:
+        intent.full_text_search = False
     if strategy == "det_overlaps_gross":
         intent.measure_sql = (
             "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + "
@@ -55,6 +72,53 @@ def run_attempt(
             intent.date_column = None
 
     sql, binds = build_sql(intent)
+
+    fts_meta: Dict[str, Any] = {
+        "enabled": bool(intent.full_text_search),
+        "tokens": None,
+        "columns": None,
+        "binds": None,
+        "error": None,
+    }
+
+    engine = app.config.get("DW_ENGINE") if app else None
+    if intent.full_text_search and engine is not None:
+        try:
+            tokens = extract_search_tokens(question)
+            if tokens:
+                table_name = os.getenv("DW_FTS_TABLE", "Contract")
+                schema = os.getenv("DW_FTS_SCHEMA") or None
+                predicate, fts_binds, columns = build_fulltext_where(
+                    engine, table_name, tokens, schema=schema
+                )
+                if predicate:
+                    sql = inject_fulltext_where(sql, predicate)
+                    binds.update(fts_binds)
+                    fts_meta.update(
+                        {
+                            "tokens": tokens,
+                            "columns": columns,
+                            "binds": list(fts_binds.keys()),
+                        }
+                    )
+            else:
+                fts_meta["error"] = "no_tokens"
+        except Exception as exc:  # pragma: no cover - defensive guard
+            fts_meta["error"] = str(exc)
+    elif intent.full_text_search and engine is None:
+        fts_meta["error"] = "no_engine"
+
+    _log(
+        logger,
+        "fts",
+        {
+            "enabled": fts_meta["enabled"],
+            "tokens": fts_meta.get("tokens"),
+            "columns": fts_meta.get("columns"),
+            "binds": fts_meta.get("binds"),
+            "error": fts_meta.get("error"),
+        },
+    )
     _log(logger, "final_sql", {"size": len(sql), "sql": sql})
     _log(
         logger,
@@ -66,7 +130,7 @@ def run_attempt(
         time.sleep(0.15)
     rows, cols = (
         _execute_sql(app.config["DW_ENGINE"], sql, binds)
-        if "DW_ENGINE" in app.config
+        if app and "DW_ENGINE" in app.config
         else ([], [])
     )
 
@@ -82,6 +146,7 @@ def run_attempt(
             "rowcount": len(rows),
             "attempt_no": attempt_no,
             "strategy": strategy,
+            "fts": fts_meta,
         },
         "debug": {
             "intent": intent.__dict__,
@@ -92,6 +157,7 @@ def run_attempt(
                 "binds": list(binds.keys()),
                 "bind_names": list(binds.keys()),
             },
+            "fts": fts_meta,
         },
     }
     return result

--- a/apps/dw/intent.py
+++ b/apps/dw/intent.py
@@ -50,6 +50,7 @@ class NLIntent:
     measure_sql: Optional[str] = None
     wants_all_columns: Optional[bool] = None
     user_requested_top_n: Optional[bool] = None
+    full_text_search: bool = False
     notes: Dict[str, Any] = field(default_factory=dict)
     expire: Optional[bool] = None
 

--- a/apps/dw/search.py
+++ b/apps/dw/search.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Tuple
+
+try:  # pragma: no cover - optional dependency
+    from sqlalchemy import inspect
+    from sqlalchemy.engine import Engine
+    from sqlalchemy.sql.sqltypes import String, Text
+except Exception:  # pragma: no cover - lightweight fallback
+    inspect = None  # type: ignore[assignment]
+    Engine = object  # type: ignore[assignment]
+
+    class _DummyType:  # pragma: no cover - sentinel for isinstance checks
+        pass
+
+    String = Text = _DummyType  # type: ignore[assignment]
+
+from .utils import env_flag, env_int
+
+_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "by",
+    "for",
+    "of",
+    "to",
+    "in",
+    "on",
+    "at",
+    "with",
+    "last",
+    "next",
+    "this",
+    "that",
+    "these",
+    "those",
+    "and",
+    "or",
+    "per",
+    "value",
+    "contract",
+    "contracts",
+}
+
+
+_QUOTE_PATTERN = re.compile(r'"([^"]+)"|“([^”]+)”|\'([^\']+)\'')
+_WORD_PATTERN = re.compile(r"[A-Za-z0-9_]+")
+
+
+def _normalise_token(token: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9_ ]+", " ", token or "").strip().lower()
+    return re.sub(r"\s+", " ", cleaned)
+
+
+def extract_search_tokens(question: str, min_len: int | None = None) -> List[str]:
+    """Tokenise a natural language question for full-text search."""
+
+    if not question:
+        return []
+
+    min_len = min_len if min_len is not None else env_int("DW_FTS_MIN_TOKEN_LEN", 3)
+
+    tokens: List[str] = []
+    seen: set[str] = set()
+
+    remainder_parts: List[str] = []
+    last_index = 0
+    for match in _QUOTE_PATTERN.finditer(question):
+        phrase = next((g for g in match.groups() if g), "")
+        norm = _normalise_token(phrase)
+        if norm and len(norm.replace(" ", "")) >= min_len and norm not in seen:
+            seen.add(norm)
+            tokens.append(norm)
+        remainder_parts.append(question[last_index : match.start()])
+        last_index = match.end()
+    remainder_parts.append(question[last_index:])
+
+    remainder = " ".join(remainder_parts).lower()
+    for word in _WORD_PATTERN.findall(remainder):
+        if word in _STOPWORDS or len(word) < min_len:
+            continue
+        if word not in seen:
+            seen.add(word)
+            tokens.append(word)
+
+    return tokens
+
+
+def _string_columns(
+    engine: Engine,
+    table_name: str,
+    schema: str | None = None,
+    max_cols: int | None = None,
+) -> List[str]:
+    if inspect is None:  # pragma: no cover - fallback when SQLAlchemy missing
+        return []
+
+    try:
+        insp = inspect(engine)
+        cols = insp.get_columns(table_name, schema=schema)
+    except Exception:
+        return []
+
+    names: List[str] = []
+    for col in cols:
+        col_type = col.get("type")
+        if isinstance(col_type, (String, Text)):
+            names.append(col["name"])
+    limit = max_cols if max_cols is not None else env_int("DW_FTS_MAX_COLS", 80)
+    return names[:limit]
+
+
+def build_fulltext_where(
+    engine: Engine,
+    table_name: str,
+    tokens: List[str],
+    schema: str | None = None,
+) -> Tuple[str, Dict[str, Any], List[str]]:
+    """Build a composite predicate scanning all string columns."""
+
+    if not tokens:
+        return "", {}, []
+
+    columns = _string_columns(engine, table_name, schema=schema)
+    if not columns:
+        return "", {}, []
+
+    binds: Dict[str, Any] = {}
+    clauses: List[str] = []
+
+    for idx, token in enumerate(tokens, start=1):
+        bind_name = f"kw{idx}"
+        binds[bind_name] = f"%{token}%"
+        ors = [f'LOWER("{col}") LIKE :{bind_name}' for col in columns]
+        clauses.append("(" + " OR ".join(ors) + ")")
+
+    return "(" + " AND ".join(clauses) + ")", binds, columns
+
+
+def inject_fulltext_where(sql_text: str, predicate: str) -> str:
+    """Inject the predicate into the SQL before ORDER/GROUP/FETCH clauses."""
+
+    if not predicate:
+        return sql_text
+
+    lower = sql_text.lower()
+    insert_pos = len(sql_text)
+    for keyword in ("\nfetch ", "\norder by", "\ngroup by"):
+        idx = lower.find(keyword)
+        if idx != -1 and idx < insert_pos:
+            insert_pos = idx
+
+    head = sql_text[:insert_pos].rstrip()
+    tail = sql_text[insert_pos:]
+
+    if " where " in head.lower():
+        head = head + "\nAND " + predicate
+    else:
+        head = head + "\nWHERE " + predicate
+
+    if tail:
+        tail = tail.lstrip("\n")
+        return head + "\n" + tail
+    return head
+
+
+def is_fulltext_allowed() -> bool:
+    """Gatekeeper for enabling full-text search."""
+
+    return env_flag("DW_FTS_ALLOW", True)

--- a/apps/dw/tests/test_search.py
+++ b/apps/dw/tests/test_search.py
@@ -1,0 +1,51 @@
+import pathlib
+import sys
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[3]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+pytest.importorskip("sqlalchemy")
+from sqlalchemy import create_engine, text
+
+from apps.dw.search import build_fulltext_where, extract_search_tokens, inject_fulltext_where
+
+
+def test_extract_search_tokens_handles_phrases(monkeypatch):
+    monkeypatch.setenv("DW_FTS_MIN_TOKEN_LEN", "3")
+    question = 'Show "Acme Holdings" contracts with VAT and the status'
+    tokens = extract_search_tokens(question)
+    assert "acme holdings" in tokens
+    assert "vat" in tokens
+    assert "contracts" not in tokens
+
+
+def test_inject_fulltext_where_with_existing_where():
+    sql = 'SELECT * FROM "Contract"\nWHERE OWNER_DEPARTMENT = :dep\nORDER BY 1'
+    predicate = '(LOWER("CONTRACT_OWNER") LIKE :kw1)'
+    updated = inject_fulltext_where(sql, predicate)
+    assert 'AND (LOWER("CONTRACT_OWNER") LIKE :kw1)' in updated
+    assert updated.endswith("ORDER BY 1")
+
+
+def test_build_fulltext_where_sqlite():
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as cx:
+        cx.execute(
+            text(
+                """
+                CREATE TABLE Contract (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT,
+                    owner VARCHAR(50),
+                    amount NUMERIC
+                )
+                """
+            )
+        )
+    predicate, binds, columns = build_fulltext_where(engine, "Contract", ["acme"])
+    assert predicate.count("LOWER(") == len(columns)
+    assert binds == {"kw1": "%acme%"}
+    assert set(columns) == {"name", "owner"}


### PR DESCRIPTION
## Summary
- add a search utility that tokenizes questions and constructs LIKE-based predicates across string columns
- expose a `full_text_search` flag from the API down into the intent so it can be toggled per request
- extend DW attempt execution to apply the generated predicate, update metadata/logging, and cover the helpers with tests

## Testing
- pytest apps/dw/tests

------
https://chatgpt.com/codex/tasks/task_e_68d4f16c472083238953ebf1e8c3e2fb