### PR TITLE
Add owner department gross aggregation helper

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -181,39 +181,39 @@ def _build_user_explain(intent: Any, binds: Dict[str, Any], sql: str) -> str:
     de = binds.get("date_end")
     if ds and de:
         parts.append(
-            f"تم تفسير «الفترة» من {_format_window_val(ds)} إلى {_format_window_val(de)}."
+            f"Interpreted the requested window from {_format_window_val(ds)} to {_format_window_val(de)}."
         )
 
     dc = getattr(intent, "date_column", None)
     if dc == "OVERLAP":
         parts.append(
-            "اعتبرنا العقد «نشطًا» إذا تداخلت فترة العقد (START_DATE/END_DATE) مع هذه النافذة."
+            "Treated a contract as active when the START_DATE/END_DATE overlap the requested window."
         )
     elif dc == "REQUEST_DATE":
-        parts.append("تم الاعتماد على REQUEST_DATE لأن الصياغة تشير إلى تاريخ الطلب.")
+        parts.append("Used REQUEST_DATE because the question refers to request timing.")
     elif dc == "END_DATE":
-        parts.append("تم الاعتماد على END_DATE كما هو مذكور في السؤال.")
+        parts.append("Used END_DATE as specified in the question.")
 
     gb = getattr(intent, "group_by", None)
     agg = getattr(intent, "agg", None)
     if gb and agg:
-        parts.append(f"قمنا بتجميع النتائج حسب «{gb}» باستخدام {str(agg).upper()}.")
+        parts.append(f"Grouped results by {gb} using {str(agg).upper()}.")
     elif gb:
-        parts.append(f"قمنا بتجميع النتائج حسب «{gb}».")
+        parts.append(f"Grouped results by {gb}.")
 
     sort_by = getattr(intent, "sort_by", None)
     if sort_by:
         desc = getattr(intent, "sort_desc", True)
-        order_word = "تنازليًا" if desc else "تصاعديًا"
-        parts.append(f"تم ترتيب النتائج {order_word} بالقيمة المطلوبة.")
+        order_word = "descending" if desc else "ascending"
+        parts.append(f"Sorted the results in {order_word} order by the requested measure.")
 
     if getattr(intent, "wants_all_columns", False):
-        parts.append("لم تُطلب أعمدة محددة، لذا عرضنا كل الأعمدة.")
+        parts.append("All columns were returned because none were specifically requested.")
 
     if getattr(intent, "full_text_search", False):
-        parts.append("تم تفعيل البحث النصي عبر أعمدة FTS المعرفة في الإعدادات.")
+        parts.append("Full-text search was enabled across the configured FTS columns.")
 
-    return " ".join(parts) if parts else "تم استخدام الإعدادات الافتراضية لتفسير سؤالك."
+    return " ".join(parts) if parts else "Used default interpretation settings for your question."
 
 
 @dw_bp.post("/answer")

--- a/apps/dw/engine/explain.py
+++ b/apps/dw/engine/explain.py
@@ -9,19 +9,20 @@ def build_explain(intent: NLIntent) -> str:
         start = intent.explicit_dates.get("start")
         end = intent.explicit_dates.get("end")
         if start and end:
-            parts.append(f"فسرتُ النافذة الزمنية: {start} → {end}.")
+            parts.append(f"Interpreted time window as {start} → {end}.")
     if intent.date_column == "OVERLAP":
-        parts.append("تعريف ‘contracts’ = ناشطة ضمن النافذة (تداخل START_DATE/END_DATE).")
+        parts.append("Treated contracts as active when START_DATE/END_DATE overlap the requested window.")
     elif intent.date_column:
-        parts.append(f"استخدمت العمود الزمني: {intent.date_column}.")
+        parts.append(f"Used {intent.date_column} as the date basis.")
     if intent.group_by:
-        parts.append(f"تجميع حسب: {intent.group_by}.")
+        parts.append(f"Grouped by {intent.group_by}.")
     if intent.agg:
-        parts.append(f"تجميع ({intent.agg}).")
+        parts.append(f"Aggregation: {intent.agg}.")
     if intent.sort_by:
-        parts.append("رتّبت حسب القيمة" + (" تنازلياً." if intent.sort_desc else " تصاعدياً."))
+        order_word = "descending" if intent.sort_desc else "ascending"
+        parts.append(f"Sorted by {intent.sort_by} in {order_word} order.")
     if intent.full_text_search:
-        parts.append("فعّلت البحث النصي عبر الأعمدة المُهيّأة.")
+        parts.append("Enabled full-text search across the configured columns.")
     if intent.wants_all_columns and not intent.group_by and not intent.agg:
-        parts.append("عرضت جميع الأعمدة لأن السؤال لم يطلب أعمدة محددة.")
+        parts.append("Returned all columns because none were specified.")
     return " ".join(parts)


### PR DESCRIPTION
## Summary
- add a reusable SQL builder for owner department gross totals and invoke it from the deterministic planner when gross VAT measures are requested
- default non-gross owner department groupings to net sums and sort request-date windows chronologically
- translate deterministic explain/debug messaging to English-only output for consistency

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68d7027fae9c832384d28705bc7f0f06