### PR TITLE
Refactor DocuWare planner around table specs

### DIFF
--- a/apps/dw/planner_det.py
+++ b/apps/dw/planner_det.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple, Optional, TYPE_CHECKING
+
+from apps.dw.tables import for_namespace
+from apps.dw.tables.base import TableSpec
+
+if TYPE_CHECKING:
+    from core.settings import Settings
+
+
+def _predicate(intent: Dict[str, Any], spec: TableSpec, settings: "Settings", binds: Dict[str, Any]) -> Optional[str]:
+    explicit = intent.get("explicit_dates")
+    if not isinstance(explicit, dict):
+        explicit = None
+    start = explicit.get("start") if explicit else None
+    end = explicit.get("end") if explicit else None
+    if not (start and end):
+        return None
+
+    binds["date_start"] = start
+    binds["date_end"] = end
+
+    mode = intent.get("date_column") or spec.default_date_mode
+    strict = bool(settings.get_bool("DW_OVERLAP_STRICT", False))
+
+    if intent.get("expire"):
+        return spec.request_date_predicate(start_bind=":date_start", end_bind=":date_end").replace(
+            spec.request_date_col, spec.end_date_col
+        )
+    if mode == "REQUEST_DATE":
+        return spec.request_date_predicate()
+    if mode == "OVERLAP":
+        return spec.overlap_predicate(strict=strict)
+    if isinstance(mode, str):
+        return f"{mode} BETWEEN :date_start AND :date_end"
+    return None
+
+
+def _projection(intent: Dict[str, Any], spec: TableSpec) -> Tuple[str, Optional[str], Optional[str]]:
+    group_by = intent.get("group_by")
+    agg = (intent.get("agg") or "").lower() or None
+    measure = intent.get("measure_sql") or spec.net_expr()
+    wants_all = bool(intent.get("wants_all_columns", True))
+    notes = intent.get("notes") if isinstance(intent.get("notes"), dict) else {}
+    projection_list = notes.get("projection") if isinstance(notes, dict) else None
+
+    if group_by:
+        if agg == "count":
+            measure_expr = "COUNT(*)"
+        elif agg == "avg":
+            measure_expr = f"AVG({measure})"
+        elif agg == "sum":
+            measure_expr = f"SUM({measure})"
+        else:
+            measure_expr = f"SUM({measure})"
+        return f"{group_by} AS GROUP_KEY, {measure_expr} AS MEASURE", "MEASURE", agg
+
+    if agg == "count":
+        return "COUNT(*) AS MEASURE", "MEASURE", agg
+
+    if isinstance(projection_list, list) and projection_list:
+        projection_sql = ", ".join(projection_list)
+    elif wants_all:
+        projection_sql = "*"
+    else:
+        projection_sql = "CONTRACT_ID, CONTRACT_OWNER, REQUEST_DATE, START_DATE, END_DATE"
+    return projection_sql, measure, agg
+
+
+def build_sql(intent: Dict[str, Any], settings: "Settings") -> Tuple[str, Dict[str, Any], str]:
+    spec = for_namespace(settings)
+    binds: Dict[str, Any] = {}
+    predicate = _predicate(intent, spec, settings, binds)
+    projection, order_measure, _ = _projection(intent, spec)
+    group_by = intent.get("group_by")
+    top_n = intent.get("top_n")
+    sort_by = intent.get("sort_by")
+    sort_desc = bool(intent.get("sort_desc", True))
+
+    lines = ["SELECT", f"  {projection}", f"FROM \"{spec.name}\""]
+    if predicate:
+        lines.append(f"WHERE {predicate}")
+
+    if group_by:
+        lines.append(f"GROUP BY {group_by}")
+
+    order_clause = ""
+    if sort_by:
+        direction = "DESC" if sort_desc else "ASC"
+        order_clause = f"ORDER BY {sort_by} {direction}"
+    elif order_measure:
+        order_clause = f"ORDER BY {order_measure} DESC"
+
+    if order_clause:
+        lines.append(order_clause)
+
+    if top_n:
+        binds["top_n"] = top_n
+        lines.append("FETCH FIRST :top_n ROWS ONLY")
+
+    sql = "\n".join(lines)
+
+    explain_bits = []
+    if intent.get("expire"):
+        explain_bits.append("Filtering by END_DATE window (expiring).")
+    elif predicate and intent.get("date_column") == "REQUEST_DATE":
+        explain_bits.append("Filtering by REQUEST_DATE window.")
+    elif predicate:
+        explain_bits.append("Treating contracts as active by date overlap.")
+
+    if group_by:
+        explain_bits.append(f"Grouping by {group_by}.")
+
+    gross_expr = spec.gross_expr()
+    if intent.get("measure_sql") == gross_expr or "gross" in (intent.get("raw") or "").lower():
+        explain_bits.append("Sorting by GROSS value.")
+    else:
+        explain_bits.append("Sorting by NET value.")
+
+    if top_n:
+        explain_bits.append(f"Limiting to Top {top_n}.")
+
+    explain = " ".join(explain_bits)
+    return sql, binds, explain

