### PR TITLE
Extend golden YAML date macros

### DIFF
--- a/apps/dw/tests/yaml_tags.py
+++ b/apps/dw/tests/yaml_tags.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 import os
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from typing import Any, Union
 
 import yaml
@@ -36,6 +36,27 @@ def _first_day_of_quarter(d: date) -> date:
     q = (d.month - 1) // 3  # 0..3
     first_month = q * 3 + 1
     return d.replace(month=first_month, day=1)
+
+
+def _start_of_month(offset: Union[int, str, None]) -> date:
+    base = _today().replace(day=1)
+    if offset is None:
+        return base
+    return base + relativedelta(months=_parse_int(offset, 0))
+
+
+def _end_of_month(offset: Union[int, str, None]) -> date:
+    start = _start_of_month(offset)
+    next_month = start + relativedelta(months=1)
+    return next_month - timedelta(days=1)
+
+
+def _start_of_last_month() -> date:
+    return _start_of_month(-1)
+
+
+def _end_of_last_month() -> date:
+    return _end_of_month(-1)
 
 def _start_of_year(offset_or_year: Union[int, str, None]) -> date:
     t = _today()
@@ -76,7 +97,28 @@ def _days_ahead(n: Union[int, str]) -> date:
     return _today() + timedelta(days=_parse_int(n))
 
 def _quarter_ago(n: Union[int, str]) -> date:
-    return _today() - relativedelta(months=3 * _parse_int(n))
+    base = _today().replace(day=1)
+    current_q_start_month = ((base.month - 1) // 3) * 3 + 1
+    current_q_start = date(base.year, current_q_start_month, 1)
+    return current_q_start - relativedelta(months=3 * _parse_int(n))
+
+
+def _months_ago(n: Union[int, str]) -> date:
+    return _today() - relativedelta(months=_parse_int(n))
+
+
+def _months_ahead(n: Union[int, str]) -> date:
+    return _today() + relativedelta(months=_parse_int(n))
+
+
+def _iso_date(value: Union[str, date]) -> date:
+    if isinstance(value, date):
+        return value
+    s = str(value).strip()
+    try:
+        return date.fromisoformat(s)
+    except ValueError:
+        return datetime.fromisoformat(s).date()
 
 
 # --- YAML constructors ---
@@ -88,9 +130,39 @@ def _construct_scalar(loader: GoldenLoader, node: yaml.Node) -> Any:
         return loader.construct_scalar(node)
     return loader.construct_object(node)
 
+
+def _normalise_optional(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, str) and not value.strip():
+        return None
+    return value
+
+
 def construct_today(loader: GoldenLoader, node: yaml.Node) -> date:
     _ = _construct_scalar(loader, node)  # ignore payload if any
     return _today()
+
+
+def construct_start_of_month(loader: GoldenLoader, node: yaml.Node) -> date:
+    val = _normalise_optional(_construct_scalar(loader, node))
+    return _start_of_month(val)
+
+
+def construct_end_of_month(loader: GoldenLoader, node: yaml.Node) -> date:
+    val = _normalise_optional(_construct_scalar(loader, node))
+    return _end_of_month(val)
+
+
+def construct_start_of_last_month(loader: GoldenLoader, node: yaml.Node) -> date:
+    _ = _construct_scalar(loader, node)
+    return _start_of_last_month()
+
+
+def construct_end_of_last_month(loader: GoldenLoader, node: yaml.Node) -> date:
+    _ = _construct_scalar(loader, node)
+    return _end_of_last_month()
+
 
 def construct_days_ago(loader: GoldenLoader, node: yaml.Node) -> date:
     val = _construct_scalar(loader, node)
@@ -121,13 +193,35 @@ def construct_quarter_ago(loader: GoldenLoader, node: yaml.Node) -> date:
     return _quarter_ago(val)
 
 
+def construct_months_ago(loader: GoldenLoader, node: yaml.Node) -> date:
+    val = _construct_scalar(loader, node)
+    return _months_ago(val)
+
+
+def construct_months_ahead(loader: GoldenLoader, node: yaml.Node) -> date:
+    val = _construct_scalar(loader, node)
+    return _months_ahead(val)
+
+
+def construct_iso(loader: GoldenLoader, node: yaml.Node) -> date:
+    val = _construct_scalar(loader, node)
+    return _iso_date(val)
+
+
 def register_yaml_tags() -> None:
     """Register all custom YAML tags on the GoldenLoader."""
-    yaml.add_constructor("!today",             construct_today,            Loader=GoldenLoader)
-    yaml.add_constructor("!days_ago",          construct_days_ago,         Loader=GoldenLoader)
-    yaml.add_constructor("!days_ahead",        construct_days_ahead,       Loader=GoldenLoader)
-    yaml.add_constructor("!start_of_year",     construct_start_of_year,    Loader=GoldenLoader)
-    yaml.add_constructor("!end_of_year",       construct_end_of_year,      Loader=GoldenLoader)
-    yaml.add_constructor("!start_of_quarter",  construct_start_of_quarter, Loader=GoldenLoader)
-    yaml.add_constructor("!end_of_quarter",    construct_end_of_quarter,   Loader=GoldenLoader)
-    yaml.add_constructor("!quarter_ago",       construct_quarter_ago,      Loader=GoldenLoader)
+    yaml.add_constructor("!today",               construct_today,              Loader=GoldenLoader)
+    yaml.add_constructor("!start_of_month",      construct_start_of_month,      Loader=GoldenLoader)
+    yaml.add_constructor("!end_of_month",        construct_end_of_month,        Loader=GoldenLoader)
+    yaml.add_constructor("!start_of_last_month", construct_start_of_last_month, Loader=GoldenLoader)
+    yaml.add_constructor("!end_of_last_month",   construct_end_of_last_month,   Loader=GoldenLoader)
+    yaml.add_constructor("!days_ago",            construct_days_ago,            Loader=GoldenLoader)
+    yaml.add_constructor("!days_ahead",          construct_days_ahead,          Loader=GoldenLoader)
+    yaml.add_constructor("!months_ago",          construct_months_ago,          Loader=GoldenLoader)
+    yaml.add_constructor("!months_ahead",        construct_months_ahead,        Loader=GoldenLoader)
+    yaml.add_constructor("!start_of_year",       construct_start_of_year,       Loader=GoldenLoader)
+    yaml.add_constructor("!end_of_year",         construct_end_of_year,         Loader=GoldenLoader)
+    yaml.add_constructor("!start_of_quarter",    construct_start_of_quarter,    Loader=GoldenLoader)
+    yaml.add_constructor("!end_of_quarter",      construct_end_of_quarter,      Loader=GoldenLoader)
+    yaml.add_constructor("!quarter_ago",         construct_quarter_ago,         Loader=GoldenLoader)
+    yaml.add_constructor("!iso",                 construct_iso,                 Loader=GoldenLoader)


### PR DESCRIPTION
## Summary
- extend the golden YAML loader with month-based macros and an !iso helper for bind dates
- normalize the quarter macro to return the start of the requested quarter
- add optional-scalar handling so tags without arguments fall back to sensible defaults

## Testing
- pytest apps/dw/tests -k nothing *(fails: missing dependency `pydantic`)*

------
https://chatgpt.com/codex/tasks/task_e_68d8f10666b4832388bf295167cd97f0