### PR TITLE
Add contract intent parsing and planner enhancements

### DIFF
--- a/apps/dw/contracts/intent.py
+++ b/apps/dw/contracts/intent.py
@@ -1,0 +1,116 @@
+"""Intent parsing heuristics for DocuWare Contract questions."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class DWIntent:
+    """Structured interpretation of a natural-language DW question."""
+
+    question: str
+    agg: Optional[str] = None
+    group_by: Optional[str] = None
+    sort_by: Optional[str] = None
+    sort_desc: Optional[bool] = None
+    top_n: Optional[int] = None
+    has_time_window: Optional[bool] = None
+    date_column: Optional[str] = None
+    explicit_dates: Optional[Dict[str, date]] = None
+    measure_sql: Optional[str] = None
+    notes: Dict[str, Any] = field(default_factory=dict)
+    wants_all_columns: bool = True
+    # signals
+    is_bottom: bool = False
+    by_dimension_hint: Optional[str] = None
+
+
+_BOTTOM_RE = re.compile(r"\b(bottom|lowest|least|smallest|min)\b", re.I)
+_TOP_RE = re.compile(r"\btop\s+(\d+)\b", re.I)
+_BOTTOM_TOP_RE = re.compile(r"\b(?:bottom|lowest|least|smallest|min)\s+(\d+)\b", re.I)
+_GROUP_HINT_RE = re.compile(r"\b(?:per|by)\b", re.I)
+_DIMENSION_PATTERNS: Dict[str, str] = {
+    r"(owner\s*department|owner_department|owner\s+dept)": "OWNER_DEPARTMENT",
+    r"(department_oul|oul\b)": "DEPARTMENT_OUL",
+    r"(entity_no|entity\s*no|entityno)": "ENTITY_NO",
+    r"\bentity\b": "ENTITY",
+}
+
+
+def parse_intent(question: str) -> DWIntent:
+    """Parse natural-language question into a :class:`DWIntent`."""
+
+    q = (question or "").strip()
+    intent = DWIntent(question=q)
+
+    if not q:
+        return intent
+
+    lowered = q.lower()
+
+    # Aggregation cues
+    if re.search(r"\bcount\b", lowered):
+        intent.agg = "count"
+        intent.wants_all_columns = False
+    elif re.search(r"\baverage|avg\b", lowered):
+        intent.agg = "avg"
+    elif re.search(r"\b(sum|total|amount)\b", lowered):
+        intent.agg = "sum"
+
+    # measure selection
+    if re.search(r"\bgross\b", lowered):
+        intent.measure_sql = (
+            "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE WHEN NVL(VAT,0) "
+            "BETWEEN 0 AND 1 THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0) * NVL(VAT,0) "
+            "ELSE NVL(VAT,0) END"
+        )
+    elif re.search(r"\bnet\b", lowered):
+        intent.measure_sql = "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
+
+    # detect top/bottom N
+    m = _TOP_RE.search(q)
+    if m:
+        intent.top_n = int(m.group(1))
+        intent.sort_desc = True
+
+    if _BOTTOM_RE.search(q):
+        m2 = _BOTTOM_TOP_RE.search(q)
+        if m2:
+            intent.top_n = int(m2.group(1))
+        intent.is_bottom = True
+        intent.sort_desc = False
+
+    # GROUP BY hints
+    if _GROUP_HINT_RE.search(q):
+        for pattern, dim in _DIMENSION_PATTERNS.items():
+            if re.search(pattern, q, re.I):
+                intent.group_by = dim
+                intent.by_dimension_hint = dim
+                break
+
+    # window hints
+    if "requested" in lowered:
+        intent.date_column = "REQUEST_DATE"
+    elif re.search(r"\b(expir(?:e|y|ing)|end\s*date)\b", lowered):
+        intent.date_column = "END_ONLY"
+    else:
+        intent.date_column = "OVERLAP"
+
+    # Year-to-date handling
+    if re.search(r"\b(ytd|year\s*to\s*date)\b", lowered):
+        intent.notes["ytd"] = True
+        intent.date_column = "OVERLAP"
+
+    # simple cues for time windows
+    if re.search(r"\blast\s+month\b", lowered):
+        intent.has_time_window = True
+    elif re.search(r"\bnext\s+\d+\s+days\b", lowered):
+        intent.has_time_window = True
+    elif re.search(r"\blast\s+\d+\s+months\b", lowered):
+        intent.has_time_window = True
+
+    return intent

--- a/apps/dw/contracts/planner.py
+++ b/apps/dw/contracts/planner.py
@@ -1,0 +1,178 @@
+"""SQL planner for DocuWare Contract table based on DWIntent."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Dict, Optional, Tuple
+
+from .intent import DWIntent
+
+DIMENSIONS_ALLOWED = {"OWNER_DEPARTMENT", "DEPARTMENT_OUL", "ENTITY_NO", "ENTITY"}
+
+
+def _overlap_clause() -> str:
+    return (
+        "(START_DATE IS NOT NULL AND END_DATE IS NOT NULL "
+        "AND START_DATE <= :date_end AND END_DATE >= :date_start)"
+    )
+
+
+def _build_window(intent: DWIntent, binds: Dict[str, object]) -> Tuple[Optional[str], Optional[str]]:
+    """Return WHERE clause for window and the window kind label."""
+
+    has_start = "date_start" in binds and binds["date_start"] is not None
+    has_end = "date_end" in binds and binds["date_end"] is not None
+    if not (has_start and has_end):
+        return None, None
+
+    if intent.date_column == "REQUEST_DATE":
+        return "REQUEST_DATE BETWEEN :date_start AND :date_end", "REQUEST"
+    if intent.date_column == "END_ONLY":
+        return "END_DATE BETWEEN :date_start AND :date_end", "END_ONLY"
+    return _overlap_clause(), "OVERLAP"
+
+
+def _apply_sort_asc_if_bottom(intent: DWIntent, default_desc: bool) -> bool:
+    """Return final sort_desc considering 'bottom/lowest' signals."""
+
+    if intent.sort_desc is not None:
+        return bool(intent.sort_desc)
+    if intent.is_bottom:
+        return False
+    return default_desc
+
+
+def build_owner_vs_oul_mismatch_sql() -> str:
+    """Rows where OWNER_DEPARTMENT and DEPARTMENT_OUL differ (lead = OUL)."""
+
+    return (
+        'SELECT OWNER_DEPARTMENT, DEPARTMENT_OUL, COUNT(*) AS CNT
+'
+        'FROM "Contract"
+'
+        "WHERE DEPARTMENT_OUL IS NOT NULL
+"
+        "  AND NVL(TRIM(OWNER_DEPARTMENT),'(None)') <> NVL(TRIM(DEPARTMENT_OUL),'(None)')
+"
+        "GROUP BY OWNER_DEPARTMENT, DEPARTMENT_OUL
+"
+        "ORDER BY CNT DESC"
+    )
+
+
+def _apply_intent_binds(intent: DWIntent, binds: Dict[str, object]) -> None:
+    if intent.explicit_dates:
+        start = intent.explicit_dates.get("start")
+        end = intent.explicit_dates.get("end")
+        if start and "date_start" not in binds:
+            binds["date_start"] = start
+        if end and "date_end" not in binds:
+            binds["date_end"] = end
+
+    if intent.notes.get("ytd"):
+        if "date_start" not in binds or "date_end" not in binds:
+            today = date.today()
+            binds.setdefault("date_start", date(today.year, 1, 1))
+            binds.setdefault("date_end", today)
+
+
+def build_sql(intent: DWIntent) -> Tuple[str, Dict[str, object], Dict[str, object]]:
+    """Build final SQL + binds + meta for the Contract table based on resolved intent."""
+
+    binds: Dict[str, object] = {}
+    meta: Dict[str, object] = {}
+
+    measure = intent.measure_sql or "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
+
+    q_lower = (intent.question or "").lower()
+    if intent.notes.get("owner_vs_oul") or ("vs" in q_lower and "department_oul" in q_lower):
+        sql = build_owner_vs_oul_mismatch_sql()
+        meta.update({"explain": "Owner vs OUL mismatch rows (non-equal)."})
+        return sql, binds, meta
+
+    _apply_intent_binds(intent, binds)
+
+    where_sql, window_kind = _build_window(intent, binds)
+    if window_kind:
+        meta["window_kind"] = window_kind
+
+    if intent.group_by is None:
+        sort_desc = _apply_sort_asc_if_bottom(intent, default_desc=True)
+        order_sql = f"ORDER BY {measure} {'DESC' if sort_desc else 'ASC'}"
+
+        top_sql = ""
+        if intent.top_n:
+            binds["top_n"] = intent.top_n
+            top_sql = "FETCH FIRST :top_n ROWS ONLY"
+
+        where_clause = f"WHERE {where_sql}
+" if where_sql else ""
+        sql = (
+            'SELECT * FROM "Contract"
+'
+            f"{where_clause}"
+            f"{order_sql}
+"
+            f"{top_sql}"
+        ).strip()
+
+        meta.update({
+            "explain": (
+                f"{'Top' if sort_desc else 'Bottom'} {intent.top_n or ''} by "
+                f"{'GROSS' if measure != 'NVL(CONTRACT_VALUE_NET_OF_VAT,0)' else 'NET'}"
+            ).strip(),
+            "binds": {k: v for k, v in binds.items() if k == "top_n"},
+        })
+        return sql, binds, meta
+
+    group_col = intent.group_by
+    if group_col not in DIMENSIONS_ALLOWED:
+        group_col = "OWNER_DEPARTMENT"
+
+    agg = (intent.agg or ("SUM" if measure != "COUNT(*)" else "COUNT")).upper()
+    if agg not in {"SUM", "AVG", "COUNT", "MEDIAN"}:
+        agg = "SUM"
+
+    sort_desc = _apply_sort_asc_if_bottom(intent, default_desc=True)
+    order_sql = f"ORDER BY MEASURE {'DESC' if sort_desc else 'ASC'}"
+
+    top_sql = ""
+    if intent.top_n:
+        binds["top_n"] = intent.top_n
+        top_sql = "FETCH FIRST :top_n ROWS ONLY"
+
+    if agg == "COUNT":
+        select_measure = "COUNT(*)"
+    else:
+        select_measure = f"{agg}({measure})"
+
+    select_sql = (
+        "SELECT
+"
+        f"  {group_col} AS GROUP_KEY,
+"
+        f"  {select_measure} AS MEASURE
+"
+    )
+
+    where_clause = f"WHERE {where_sql}
+" if where_sql else ""
+    sql = (
+        f'{select_sql}FROM "Contract"
+'
+        f"{where_clause}"
+        f"GROUP BY {group_col}
+"
+        f"{order_sql}
+"
+        f"{top_sql}"
+    ).strip()
+
+    meta.update({
+        "group_by": group_col,
+        "agg": agg.lower(),
+        "gross": measure != "NVL(CONTRACT_VALUE_NET_OF_VAT,0)",
+        "explain": f"{agg.title()} per {group_col} using {window_kind or 'ALL_TIME'} window.",
+        "binds": {k: v for k, v in binds.items() if k == "top_n"},
+    })
+    return sql, binds, meta


### PR DESCRIPTION
## Summary
- add a lightweight `DWIntent` structure and parser for contract questions, including bottom detection, YTD hints, and group-by dimension mapping
- introduce a deterministic contract planner that applies the new intent signals, supports owner-vs-OUL mismatch reporting, and normalizes top/bottom ordering
- extend the golden test runner with additional temporal YAML tags, a generic fallback constructor, and more robust SQL normalization while hardening Oracle bind date coercion

## Testing
- pytest apps/dw/tests/test_dw_golden.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68daa7ee2ef08323a8ca4b6df55805bd