### PR TITLE
Add contract builder rules for advanced DW queries

### DIFF
--- a/apps/dw/contracts/builder_contracts.py
+++ b/apps/dw/contracts/builder_contracts.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import re
+from datetime import date, datetime, timedelta
+from typing import Optional, Sequence, Tuple
+
+from core.nlu.schema import NLIntent
+
+from .sql_templates import (
+    BuiltSQL,
+    sql_avg_gross_by_request_type,
+    sql_counts_30_60_90,
+    sql_duplicate_contract_ids,
+    sql_duration_mismatch_12m,
+    sql_end_before_start,
+    sql_entity_top3_gross,
+    sql_gross_by_stakeholder_slots,
+    sql_missing_contract_id,
+    sql_missing_rep_email,
+    sql_monthly_trend_by_request_date,
+    sql_owner_dept_highest_avg_gross,
+    sql_owner_stakeholder_pairs_top,
+    sql_owner_vs_oul_mismatch,
+    sql_requester_quarter_totals,
+    sql_stakeholder_dept_2024,
+    sql_stakeholders_more_than_n_2024,
+    sql_status_in_gross_threshold,
+    sql_status_totals_for_entity_no,
+    sql_top_gross_ytd,
+    sql_yoy,
+    sql_median_gross_by_owner_dept_this_year,
+)
+
+
+def _ensure_date(value: date | datetime) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def window_last_days(now: date, days: int) -> Tuple[date, date]:
+    days = max(1, days)
+    end = now
+    start = now - timedelta(days=days - 1)
+    return start, end
+
+
+def window_last_months(now: date, months: int) -> Tuple[date, date]:
+    months = max(1, months)
+    end = now
+    month = now.month
+    year = now.year
+    for _ in range(months - 1):
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    start = date(year, month, 1)
+    return start, end
+
+
+def window_last_quarter(now: date) -> Tuple[date, date]:
+    quarter = ((now.month - 1) // 3) + 1
+    if quarter == 1:
+        year = now.year - 1
+        quarter = 4
+    else:
+        year = now.year
+        quarter -= 1
+    start_month = 3 * (quarter - 1) + 1
+    start = date(year, start_month, 1)
+    end_month = start_month + 2
+    if end_month > 12:
+        end_month -= 12
+        year += 1
+    last_day = _month_last_day(year, end_month)
+    end = date(year, end_month, last_day)
+    return start, end
+
+
+def _month_last_day(year: int, month: int) -> int:
+    if month == 12:
+        return 31
+    next_month = date(year, month, 1) + timedelta(days=32)
+    first_next = date(next_month.year, next_month.month, 1)
+    return (first_next - timedelta(days=1)).day
+
+
+def infer_yoy_period(now: date) -> Tuple[date, date]:
+    start = date(now.year, 1, 1)
+    end = now
+    return start, end
+
+
+_RE_QUOTED = re.compile(r"'([^']+)'")
+
+
+def extract_quoted_value(question: Optional[str], *, key: Optional[str] = None) -> Optional[str]:
+    if not question:
+        return None
+    text = question
+    if key:
+        pattern = re.compile(rf"{re.escape(key)}[^']*'([^']+)'", re.IGNORECASE)
+        match = pattern.search(text)
+        if match:
+            return match.group(1).strip()
+    match = _RE_QUOTED.search(text)
+    if match:
+        return match.group(1).strip()
+    return None
+
+
+_RE_INT = re.compile(r"(-?\d+)")
+
+
+def extract_integer(text: str) -> Optional[int]:
+    if not text:
+        return None
+    match = _RE_INT.search(text)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+_RE_NUMBER = re.compile(r"(-?\d[\d,]*(?:\.\d+)?)")
+
+
+def extract_number(text: str) -> Optional[float]:
+    if not text:
+        return None
+    match = _RE_NUMBER.search(text)
+    if not match:
+        return None
+    value = match.group(1).replace(",", "")
+    try:
+        return float(value)
+    except ValueError:
+        return None
+
+
+def extract_statuses(text: str) -> Sequence[str]:
+    if not text:
+        return []
+    pattern = re.compile(r"CONTRACT_STATUS\s+IN\s*\(([^)]+)\)", re.IGNORECASE)
+    match = pattern.search(text)
+    if not match:
+        return []
+    inner = match.group(1)
+    candidates = re.findall(r"'([^']+)'", inner)
+    cleaned = [cand.strip() for cand in candidates if cand.strip()]
+    return cleaned
+
+
+def _fallback_listing() -> BuiltSQL:
+    sql = (
+        'SELECT *\n'
+        'FROM "Contract"\n'
+        'ORDER BY REQUEST_DATE DESC\n'
+        'FETCH FIRST 50 ROWS ONLY'
+    )
+    return BuiltSQL(sql=sql, binds={})
+
+
+def build_sql(intent: NLIntent, now: date | datetime | None = None) -> BuiltSQL:
+    now = _ensure_date(now or date.today())
+    q_raw = getattr(intent, "notes", {}).get("q") if getattr(intent, "notes", None) else None
+    if not q_raw and getattr(intent, "question", None):
+        q_raw = intent.question
+    q = (q_raw or getattr(intent, "raw_question", "") or "").lower()
+
+    if "missing" in q and "contract_id" in q:
+        return sql_missing_contract_id()
+
+    if "last 90 days" in q and "gross" in q and "stakeholder" in q:
+        ds, de = window_last_days(now, 90)
+        return sql_gross_by_stakeholder_slots(ds, de)
+
+    if "2024 ytd" in q and "top" in q and "gross" in q:
+        top = extract_integer(q) or 5
+        return sql_top_gross_ytd(2024, top, today=now)
+
+    if "average" in q and "request_type" in q and "last 6 months" in q:
+        ds, de = window_last_months(now, 6)
+        return sql_avg_gross_by_request_type(ds, de)
+
+    if "monthly trend" in q and "last 12 months" in q:
+        ds, de = window_last_months(now, 12)
+        return sql_monthly_trend_by_request_date(ds, de)
+
+    if "for entity_no" in q and "status" in q:
+        entity_no = extract_quoted_value(q_raw or intent.question, key="ENTITY_NO")
+        if entity_no:
+            return sql_status_totals_for_entity_no(entity_no)
+
+    if "expiring in 30/60/90 days" in q:
+        return sql_counts_30_60_90(now)
+
+    if "highest average gross" in q and "last quarter" in q:
+        ds, de = window_last_quarter(now)
+        return sql_owner_dept_highest_avg_gross(ds, de)
+
+    if "stakeholders involved in more than" in q and "in 2024" in q:
+        n_min = extract_integer(q) or 1
+        return sql_stakeholders_more_than_n_2024(n_min)
+
+    if "representative_email" in q and ("missing" in q or "null" in q or "blank" in q):
+        return sql_missing_rep_email()
+
+    if "total gross & count by quarter" in q and "requester" in q:
+        requester = extract_quoted_value(q_raw or intent.question, key="REQUESTER")
+        if requester:
+            return sql_requester_quarter_totals(requester)
+
+    if "for each stakeholder" in q and "2024" in q and "distinct departments" in q:
+        return sql_stakeholder_dept_2024()
+
+    if "pairs" in q and "last 180 days" in q:
+        ds, de = window_last_days(now, 180)
+        return sql_owner_stakeholder_pairs_top(ds, de, top_n=10)
+
+    if "duplicate" in q and "contract id" in q:
+        return sql_duplicate_contract_ids()
+
+    if "median" in q and "owner department" in q and ("this year" in q or "current year" in q):
+        return sql_median_gross_by_owner_dept_this_year(now)
+
+    if "end_date < start_date" in q or "integrity check" in q:
+        return sql_end_before_start()
+
+    if "duration" in q and "12" in q and "months" in q and ("!=" in q or "not" in q or "mismatch" in q):
+        return sql_duration_mismatch_12m()
+
+    if "year-over-year" in q or "yoy" in q:
+        ds, de = infer_yoy_period(now)
+        return sql_yoy(ds, de)
+
+    if "for contract_status in (" in q and "exceeds a threshold" in q:
+        statuses = extract_statuses(q_raw or intent.question or "")
+        if statuses:
+            gross_min = extract_number(q) or 1_000_000
+            return sql_status_in_gross_threshold(statuses, gross_min)
+
+    if "for each entity" in q and "top 3" in q and "last 365 days" in q:
+        ds, de = window_last_days(now, 365)
+        return sql_entity_top3_gross(ds, de)
+
+    if "owner_department vs department_oul" in q:
+        return sql_owner_vs_oul_mismatch()
+
+    return _fallback_listing()
+

--- a/apps/dw/contracts/sql_templates.py
+++ b/apps/dw/contracts/sql_templates.py
@@ -1,0 +1,373 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Dict, Iterable, List, Sequence, Tuple
+
+
+@dataclass
+class BuiltSQL:
+    sql: str
+    binds: Dict[str, object]
+
+
+def gross_expr() -> str:
+    return (
+        "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + "
+        "CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
+        "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0) * NVL(VAT,0) ELSE NVL(VAT,0) END"
+    )
+
+
+def overlap_predicate(
+    date_start_bind: str = ":date_start", date_end_bind: str = ":date_end"
+) -> str:
+    return (
+        "(START_DATE IS NOT NULL AND END_DATE IS NOT NULL "
+        f"AND START_DATE <= {date_end_bind} AND END_DATE >= {date_start_bind})"
+    )
+
+
+def request_date_between(
+    date_start_bind: str = ":date_start", date_end_bind: str = ":date_end"
+) -> str:
+    return f"REQUEST_DATE BETWEEN {date_start_bind} AND {date_end_bind}"
+
+
+def end_date_between(
+    date_start_bind: str = ":date_start", date_end_bind: str = ":date_end"
+) -> str:
+    return f"END_DATE BETWEEN {date_start_bind} AND {date_end_bind}"
+
+
+def _stakeholder_select(slot: int, where_clause: str) -> str:
+    return (
+        "SELECT CONTRACT_STAKEHOLDER_{slot} AS STK, {gross} AS GVAL, "
+        "OWNER_DEPARTMENT AS OWNER_DEPT, CONTRACT_OWNER AS OWNER, CONTRACT_ID AS CONTRACT_ID "
+        'FROM "Contract" {where}'
+    ).format(slot=slot, gross=gross_expr(), where=where_clause)
+
+
+def stakeholder_union(
+    where_clause: str,
+    *,
+    slots: int = 8,
+) -> str:
+    selects = [_stakeholder_select(i, where_clause) for i in range(1, slots + 1)]
+    return "\nUNION ALL\n".join(selects)
+
+
+def sql_missing_contract_id() -> BuiltSQL:
+    sql = (
+        'SELECT *\n'
+        'FROM "Contract"\n'
+        "WHERE CONTRACT_ID IS NULL OR TRIM(CONTRACT_ID) = ''\n"
+        'ORDER BY REQUEST_DATE DESC'
+    )
+    return BuiltSQL(sql=sql, binds={})
+
+
+def sql_gross_by_stakeholder_slots(ds: date, de: date, *, slots: int = 8) -> BuiltSQL:
+    where_clause = "WHERE " + overlap_predicate()
+    union = stakeholder_union(where_clause, slots=slots)
+    sql = (
+        "WITH STAKEHOLDER_UNION AS (\n"
+        f"{union}\n"
+        ")\n"
+        "SELECT\n"
+        "  STK AS STAKEHOLDER,\n"
+        "  SUM(GVAL) AS TOTAL_GROSS\n"
+        "FROM STAKEHOLDER_UNION\n"
+        "WHERE STK IS NOT NULL AND TRIM(STK) <> ''\n"
+        "GROUP BY STK\n"
+        "ORDER BY TOTAL_GROSS DESC"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": ds, "date_end": de})
+
+
+def sql_top_gross_ytd(year: int, top_n: int, *, today: date) -> BuiltSQL:
+    start = date(year, 1, 1)
+    end = min(date(year, 12, 31), today)
+    sql = (
+        f"SELECT CONTRACT_ID, CONTRACT_OWNER, {gross_expr()} AS TOTAL_GROSS\n"
+        'FROM "Contract"\n'
+        "WHERE "
+        + request_date_between()
+        + "\nORDER BY TOTAL_GROSS DESC\n"
+        "FETCH FIRST :top_n ROWS ONLY"
+    )
+    return BuiltSQL(
+        sql=sql,
+        binds={"date_start": start, "date_end": end, "top_n": top_n},
+    )
+
+
+def sql_avg_gross_by_request_type(ds: date, de: date) -> BuiltSQL:
+    sql = (
+        f"SELECT REQUEST_TYPE AS REQUEST_TYPE, AVG({gross_expr()}) AS AVG_GROSS\n"
+        'FROM "Contract"\n'
+        "WHERE "
+        + request_date_between()
+        + "\nGROUP BY REQUEST_TYPE\nORDER BY AVG_GROSS DESC"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": ds, "date_end": de})
+
+
+def sql_monthly_trend_by_request_date(ds: date, de: date) -> BuiltSQL:
+    sql = (
+        "SELECT TRUNC(REQUEST_DATE, 'MM') AS MONTH_BUCKET, COUNT(*) AS CONTRACT_COUNT\n"
+        'FROM "Contract"\n'
+        "WHERE "
+        + request_date_between()
+        + "\nGROUP BY TRUNC(REQUEST_DATE, 'MM')\nORDER BY MONTH_BUCKET"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": ds, "date_end": de})
+
+
+def sql_status_totals_for_entity_no(entity_no: str) -> BuiltSQL:
+    sql = (
+        f"SELECT CONTRACT_STATUS AS CONTRACT_STATUS, SUM({gross_expr()}) AS TOTAL_GROSS, COUNT(*) AS CONTRACT_COUNT\n"
+        'FROM "Contract"\n'
+        "WHERE ENTITY_NO = :entity_no\n"
+        "GROUP BY CONTRACT_STATUS\n"
+        "ORDER BY TOTAL_GROSS DESC"
+    )
+    return BuiltSQL(sql=sql, binds={"entity_no": entity_no})
+
+
+def sql_counts_30_60_90(now: date) -> BuiltSQL:
+    buckets = [
+        ("0-30", now, now + timedelta(days=30)),
+        ("31-60", now + timedelta(days=31), now + timedelta(days=60)),
+        ("61-90", now + timedelta(days=61), now + timedelta(days=90)),
+    ]
+    selects: List[str] = []
+    binds: Dict[str, object] = {}
+    for idx, (label, start, end) in enumerate(buckets, start=1):
+        k_start = f"b{idx}_start"
+        k_end = f"b{idx}_end"
+        binds[k_start] = start
+        binds[k_end] = end
+        selects.append(
+            "SELECT '{label}' AS BUCKET, COUNT(*) AS CONTRACT_COUNT FROM \"Contract\" "
+            "WHERE {predicate}"
+            .format(
+                label=label,
+                predicate=end_date_between(f":{k_start}", f":{k_end}"),
+            )
+        )
+    sql = "\nUNION ALL\n".join(selects)
+    return BuiltSQL(sql=sql, binds=binds)
+
+
+def sql_owner_dept_highest_avg_gross(ds: date, de: date) -> BuiltSQL:
+    sql = (
+        f"SELECT OWNER_DEPARTMENT, AVG({gross_expr()}) AS AVG_GROSS\n"
+        'FROM "Contract"\n'
+        "WHERE "
+        + request_date_between()
+        + "\nGROUP BY OWNER_DEPARTMENT\n"
+        "ORDER BY AVG_GROSS DESC\n"
+        "FETCH FIRST 1 ROWS ONLY"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": ds, "date_end": de})
+
+
+def sql_stakeholders_more_than_n_2024(n_min: int) -> BuiltSQL:
+    ds = date(2024, 1, 1)
+    de = date(2024, 12, 31)
+    where_clause = "WHERE " + request_date_between()
+    union = stakeholder_union(where_clause)
+    sql = (
+        "WITH STAKEHOLDER_HITS AS (\n"
+        f"{union}\n"
+        ")\n"
+        "SELECT\n"
+        "  STK AS STAKEHOLDER,\n"
+        "  COUNT(*) AS CONTRACT_COUNT\n"
+        "FROM STAKEHOLDER_HITS\n"
+        "WHERE STK IS NOT NULL AND TRIM(STK) <> ''\n"
+        "GROUP BY STK\n"
+        "HAVING COUNT(*) > :min_count\n"
+        "ORDER BY CONTRACT_COUNT DESC"
+    )
+    return BuiltSQL(
+        sql=sql,
+        binds={"date_start": ds, "date_end": de, "min_count": int(n_min)},
+    )
+
+
+def sql_missing_rep_email() -> BuiltSQL:
+    sql = (
+        'SELECT *\n'
+        'FROM "Contract"\n'
+        "WHERE REPRESENTATIVE_EMAIL IS NULL "
+        "OR TRIM(UPPER(REPRESENTATIVE_EMAIL)) IN ('', 'NA', 'N/A')\n"
+        'ORDER BY REQUEST_DATE DESC'
+    )
+    return BuiltSQL(sql=sql, binds={})
+
+
+def sql_requester_quarter_totals(requester: str) -> BuiltSQL:
+    sql = (
+        f"SELECT TRUNC(REQUEST_DATE, 'Q') AS QUARTER_START, SUM({gross_expr()}) AS TOTAL_GROSS, COUNT(*) AS CONTRACT_COUNT\n"
+        'FROM "Contract"\n'
+        "WHERE REQUESTER = :requester\n"
+        "GROUP BY TRUNC(REQUEST_DATE, 'Q')\n"
+        "ORDER BY QUARTER_START"
+    )
+    return BuiltSQL(sql=sql, binds={"requester": requester})
+
+
+def sql_stakeholder_dept_2024() -> BuiltSQL:
+    ds = date(2024, 1, 1)
+    de = date(2024, 12, 31)
+    where_clause = "WHERE " + request_date_between()
+    union = stakeholder_union(where_clause)
+    sql = (
+        "WITH STAKEHOLDER_DEPTS AS (\n"
+        f"{union}\n"
+        ")\n"
+        "SELECT\n"
+        "  STK AS STAKEHOLDER,\n"
+        "  COUNT(*) AS CONTRACT_COUNT,\n"
+        "  SUM(GVAL) AS TOTAL_GROSS,\n"
+        "  LISTAGG(DISTINCT OWNER_DEPT, ', ') WITHIN GROUP (ORDER BY OWNER_DEPT) AS DEPARTMENTS\n"
+        "FROM STAKEHOLDER_DEPTS\n"
+        "WHERE STK IS NOT NULL AND TRIM(STK) <> ''\n"
+        "GROUP BY STK\n"
+        "ORDER BY TOTAL_GROSS DESC"
+    )
+    return BuiltSQL(
+        sql=sql,
+        binds={"date_start": ds, "date_end": de},
+    )
+
+
+def sql_owner_stakeholder_pairs_top(ds: date, de: date, *, top_n: int) -> BuiltSQL:
+    where_clause = "WHERE " + overlap_predicate()
+    union = stakeholder_union(where_clause)
+    sql = (
+        "WITH PAIRS AS (\n"
+        f"{union}\n"
+        ")\n"
+        "SELECT\n"
+        "  OWNER AS CONTRACT_OWNER,\n"
+        "  STK AS STAKEHOLDER,\n"
+        "  SUM(GVAL) AS TOTAL_GROSS\n"
+        "FROM PAIRS\n"
+        "WHERE STK IS NOT NULL AND TRIM(STK) <> ''\n"
+        "GROUP BY OWNER, STK\n"
+        "ORDER BY TOTAL_GROSS DESC\n"
+        "FETCH FIRST :top_n ROWS ONLY"
+    )
+    return BuiltSQL(
+        sql=sql,
+        binds={"date_start": ds, "date_end": de, "top_n": top_n},
+    )
+
+
+def sql_duplicate_contract_ids() -> BuiltSQL:
+    sql = (
+        "SELECT CONTRACT_ID, COUNT(*) AS DUP_COUNT\n"
+        'FROM "Contract"\n'
+        "WHERE CONTRACT_ID IS NOT NULL AND TRIM(CONTRACT_ID) <> ''\n"
+        "GROUP BY CONTRACT_ID\n"
+        "HAVING COUNT(*) > 1\n"
+        "ORDER BY DUP_COUNT DESC"
+    )
+    return BuiltSQL(sql=sql, binds={})
+
+
+def sql_median_gross_by_owner_dept_this_year(today: date) -> BuiltSQL:
+    start = date(today.year, 1, 1)
+    end = date(today.year, 12, 31)
+    sql = (
+        f"SELECT OWNER_DEPARTMENT, PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY {gross_expr()}) AS MEDIAN_GROSS\n"
+        'FROM "Contract"\n'
+        "WHERE "
+        + request_date_between()
+        + "\nGROUP BY OWNER_DEPARTMENT\n"
+        "ORDER BY MEDIAN_GROSS DESC"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": start, "date_end": end})
+
+
+def sql_end_before_start() -> BuiltSQL:
+    sql = (
+        'SELECT *\n'
+        'FROM "Contract"\n'
+        "WHERE END_DATE < START_DATE\n"
+        'ORDER BY REQUEST_DATE DESC'
+    )
+    return BuiltSQL(sql=sql, binds={})
+
+
+def sql_duration_mismatch_12m() -> BuiltSQL:
+    sql = (
+        'SELECT *\n'
+        'FROM "Contract"\n'
+        "WHERE REGEXP_SUBSTR(UPPER(DURATION), '([0-9]+)\\s*MONTH') = '12'\n"
+        "  AND START_DATE IS NOT NULL AND END_DATE IS NOT NULL\n"
+        "  AND ADD_MONTHS(START_DATE, 12) <> END_DATE\n"
+        'ORDER BY START_DATE'
+    )
+    return BuiltSQL(sql=sql, binds={})
+
+
+def sql_yoy(ds: date, de: date) -> BuiltSQL:
+    sql = (
+        f"SELECT 'CURRENT' AS PERIOD_LABEL, SUM({gross_expr()}) AS TOTAL_GROSS\n"
+        'FROM "Contract"\n'
+        "WHERE "
+        + request_date_between()
+        + "\nUNION ALL\n"
+        f"SELECT 'PRIOR' AS PERIOD_LABEL, SUM({gross_expr()}) AS TOTAL_GROSS\n"
+        'FROM "Contract"\n'
+        "WHERE REQUEST_DATE BETWEEN ADD_MONTHS(:date_start, -12) AND ADD_MONTHS(:date_end, -12)"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": ds, "date_end": de})
+
+
+def sql_status_in_gross_threshold(statuses: Sequence[str], gross_min: float) -> BuiltSQL:
+    placeholders = [f":status_{i}" for i in range(len(statuses))]
+    status_in = ", ".join(placeholders)
+    sql = (
+        f"SELECT *, {gross_expr()} AS TOTAL_GROSS\n"
+        'FROM "Contract"\n'
+        f"WHERE CONTRACT_STATUS IN ({status_in})\n"
+        f"  AND {gross_expr()} > :gross_min\n"
+        "ORDER BY TOTAL_GROSS DESC"
+    )
+    binds: Dict[str, object] = {f"status_{i}": status for i, status in enumerate(statuses)}
+    binds["gross_min"] = gross_min
+    return BuiltSQL(sql=sql, binds=binds)
+
+
+def sql_entity_top3_gross(ds: date, de: date) -> BuiltSQL:
+    gross = gross_expr()
+    sql = (
+        "WITH RANKED AS (\n"
+        f"  SELECT ENTITY, CONTRACT_ID, {gross} AS TOTAL_GROSS,\n"
+        f"         ROW_NUMBER() OVER (PARTITION BY ENTITY ORDER BY {gross} DESC) AS RN\n"
+        '  FROM "Contract"\n'
+        "  WHERE "
+        + request_date_between()
+        + "\n)\n"
+        "SELECT ENTITY, CONTRACT_ID, TOTAL_GROSS\n"
+        "FROM RANKED\n"
+        "WHERE RN <= 3\n"
+        "ORDER BY ENTITY, RN"
+    )
+    return BuiltSQL(sql=sql, binds={"date_start": ds, "date_end": de})
+
+
+def sql_owner_vs_oul_mismatch() -> BuiltSQL:
+    sql = (
+        'SELECT *\n'
+        'FROM "Contract"\n'
+        "WHERE NVL(TRIM(OWNER_DEPARTMENT), '(NULL)') <> NVL(TRIM(DEPARTMENT_OUL), '(NULL)')\n"
+        'ORDER BY REQUEST_DATE DESC'
+    )
+    return BuiltSQL(sql=sql, binds={})
+

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -124,8 +124,8 @@ tests:
     question: "Contracts missing CONTRACT_ID (data quality check)."
     expect_contains:
       - 'FROM "Contract"'
-      - 'WHERE'
-      - 'CONTRACT_ID'
+      - "WHERE CONTRACT_ID IS NULL OR TRIM(CONTRACT_ID) = ''"
+      - 'ORDER BY REQUEST_DATE DESC'
     notes: "Check CONTRACT_ID IS NULL or blank."
 
   - name: "gross_by_stakeholder_last_90_days_slots_1_8"
@@ -134,8 +134,9 @@ tests:
       - 'FROM "Contract"'
       - 'CONTRACT_STAKEHOLDER_1'
       - 'UNION ALL'
-      - 'GROUP BY'
-      - 'SUM(NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE'
+      - 'WITH STAKEHOLDER_UNION'
+      - 'SUM(GVAL) AS TOTAL_GROSS'
+      - 'WHERE STK IS NOT NULL'
     notes: "UNION ALL across stakeholder slots; group & sum gross."
 
   - name: "top5_by_gross_ytd_2024"
@@ -144,6 +145,7 @@ tests:
       - 'FROM "Contract"'
       - 'ORDER BY NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE'
       - 'FETCH FIRST :top_n ROWS ONLY'
+      - 'REQUEST_DATE BETWEEN :date_start AND :date_end'
     notes: "YTD window; top by gross."
 
   - name: "avg_gross_per_request_type_last_6_months"
@@ -152,6 +154,7 @@ tests:
       - 'FROM "Contract"'
       - 'GROUP BY REQUEST_TYPE'
       - 'AVG('
+      - 'REQUEST_DATE BETWEEN :date_start AND :date_end'
     notes: "AVG gross by request type; windowed."
 
   - name: "monthly_trend_active_by_request_date_last_12_months"
@@ -160,6 +163,7 @@ tests:
       - 'FROM "Contract"'
       - "TRUNC(REQUEST_DATE, 'MM')"
       - 'GROUP BY'
+      - 'ORDER BY MONTH_BUCKET'
     notes: "Monthly buckets by REQUEST_DATE."
 
   - name: "entity_no_e123_total_and_count_by_status"
@@ -169,6 +173,7 @@ tests:
       - 'WHERE'
       - 'ENTITY_NO'
       - 'GROUP BY CONTRACT_STATUS'
+      - 'COUNT(*) AS CONTRACT_COUNT'
     notes: "Filter ENTITY_NO then group by status."
 
   - name: "expiring_30_60_90_three_counts"
@@ -177,6 +182,7 @@ tests:
       - 'FROM "Contract"'
       - 'END_DATE BETWEEN'
       - 'UNION ALL'
+      - 'AS BUCKET'
     notes: "Three buckets via UNION ALL."
 
   - name: "owner_dept_highest_avg_gross_last_quarter"
@@ -186,21 +192,23 @@ tests:
       - 'GROUP BY OWNER_DEPARTMENT'
       - 'AVG('
       - 'FETCH FIRST 1 ROWS ONLY'
+      - 'REQUEST_DATE BETWEEN :date_start AND :date_end'
     notes: "Top-1 by AVG gross last quarter."
 
   - name: "stakeholders_more_than_n_in_2024"
     question: "Stakeholders involved in more than N contracts in 2024."
     expect_contains:
-      - 'GROUP BY'
-      - 'HAVING COUNT(*) >'
+      - 'WITH STAKEHOLDER_HITS'
+      - 'HAVING COUNT(*) > :min_count'
+      - 'REQUEST_DATE BETWEEN :date_start AND :date_end'
     notes: "Threshold via HAVING; 2024 window."
 
   - name: "missing_representative_email"
     question: "Contracts where representative_email is missing."
     expect_contains:
       - 'FROM "Contract"'
-      - 'WHERE'
-      - 'REPRESENTATIVE_EMAIL'
+      - 'WHERE REPRESENTATIVE_EMAIL IS NULL'
+      - "TRIM(UPPER(REPRESENTATIVE_EMAIL)) IN ('', 'NA', 'N/A')"
     notes: "Null/blank email filter."
 
   - name: "requester_quarterly_totals"
@@ -211,20 +219,23 @@ tests:
       - 'REQUESTER'
       - "TRUNC(REQUEST_DATE, 'Q')"
       - 'GROUP BY'
+      - 'COUNT(*) AS CONTRACT_COUNT'
     notes: "Group by quarter; filter requester."
 
   - name: "stakeholder_departments_2024_with_totals"
     question: "For each stakeholder, list distinct departments they touched in 2024, total gross, and contract count (one row per stakeholder)."
     expect_contains:
       - 'FROM "Contract"'
-      - 'LISTAGG'
-      - 'GROUP BY'
+      - 'WITH STAKEHOLDER_DEPTS'
+      - 'LISTAGG(DISTINCT OWNER_DEPT'
+      - 'SUM(GVAL) AS TOTAL_GROSS'
     notes: "LISTAGG departments per stakeholder; 2024 window."
 
   - name: "top10_contract_pairs_last_180_days"
     question: "Top 10 contracts pairs by gross in the last 180 days."
     expect_contains:
       - 'FROM "Contract"'
+      - 'WITH PAIRS AS'
       - 'FETCH FIRST :top_n ROWS ONLY'
     skip: true
     notes: "Marked pending/skip — pairing definition ambiguous."
@@ -235,6 +246,7 @@ tests:
       - 'FROM "Contract"'
       - 'GROUP BY CONTRACT_ID'
       - 'HAVING COUNT(*) > 1'
+      - 'ORDER BY DUP_COUNT DESC'
     notes: "Duplicate check."
 
   - name: "median_gross_per_owner_dept_this_year"
@@ -243,6 +255,7 @@ tests:
       - 'FROM "Contract"'
       - 'PERCENTILE_CONT(0.5) WITHIN GROUP'
       - 'GROUP BY OWNER_DEPARTMENT'
+      - 'REQUEST_DATE BETWEEN :date_start AND :date_end'
     notes: "Median via PERCENTILE_CONT; year window."
 
   - name: "end_date_lt_start_date_check"
@@ -250,6 +263,7 @@ tests:
     expect_contains:
       - 'FROM "Contract"'
       - 'WHERE END_DATE < START_DATE'
+      - 'ORDER BY REQUEST_DATE DESC'
     notes: "Simple integrity filter."
 
   - name: "duration_mismatch_12_months"
@@ -258,6 +272,7 @@ tests:
       - 'FROM "Contract"'
       - 'REGEXP_SUBSTR'
       - 'ADD_MONTHS(START_DATE'
+      - "TRIM(UPPER(DURATION))"
     notes: "Duration text vs date delta; REGEXP + ADD_MONTHS."
 
   - name: "yoy_gross_same_period"
@@ -267,6 +282,7 @@ tests:
       - 'UNION ALL'
       - 'SUM('
       - 'REQUEST_DATE BETWEEN'
+      - 'ADD_MONTHS(:date_start, -12)'
     notes: "Two windows; compare with UNION ALL."
 
   - name: "status_active_pending_gross_threshold"
@@ -276,6 +292,7 @@ tests:
       - 'CONTRACT_STATUS'
       - '>'
       - 'NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE'
+      - ':gross_min'
     notes: "Filter status IN; gross threshold."
 
   - name: "entity_top3_contracts_last_365_days"
@@ -284,14 +301,12 @@ tests:
       - 'FROM "Contract"'
       - 'ROW_NUMBER() OVER (PARTITION BY ENTITY ORDER BY'
       - 'WHERE rn <= 3'
+      - 'REQUEST_DATE BETWEEN :date_start AND :date_end'
     notes: "Top-N per ENTITY via analytic row_number."
 
   - name: "owner_dept_vs_oul_diff"
     question: "OWNER_DEPARTMENT vs DEPARTMENT_OUL comparison (where OUL is the lead); list any cases."
     expect_contains:
       - 'FROM "Contract"'
-      - 'WHERE'
-      - 'DEPARTMENT_OUL'
-      - '<>'
-      - 'OWNER_DEPARTMENT'
+      - "NVL(TRIM(OWNER_DEPARTMENT), '(NULL)') <> NVL(TRIM(DEPARTMENT_OUL), '(NULL)')"
     notes: "Find mismatches between OUL and Owner department."


### PR DESCRIPTION
## Summary
- add a contract builder entry point that routes intent patterns for cases 15–35 to dedicated SQL templates
- provide reusable SQL template helpers for stakeholder unpivoting, gross metrics, and date windows used by those cases
- update the DW golden expectations to assert the new deterministic SQL for questions 15–35

## Testing
- pytest apps/dw/tests/test_projection.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68d834b17cd8832384a8a9addbbde66f