### PR TITLE
Handle YTD overlap logic and tolerant golden SQL checks

### DIFF
--- a/apps/dw/contracts/builder.py
+++ b/apps/dw/contracts/builder.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import re
 from datetime import date, datetime
 from typing import Dict, Tuple, Optional, List
 
@@ -6,10 +7,17 @@ from typing import Dict, Tuple, Optional, List
 #       Cross-table / DocuWare-generic helpers should live elsewhere.
 
 _NET = "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
-_GROSS = f"{_NET} + CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 THEN {_NET} * NVL(VAT,0) ELSE NVL(VAT,0) END"
+
+
+def gross_expr() -> str:
+    return (
+        "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
+        "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0) * NVL(VAT,0) ELSE NVL(VAT,0) END"
+    )
+
 
 # --- Helpers: measures / overlap predicate ---
-GROSS_EXPR = _GROSS
+GROSS_EXPR = gross_expr()
 
 
 def overlap_pred() -> str:
@@ -25,13 +33,13 @@ def sql_missing_contract_id() -> str:
     )
 
 
-# --- Case (17): YTD top 5 by gross ---
-def sql_ytd_top5_gross() -> str:
+# --- Case (17): YTD top N by gross ---
+def sql_ytd_top_gross() -> str:
     return (
         'SELECT * FROM "Contract"\n'
         f"WHERE {overlap_pred()}\n"
-        f"ORDER BY {GROSS_EXPR} DESC\n"
-        "FETCH FIRST 5 ROWS ONLY"
+        f"ORDER BY {gross_expr()} DESC\n"
+        "FETCH FIRST :top_n ROWS ONLY"
     )
 
 
@@ -77,7 +85,10 @@ def _ensure_date_binds(binds: Dict[str, object], *keys: str) -> None:
 
 def _overlap_pred(date_start_bind: str = ":date_start", date_end_bind: str = ":date_end") -> str:
     # Strict overlap: start <= end AND end >= start (both not null)
-    return f"(START_DATE IS NOT NULL AND END_DATE IS NOT NULL AND START_DATE <= {date_end_bind} AND END_DATE >= {date_start_bind})"
+    return (
+        "(START_DATE IS NOT NULL AND END_DATE IS NOT NULL "
+        f"AND START_DATE <= {date_end_bind} AND END_DATE >= {date_start_bind})"
+    )
 
 def build_contracts_sql(
     intent: Dict,
@@ -108,30 +119,49 @@ def build_contracts_sql(
     if "missing contract_id" in q_norm or "data quality" in q_norm:
         return sql_missing_contract_id(), {}
 
-    if "ytd" in q_norm and "top 5" in q_norm and "gross" in q_norm:
+    if "ytd" in q_norm and "gross" in q_norm and "top" in q_norm:
         today_obj = (
             intent.get("today")
             or (intent.get("notes") or {}).get("today")
             or date.today()
         )
         today_date = _as_date(today_obj)
+        year_match = re.search(r"\b(20\d{2})\b", q_norm)
+        year = int(year_match.group(1)) if year_match else today_date.year
+        top_hint = re.search(r"top\s+(\d+)", q_norm)
+        default_top = int(top_hint.group(1)) if top_hint else 5
+        try:
+            top_n = int(intent.get("top_n", default_top))
+        except (TypeError, ValueError):
+            top_n = default_top
         binds = {
-            "date_start": date(today_date.year, 1, 1),
+            "date_start": date(year, 1, 1),
             "date_end": today_date,
-            "top_n": 5,
+            "top_n": top_n,
         }
         _ensure_date_binds(binds, "date_start", "date_end")
-        return sql_ytd_top5_gross(), binds
+        return sql_ytd_top_gross(), binds
 
     if "year-over-year" in q_norm or "yoy" in q_norm:
-        binds = {
-            "ds": intent.get("ds"),
-            "de": intent.get("de"),
-            "p_ds": intent.get("p_ds"),
-            "p_de": intent.get("p_de"),
-        }
+        today_obj = (
+            intent.get("today")
+            or (intent.get("notes") or {}).get("today")
+            or date.today()
+        )
+        today_date = _as_date(today_obj)
+        explicit = intent.get("explicit_dates") or {}
+        ds = explicit.get("ds") or explicit.get("start") or intent.get("ds")
+        de = explicit.get("de") or explicit.get("end") or intent.get("de")
+        p_ds = explicit.get("p_ds") or explicit.get("previous_ds") or intent.get("p_ds")
+        p_de = explicit.get("p_de") or explicit.get("previous_de") or intent.get("p_de")
+        if not all([ds, de, p_ds, p_de]):
+            this_year = today_date.year
+            ds = ds or date(this_year, 1, 1)
+            de = de or date(this_year, 3, 31)
+            p_ds = p_ds or date(this_year - 1, 1, 1)
+            p_de = p_de or date(this_year - 1, 3, 31)
+        binds = {"ds": ds, "de": de, "p_ds": p_ds, "p_de": p_de}
         _ensure_date_binds(binds, "ds", "de", "p_ds", "p_de")
-        binds = {k: v for k, v in binds.items() if v is not None}
         return sql_yoy_same_period_overlap(), binds
 
     if "owner_department vs department_oul" in q_norm or (


### PR DESCRIPTION
## Summary
- make golden runner SQL fragment checks whitespace- and case-tolerant by canonicalising SQL text
- add a gross_expr helper and enhance the YTD top-N and YoY contract SQL branches to use overlap windows with proper date binds
- keep the OWNER_DEPARTMENT vs DEPARTMENT_OUL mismatch special case ahead of the fallback logic

## Testing
- pytest apps/dw/tests/test_projection.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68d8d57ef57c832397011a0dbbd133d1