--- a/apps/dw/tables/__init__.py
+++ b/apps/dw/tables/__init__.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+from typing import Dict, TYPE_CHECKING
+
+from .base import TableSpec
+
+if TYPE_CHECKING:
+    from core.settings import Settings
+
+_REGISTRY: Dict[str, TableSpec] = {}
+
+
+def register(spec: TableSpec) -> None:
+    _REGISTRY[spec.name.lower()] = spec
+
+
+def get(name: str) -> TableSpec:
+    return _REGISTRY[name.lower()]
+
+
+def for_namespace(settings: "Settings") -> TableSpec:
+    """
+    Pick the active table from settings (for DocuWare you used DW_CONTRACT_TABLE).
+    Falls back to 'Contract' if not set.
+    """
+    tbl = (settings.get("DW_CONTRACT_TABLE") or "Contract")
+    return get(str(tbl))
+
+
+# Ensure default Contract spec is registered on import
+from . import contract  # noqa: E402,F401

--- a/apps/dw/tables/base.py
+++ b/apps/dw/tables/base.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from core.settings import Settings
+
+
+@dataclass
+class TableSpec:
+    """
+    Generic, table-agnostic contract for DW tables.
+    Everything that is table-specific lives in subclasses (e.g. ContractSpec).
+    """
+    name: str
+    # Date semantics:
+    #   "OVERLAP"      -> active window (START<=end && END>=start)
+    #   "REQUEST_DATE" -> use REQUEST_DATE BETWEEN :start AND :end
+    default_date_mode: str = "OVERLAP"
+    request_date_col: str = "REQUEST_DATE"
+    start_date_col: str   = "START_DATE"
+    end_date_col: str     = "END_DATE"
+
+    # Measures:
+    value_col_net: str = "CONTRACT_VALUE_NET_OF_VAT"
+    value_col_vat: str = "VAT"
+
+    # Dimension synonyms (natural language -> column name)
+    dimension_map: Dict[str, str] = field(default_factory=dict)
+
+    # Optional default FTS columns if settings does not provide them
+    fts_default: List[str] = field(default_factory=list)
+
+    # ---------- value expressions ----------
+    def net_expr(self) -> str:
+        return f"NVL({self.value_col_net},0)"
+
+    def gross_expr(self) -> str:
+        # VAT can be a rate (0..1) or absolute; handle both.
+        return (
+            f"NVL({self.value_col_net},0) + "
+            f"CASE WHEN NVL({self.value_col_vat},0) BETWEEN 0 AND 1 "
+            f"THEN NVL({self.value_col_net},0) * NVL({self.value_col_vat},0) "
+            f"ELSE NVL({self.value_col_vat},0) END"
+        )
+
+    # ---------- predicates ----------
+    def overlap_predicate(self, start_bind=":date_start", end_bind=":date_end",
+                          strict: bool = False) -> str:
+        s, e = self.start_date_col, self.end_date_col
+        if strict:
+            return f"({s} <= {end_bind} AND {e} >= {start_bind})"
+        return f"(({s} IS NULL OR {s} <= {end_bind}) AND ({e} IS NULL OR {e} >= {start_bind}))"
+
+    def request_date_predicate(self, start_bind=":date_start", end_bind=":date_end") -> str:
+        col = self.request_date_col
+        return f"{col} BETWEEN {start_bind} AND {end_bind}"
+
+    # ---------- FTS columns ----------
+    def fts_columns(self, settings: "Settings") -> List[str]:
+        cfg = (settings.get("DW_FTS_COLUMNS") or {})
+        # Per-table
+        if self.name in cfg and isinstance(cfg[self.name], list):
+            return cfg[self.name]
+        # Wildcard override
+        if "*" in cfg and isinstance(cfg["*"], list):
+            return cfg["*"]
+        # Fallback
+        return list(self.fts_default)
+
+    # ---------- synonyms ----------
+    def synonym(self, noun: str) -> Optional[str]:
+        return self.dimension_map.get((noun or "").strip().lower())

