### PR TITLE
Improve DW intent parsing and window handling

### DIFF
--- a/apps/dw/sql_builder.py
+++ b/apps/dw/sql_builder.py
@@ -16,7 +16,7 @@ def _window_predicate(intent: NLIntent, overlap_strict: bool) -> Optional[str]:
     if col == "END_DATE":
         return "END_DATE BETWEEN :date_start AND :date_end"
     if overlap_strict:
-        return "(START_DATE <= :date_end AND END_DATE >= :date_start)"
+        return "(START_DATE IS NOT NULL AND END_DATE IS NOT NULL AND START_DATE <= :date_end AND END_DATE >= :date_start)"
     return "((START_DATE IS NULL OR START_DATE <= :date_end) AND (END_DATE IS NULL OR END_DATE >= :date_start))"
 
 


### PR DESCRIPTION
## Summary
- expand the deterministic DW intent parser to recognise spelled-out numbers, richer "last N"/"in <year>" time phrases, and additional dimension synonyms while defaulting to overlap dates unless explicitly requested
- normalise detected windows (including expiring/YTD cases) into ISO date bounds and ensure "last 12 months" requests pivot to REQUEST_DATE when appropriate
- tighten the deterministic SQL window predicate by requiring non-null START_DATE/END_DATE before applying the overlap filter

## Testing
- pytest apps/dw/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d67dabcd34832385b621bfa321a466