### PR TITLE
Add DW FTS mapping helpers and Oracle predicate builder

### DIFF
--- a/apps/dw/fts.py
+++ b/apps/dw/fts.py
@@ -1,33 +1,81 @@
 from __future__ import annotations
-import os, re
-from typing import Tuple, Dict, Any, List
 
-STOP = set(["the", "and", "of", "in", "for", "by", "to", "a", "an", "on", "at", "last", "month", "months", "next", "this"])
+import re
+from typing import Dict, List, Tuple
+
+_STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "of",
+    "and",
+    "by",
+    "per",
+    "for",
+    "to",
+    "in",
+    "on",
+    "at",
+    "with",
+    "contract",
+    "contracts",
+    "value",
+    "gross",
+    "net",
+    "top",
+    "last",
+    "month",
+    "months",
+    "this",
+    "next",
+    "previous",
+    "owner",
+    "department",
+    "requested",
+    "start",
+    "end",
+    "date",
+}
+
+_WORD = re.compile(r"[A-Za-z0-9_]+")
 
 
-def _env_columns() -> List[str]:
-    v = os.getenv("DW_FTS_COLUMNS") or ""
-    cols = [c.strip() for c in v.split(",") if c.strip()]
-    return cols
+def tokenize(text: str) -> List[str]:
+    tokens = [t.lower() for t in _WORD.findall(text or "")]
+    tokens = [t for t in tokens if t not in _STOPWORDS and len(t) >= 2]
+    return tokens[:8]
 
 
-def _tokens(text: str) -> List[str]:
-    raw = re.split(r"[^\w]+", text.lower())
-    return [t for t in raw if t and t not in STOP and len(t) >= 3]
+def sanitize_columns(cols: List[str]) -> List[str]:
+    return [re.sub(r"[^0-9A-Za-z_]", "", c).upper() for c in (cols or [])]
 
 
-def build_fts_clause(
-    question: str, columns: List[str] | None = None
-) -> Tuple[str, Dict[str, Any], List[str], List[str]]:
-    cols = columns or _env_columns()
-    toks = _tokens(question)
-    if not cols or not toks:
-        return ("", {}, toks, cols)
-    where_parts = []
-    binds: Dict[str, Any] = {}
-    for i, tok in enumerate(toks[:8]):
-        bname = f"kw_{i}"
-        binds[bname] = f"%{tok}%"
-        col_or = [f"UPPER({c}) LIKE UPPER(:{bname})" for c in cols]
-        where_parts.append("(" + " OR ".join(col_or) + ")")
-    return ("(" + " AND ".join(where_parts) + ")", binds, toks, cols)
+def build_oracle_fts_predicate(
+    tokens: List[str],
+    columns: List[str],
+    bind_prefix: str = "fts",
+    tokens_mode: str = "all",
+) -> Tuple[str, Dict[str, str]]:
+    """
+    Build a case-insensitive LIKE predicate for Oracle FTS emulation.
+
+    For each token we create an OR clause across all provided columns. The
+    clauses are then combined using AND (default) or OR when
+    ``tokens_mode == 'any'``. The function returns a tuple of the SQL fragment
+    and the dictionary of bind parameters.
+    """
+
+    columns = sanitize_columns(columns)
+    binds: Dict[str, str] = {}
+    if not tokens or not columns:
+        return "", binds
+
+    per_token_clauses: List[str] = []
+    for i, tok in enumerate(tokens):
+        bind_name = f"{bind_prefix}{i}"
+        binds[bind_name] = f"%{tok}%"
+        ors = [f"UPPER({col}) LIKE UPPER(:{bind_name})" for col in columns]
+        per_token_clauses.append("(" + " OR ".join(ors) + ")")
+
+    glue = " AND " if tokens_mode.lower() != "any" else " OR "
+    return "(" + glue.join(per_token_clauses) + ")", binds


### PR DESCRIPTION
## Summary
- add helper utilities in the settings layer to parse JSON configuration and resolve per-table FTS column lists
- introduce a dedicated DW FTS module that tokenizes questions and builds Oracle-compatible predicates
- wire DW answer endpoint to use the per-table mapping, sanitized identifiers, and configurable token joining

## Testing
- pytest apps/dw/tests/test_search.py

------
https://chatgpt.com/codex/tasks/task_e_68d52aee459c8323ab3135a2efba7afc