### PR TITLE
Support relative date tags in DW golden tests

### DIFF
--- a/apps/dw/tests/routes.py
+++ b/apps/dw/tests/routes.py
@@ -12,4 +12,8 @@ def run_golden():
     limit = req.get("limit")
 
     report = run_golden_tests(flask_app=current_app, namespace=ns, limit=limit)
+    if not report.get("ok", True):
+        report.setdefault("error", "Golden YAML failed to load or contained no matching cases.")
+        report.setdefault("namespace", ns)
+        return jsonify(report), 400
     return jsonify(report), 200


### PR DESCRIPTION
## Summary
- extend the DW golden test runner with a custom YAML loader that supports relative-date tags and bind normalization
- ensure golden test execution serializes bind values for requests and surfaces namespace metadata in reports
- return a 400 error from the admin golden route when the golden YAML fails to load so callers see a clear failure

## Testing
- pytest apps/dw/tests/test_projection.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68d8c47c23988323b427faaeed87bf6e