### PR TITLE
Add contract SQL helper routing and improve golden fallbacks

### DIFF
--- a/apps/dw/planner.py
+++ b/apps/dw/planner.py
@@ -1,11 +1,83 @@
 from __future__ import annotations
-from typing import Dict, Tuple, Optional, List
+from typing import Any, Dict, List, Optional, Tuple
+
 from apps.dw.contracts.builder import build_contracts_sql
+from apps.dw.contracts.builder_contracts import (
+    GROSS_EXPR,
+    build_grouped_gross_per_dim,
+    build_owner_vs_oul_diff,
+    build_top_contracts_by_gross,
+    build_top_contracts_by_net,
+    build_yoy_overlap,
+)
+
+# Re-exported so legacy callers can import from planner if needed.
+_ = GROSS_EXPR
 
 
-def build_sql(question: str, intent: Dict, *, table: str = "Contract", fts_columns: Optional[List[str]] = None) -> Tuple[str, Dict[str, object]]:
-    """
-    Thin planner facade used by tests and admin routes.
-    Delegates to the table-specific builder for Contract.
-    """
+def _is_contracts_namespace(namespace: str) -> bool:
+    return namespace.startswith("dw::")
+
+
+def _route_contract_intent(intent: Dict[str, Any]) -> Tuple[Optional[str], Dict[str, Any], str]:
+    """Build SQL for Contract questions. Comments in English only."""
+
+    q = (intent.get("notes", {}) or {}).get("q", "") or intent.get("q", "")
+    q = str(q or "")
+    top_n = intent.get("top_n")
+    ds = ":date_start"
+    de = ":date_end"
+    # Switches:
+    use_window = bool(intent.get("has_time_window"))
+    q_lower = q.lower()
+    wants_gross = bool(intent.get("wants_gross") or ("gross" in q_lower))
+    group_dim = intent.get("group_by")
+
+    # Top/Bottom by NET or GROSS:
+    if top_n and not group_dim and "contract" in q_lower:
+        if wants_gross:
+            sql, extra_binds, explain = build_top_contracts_by_gross(q, use_window, ":top_n", ds, de)
+        else:
+            sql, extra_binds, explain = build_top_contracts_by_net(q, use_window, ":top_n", ds, de)
+        return sql, extra_binds, explain
+
+    # Per-dimension gross (OWNER_DEPARTMENT / DEPARTMENT_OUL / ENTITY / ENTITY_NO / CONTRACT_STATUS / REQUEST_TYPE):
+    if group_dim in {"OWNER_DEPARTMENT", "DEPARTMENT_OUL", "ENTITY", "ENTITY_NO", "CONTRACT_STATUS", "REQUEST_TYPE"}:
+        agg = intent.get("agg") or "SUM"
+        sql, extra_binds, explain = build_grouped_gross_per_dim(group_dim, use_window, ds, de, agg=agg)
+        return sql, extra_binds, explain
+
+    # Owner vs OUL comparison:
+    if "owner department" in q_lower and "oul" in q_lower:
+        return build_owner_vs_oul_diff()
+
+    # Year-over-year comparison:
+    if "year-over-year" in q_lower or "yoy" in q_lower:
+        # Binds expected: :ds, :de, :p_ds, :p_de (built by date parser)
+        sql, extra_binds, explain = build_yoy_overlap(":ds", ":de", ":p_ds", ":p_de")
+        return sql, extra_binds, explain
+
+    # Fallback to previous deterministic logic:
+    return None, {}, ""
+
+
+def build_sql(
+    question: str,
+    intent: Dict,
+    *,
+    table: str = "Contract",
+    fts_columns: Optional[List[str]] = None,
+) -> Tuple[str, Dict[str, object]]:
+    """Thin planner facade used by tests and admin routes."""
+
+    namespace = str(intent.get("namespace") or "dw::common")
+    if _is_contracts_namespace(namespace):
+        sql, extra_binds, _ = _route_contract_intent(intent)
+        if sql:
+            binds = dict(intent.get("binds") or {})
+            if intent.get("top_n") is not None and "top_n" not in binds:
+                binds["top_n"] = intent["top_n"]
+            binds.update(extra_binds or {})
+            return sql, binds
+
     return build_contracts_sql(intent, table=table, fts_columns=fts_columns)

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -415,8 +415,10 @@ cases:
         - "SELECT 'PREVIOUS' AS PERIOD"
         - 'SUM('
         - 'UNION ALL'
-        - 'WHERE REQUEST_DATE BETWEEN :ds AND :de'
-        - 'WHERE REQUEST_DATE BETWEEN :p_ds AND :p_de'
+        - 'START_DATE <= :de'
+        - 'END_DATE >= :ds'
+        - 'START_DATE <= :p_de'
+        - 'END_DATE >= :p_ds'
       must_not: []
       notes: "YoY totals comparing overlap windows for current vs previous periods."
     assertions: {}

--- a/apps/dw/tests/golden_runner.py
+++ b/apps/dw/tests/golden_runner.py
@@ -252,7 +252,7 @@ def _generic_start(loader: Any, suffix: str, node: yaml.Node) -> str:
         return _start_of_quarter(loader, node)
     if s in {"last_quarter", "previous_quarter"}:
         return _start_of_last_quarter(loader, node)
-    return _iso(_today())
+    return _start_of_last_month(loader, node)
 
 
 def _generic_end(loader: Any, suffix: str, node: yaml.Node) -> str:
@@ -274,7 +274,7 @@ def _generic_end(loader: Any, suffix: str, node: yaml.Node) -> str:
         return _end_of_quarter(loader, node)
     if s in {"last_quarter", "previous_quarter"}:
         return _end_of_last_quarter(loader, node)
-    return _iso(_today())
+    return _end_of_last_month(loader, node)
 
 
 GoldenLoader.add_constructor("!today", _construct_today)
@@ -333,6 +333,10 @@ def _generic_construct(loader: yaml.Loader, node: yaml.Node):
             base = _today().replace(day=1) - relativedelta(months=numeric)
             last = monthrange(base.year, base.month)[1]
             return _iso(base.replace(day=last))
+    if tag.startswith("!start_of_"):
+        return _start_of_last_month(loader, node)
+    if tag.startswith("!end_of_"):
+        return _end_of_last_month(loader, node)
     return _iso(_today())
 
 


### PR DESCRIPTION
## Summary
- add contract-specific SQL helper functions for top/bottom, grouped gross, owner vs OUL, and YoY queries
- route DW planner intents through the new helpers and normalize Oracle bind parameters to real dates
- expand golden loader fallbacks and update YoY assertions to cover overlap predicates

## Testing
- pytest apps/dw/tests/golden.py *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_68daead5a6e88323be3f87833755a02a