### PR TITLE
Improve DW FTS and intent handling

### DIFF
--- a/apps/dw/config.py
+++ b/apps/dw/config.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+
+def get_dw_fts_columns(settings: "Settings", table: str) -> List[str]:
+    """Return the configured DW full-text search columns for ``table``."""
+
+    mapping: Any = settings.get("DW_FTS_COLUMNS", scope="namespace") or {}
+    if not isinstance(mapping, dict):
+        return []
+
+    def _sanitize(value: Any) -> List[str]:
+        return [c for c in value if isinstance(c, str)]
+
+    table_cols = mapping.get(table)
+    if isinstance(table_cols, list):
+        return _sanitize(table_cols)
+
+    wildcard_cols = mapping.get("*")
+    if isinstance(wildcard_cols, list):
+        return _sanitize(wildcard_cols)
+    return []

--- a/apps/dw/sqlbuilder.py
+++ b/apps/dw/sqlbuilder.py
@@ -1,8 +1,32 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 from core.nlu.schema import NLIntent
+
+
+def overlap_predicate(strict: bool = True) -> str:
+    """Return the contract overlap predicate with optional NULL tolerance."""
+
+    if strict:
+        return "(START_DATE <= :date_end AND END_DATE >= :date_start)"
+    return (
+        "((START_DATE IS NULL OR START_DATE <= :date_end) "
+        "AND (END_DATE IS NULL OR END_DATE >= :date_start))"
+    )
+
+
+def select_all(table: str) -> str:
+    return f'SELECT * FROM "{table}"'
+
+
+def order_limit(order_sql: str | None, top_n: int | None) -> str:
+    parts: List[str] = []
+    if order_sql:
+        parts.append(f"ORDER BY {order_sql}")
+    if top_n:
+        parts.append("FETCH FIRST :top_n ROWS ONLY")
+    return "\n".join(parts)
 
 
 def _intent_dates(intent: NLIntent) -> tuple[Optional[str], Optional[str]]:


### PR DESCRIPTION
## Summary
- add a DW settings helper to resolve per-table full-text search columns and update the FTS tokenizer/builder to use safe LIKE binds
- tighten DW intent parsing defaults (overlap date policy, explicit grouping cues, gross/count signals) and respect DW settings in the endpoint when building SQL
- expose strict overlap selection helpers for reuse and plumb the strict-overlap flag into SQL generation

## Testing
- `pytest apps/dw/tests` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68d535d368388323afeb35093a7e5017