### PR TITLE
Add deterministic DW helpers and update blueprint

### DIFF
--- a/apps/dw/attempts.py
+++ b/apps/dw/attempts.py
@@ -17,7 +17,7 @@ except Exception:  # pragma: no cover
         return sql
 
 from .builder import build_sql
-from .intent import NLIntent, parse_intent
+from .intent import NLIntent, parse_intent_legacy
 from .search import (
     build_fulltext_where,
     extract_search_tokens,
@@ -51,7 +51,7 @@ def run_attempt(
 ) -> Dict[str, Any]:
     app = current_app
     logger = getattr(app, "logger", None)
-    intent: NLIntent = parse_intent(question)
+    intent: NLIntent = parse_intent_legacy(question)
     allow_fts = is_fulltext_allowed()
     if allow_fts:
         default_on = env_flag("DW_FTS_DEFAULT_ON", False)

--- a/apps/dw/fts.py
+++ b/apps/dw/fts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+import os, re
+from typing import Tuple, Dict, Any, List
+
+STOP = set(["the", "and", "of", "in", "for", "by", "to", "a", "an", "on", "at", "last", "month", "months", "next", "this"])
+
+
+def _env_columns() -> List[str]:
+    v = os.getenv("DW_FTS_COLUMNS") or ""
+    cols = [c.strip() for c in v.split(",") if c.strip()]
+    return cols
+
+
+def _tokens(text: str) -> List[str]:
+    raw = re.split(r"[^\w]+", text.lower())
+    return [t for t in raw if t and t not in STOP and len(t) >= 3]
+
+
+def build_fts_clause(
+    question: str, columns: List[str] | None = None
+) -> Tuple[str, Dict[str, Any], List[str], List[str]]:
+    cols = columns or _env_columns()
+    toks = _tokens(question)
+    if not cols or not toks:
+        return ("", {}, toks, cols)
+    where_parts = []
+    binds: Dict[str, Any] = {}
+    for i, tok in enumerate(toks[:8]):
+        bname = f"kw_{i}"
+        binds[bname] = f"%{tok}%"
+        col_or = [f"UPPER({c}) LIKE UPPER(:{bname})" for c in cols]
+        where_parts.append("(" + " OR ".join(col_or) + ")")
+    return ("(" + " AND ".join(where_parts) + ")", binds, toks, cols)

--- a/apps/dw/sqlgen.py
+++ b/apps/dw/sqlgen.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+import os
+from typing import Tuple, Dict, Any, List
+from .intent import DWIntent
+
+
+def _env_flag(name: str, default: int = 0) -> int:
+    v = os.getenv(name)
+    if v is None:
+        return default
+    return 1 if str(v).lower() in ("1", "true", "yes", "y") else 0
+
+
+def _contract_table() -> str:
+    return os.getenv("DW_CONTRACT_TABLE", "Contract")
+
+
+def _strict_overlap() -> bool:
+    return bool(_env_flag("DW_OVERLAP_REQUIRE_BOTH_DATES", 1))
+
+
+def _overlap_predicate() -> str:
+    if _strict_overlap():
+        return "(START_DATE <= :date_end AND END_DATE >= :date_start)"
+    return "((START_DATE IS NULL OR START_DATE <= :date_end) AND (END_DATE IS NULL OR END_DATE >= :date_start))"
+
+
+def _date_filter(intent: DWIntent) -> Tuple[str, Dict[str, Any]]:
+    if not intent.has_time_window and not intent.explicit_dates:
+        return ("", {})
+    binds: Dict[str, Any] = {}
+    if intent.date_column == "REQUEST_DATE":
+        where = "REQUEST_DATE BETWEEN :date_start AND :date_end"
+        binds["date_start"] = intent.explicit_dates["start"]
+        binds["date_end"] = intent.explicit_dates["end"]
+        return (where, binds)
+    where = _overlap_predicate()
+    binds["date_start"] = intent.explicit_dates["start"]
+    binds["date_end"] = intent.explicit_dates["end"]
+    return (where, binds)
+
+
+def _select_star_or_projection(intent: DWIntent) -> str:
+    if intent.group_by or intent.agg:
+        if intent.agg == "count" and intent.group_by:
+            return f"{intent.group_by} AS GROUP_KEY, COUNT(*) AS CNT"
+        if intent.group_by:
+            m = intent.measure_sql or "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
+            return f"{intent.group_by} AS GROUP_KEY, SUM({m}) AS MEASURE"
+        if intent.agg == "count":
+            return "COUNT(*) AS CNT"
+    return "*"
+
+
+def build_sql(intent: DWIntent) -> Tuple[str, Dict[str, Any]]:
+    table = _contract_table()
+    select_clause = _select_star_or_projection(intent)
+    where_parts: List[str] = []
+    binds: Dict[str, Any] = {}
+
+    w_sql, w_binds = _date_filter(intent)
+    if w_sql:
+        where_parts.append(w_sql)
+    binds.update(w_binds)
+
+    sql = [f"SELECT {select_clause}", f'FROM "{table}"']
+    if where_parts:
+        sql.append("WHERE " + " AND ".join(where_parts))
+
+    if intent.group_by:
+        sql.append(f"GROUP BY {intent.group_by}")
+    if intent.sort_by:
+        sql.append(f"ORDER BY {intent.sort_by} {'DESC' if intent.sort_desc else 'ASC'}")
+    if intent.top_n:
+        binds["top_n"] = intent.top_n
+        sql.append("FETCH FIRST :top_n ROWS ONLY")
+
+    return ("\n".join(sql), binds)

--- a/apps/dw/tests/test_dw_golden.py
+++ b/apps/dw/tests/test_dw_golden.py
@@ -6,7 +6,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[3]
 if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
-from apps.dw.intent import parse_intent
+from apps.dw.intent import parse_intent_legacy
 
 
 def _set_now(monkeypatch, when: datetime) -> None:
@@ -16,7 +16,7 @@ def _set_now(monkeypatch, when: datetime) -> None:
 def test_parse_intent_last_month(monkeypatch):
     now = datetime(2023, 2, 10, tzinfo=timezone.utc)
     _set_now(monkeypatch, now)
-    intent = parse_intent("top 10 stakeholders by contract value last month")
+    intent = parse_intent_legacy("top 10 stakeholders by contract value last month")
     assert intent.top_n == 10
     assert intent.user_requested_top_n is True
     assert intent.group_by == "CONTRACT_STAKEHOLDER_1"
@@ -27,14 +27,14 @@ def test_parse_intent_last_month(monkeypatch):
 def test_parse_intent_expiring_window(monkeypatch):
     now = datetime(2023, 5, 1, tzinfo=timezone.utc)
     _set_now(monkeypatch, now)
-    intent = parse_intent("contracts expiring in 30 days")
+    intent = parse_intent_legacy("contracts expiring in 30 days")
     assert intent.expire is True
     assert intent.date_column == "END_DATE"
     assert intent.explicit_dates == {"start": "2023-04-01", "end": "2023-05-01"}
 
 
 def test_parse_intent_by_status_sets_count():
-    intent = parse_intent("Count of contracts by status")
+    intent = parse_intent_legacy("Count of contracts by status")
     assert intent.agg == "count"
     assert intent.group_by == "CONTRACT_STATUS"
 
@@ -42,7 +42,7 @@ def test_parse_intent_by_status_sets_count():
 def test_parse_intent_projection(monkeypatch):
     now = datetime(2023, 7, 15, tzinfo=timezone.utc)
     _set_now(monkeypatch, now)
-    intent = parse_intent(
+    intent = parse_intent_legacy(
         "List all contracts requested last month (contract_id, contract_owner, request_date)"
     )
     assert intent.date_column == "REQUEST_DATE"

--- a/apps/dw/tests/test_projection.py
+++ b/apps/dw/tests/test_projection.py
@@ -7,7 +7,7 @@ if str(ROOT) not in sys.path:
     sys.path.append(str(ROOT))
 
 from apps.dw.builder import build_sql
-from apps.dw.intent import parse_intent
+from apps.dw.intent import parse_intent_legacy
 
 
 def _set_now(monkeypatch, when: datetime) -> None:
@@ -17,7 +17,7 @@ def _set_now(monkeypatch, when: datetime) -> None:
 def test_build_sql_top_n_group(monkeypatch):
     now = datetime(2023, 6, 1, tzinfo=timezone.utc)
     _set_now(monkeypatch, now)
-    intent = parse_intent("Top 5 stakeholders by contract value last 3 months")
+    intent = parse_intent_legacy("Top 5 stakeholders by contract value last 3 months")
     sql, binds = build_sql(intent)
     assert "GROUP BY CONTRACT_STAKEHOLDER_1" in sql
     assert "ORDER BY MEASURE DESC" in sql
@@ -30,7 +30,7 @@ def test_build_sql_top_n_group(monkeypatch):
 def test_build_sql_projection(monkeypatch):
     now = datetime(2023, 8, 5, tzinfo=timezone.utc)
     _set_now(monkeypatch, now)
-    intent = parse_intent(
+    intent = parse_intent_legacy(
         "List all contracts requested last month (contract_id, contract_owner, request_date)"
     )
     sql, binds = build_sql(intent)
@@ -41,14 +41,14 @@ def test_build_sql_projection(monkeypatch):
 def test_build_sql_expiring(monkeypatch):
     now = datetime(2024, 1, 15, tzinfo=timezone.utc)
     _set_now(monkeypatch, now)
-    intent = parse_intent("Contracts expiring in 30 days")
+    intent = parse_intent_legacy("Contracts expiring in 30 days")
     sql, binds = build_sql(intent)
     assert "END_DATE BETWEEN :date_start AND :date_end" in sql
     assert binds == {"date_start": "2023-12-16", "date_end": "2024-01-15"}
 
 
 def test_build_sql_count_by_status():
-    intent = parse_intent("Count of contracts by status")
+    intent = parse_intent_legacy("Count of contracts by status")
     sql, binds = build_sql(intent)
     assert sql.strip().upper() == 'SELECT COUNT(*) AS CNT FROM "CONTRACT"'
     assert binds == {}


### PR DESCRIPTION
## Summary
- introduce a deterministic DW intent parser alongside the legacy NLIntent implementation
- add helpers for building deterministic SQL and optional full-text search clauses
- update the /dw/answer blueprint to run the deterministic plan and capture FTS metadata, while keeping existing retry plumbing on legacy code
- point legacy attempt/test code at the preserved parse_intent_legacy helper

## Testing
- `pytest apps/dw/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68d512a01a2483238320463650829609