--- a/apps/dw/tables/contract.py
+++ b/apps/dw/tables/contract.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from .base import TableSpec
+from . import register
+
+# Natural-language → columns (what you told me)
+_DIMENSIONS = {
+    "contract":              "CONTRACT_ID",
+    "contract id":           "CONTRACT_ID",
+    "owner":                 "CONTRACT_OWNER",
+    "contract owner":        "CONTRACT_OWNER",
+    "owner department":      "OWNER_DEPARTMENT",
+    "department":            "OWNER_DEPARTMENT",
+    "manager":               "DEPARTMENT_OUL",
+    "department_oul":        "DEPARTMENT_OUL",
+    "entity":                "ENTITY",
+    "entity no":             "ENTITY_NO",
+    "stakeholder":           "CONTRACT_STAKEHOLDER_1",  # default slot; we can extend to 1..8 later
+    "stakeholder1":          "CONTRACT_STAKEHOLDER_1",
+    "status":                "CONTRACT_STATUS",
+    "request type":          "REQUEST_TYPE",
+    "request":               "REQUEST_TYPE",
+}
+
+ContractSpec = TableSpec(
+    name="Contract",
+    # Per your latest rule: default is OVERLAP unless user explicitly says "requested"
+    default_date_mode="OVERLAP",
+    request_date_col="REQUEST_DATE",
+    start_date_col="START_DATE",
+    end_date_col="END_DATE",
+    value_col_net="CONTRACT_VALUE_NET_OF_VAT",
+    value_col_vat="VAT",
+    dimension_map=_DIMENSIONS,
+    fts_default=[
+        "CONTRACT_SUBJECT","CONTRACT_PURPOSE","OWNER_DEPARTMENT","DEPARTMENT_OUL",
+        "CONTRACT_OWNER","CONTRACT_STAKEHOLDER_1","CONTRACT_STAKEHOLDER_2",
+        "LEGAL_NAME_OF_THE_COMPANY","ENTITY","ENTITY_NO"
+    ],
+)
+
+register(ContractSpec)


### PR DESCRIPTION
## Summary
- add a table specification framework under `apps/dw/tables` to centralise DocuWare table metadata and register the Contract table spec
- update legacy and new intent parsing to leverage the table spec for synonyms, measure expressions, and defaults while keeping existing behaviours intact
- introduce a deterministic planner that builds SQL and human-friendly explanations from the table spec and wire it into the `/dw/answer` endpoint

## Testing
- pytest apps/dw/tests/test_dw_golden.py -q *(fails: environment missing pydantic dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a767f8f88323a61fcec6707d7f1e