### PR TITLE
Add request type synonym support across DW filters

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -232,7 +232,9 @@ def derive_sql_for_test(
         binds.update(test_binds)
 
     if sql and rate_comment and rate_comment.strip():
-        hints = parse_rate_hints(rate_comment)
+        settings_obj = _get_settings()
+        getter = getattr(settings_obj, "get_json", None) if settings_obj else None
+        hints = parse_rate_hints(rate_comment, getter)
         if hints.where_sql:
             sql = append_where(sql, hints.where_sql)
             binds.update(hints.where_binds)

--- a/apps/dw/attempts.py
+++ b/apps/dw/attempts.py
@@ -118,7 +118,16 @@ def run_attempt(
     }
 
     if sql and rate_comment and rate_comment.strip():
-        hints = parse_rate_hints(rate_comment)
+        getter = None
+        app_config = getattr(app, "config", {}) if app else {}
+        pipeline = None
+        if hasattr(app_config, "get"):
+            pipeline = app_config.get("PIPELINE") or app_config.get("pipeline")
+        elif isinstance(app_config, dict):
+            pipeline = app_config.get("PIPELINE") or app_config.get("pipeline")
+        settings_obj = getattr(pipeline, "settings", None) if pipeline else None
+        getter = getattr(settings_obj, "get_json", None) if settings_obj else None
+        hints = parse_rate_hints(rate_comment, getter)
         if hints.where_sql:
             sql = append_where(sql, hints.where_sql)
             binds.update(hints.where_binds)

--- a/apps/dw/contracts/synonyms.py
+++ b/apps/dw/contracts/synonyms.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+DEFAULT_REQUEST_TYPE_SYNONYMS: Dict[str, List[str]] = {
+    "RENEWAL": ["renew", "renewal", "renew contract", "renewed", "extension"],
+    "NEW CONTRACT": ["new", "new contract"],
+    "ADDENDUM": ["addendum", "amendment", "appendix"],
+}
+
+
+def _normalize_list(values: Iterable[Any]) -> List[str]:
+    out: List[str] = []
+    for v in values:
+        if v is None:
+            continue
+        text = str(v).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def normalize_key(val: Optional[str]) -> str:
+    return (val or "").strip().upper()
+
+
+def _load_settings_synonyms(getter: Callable[..., Any]) -> Optional[Dict[str, List[str]]]:
+    for kwargs in (
+        {"default": None, "scope": "namespace"},
+        {"default": None},
+        {},
+    ):
+        try:
+            cfg = getter("DW_REQUEST_TYPE_SYNONYMS", **kwargs)
+        except TypeError:
+            continue
+        if isinstance(cfg, dict) and cfg:
+            fixed: Dict[str, List[str]] = {}
+            for key, arr in cfg.items():
+                if isinstance(arr, (list, tuple)):
+                    fixed[normalize_key(str(key))] = _normalize_list(arr)
+            if fixed:
+                return fixed
+        break
+    return None
+
+
+def get_request_type_synonyms(
+    settings_get_json: Optional[Callable[..., Any]],
+) -> Dict[str, List[str]]:
+    if callable(settings_get_json):
+        loaded = _load_settings_synonyms(settings_get_json)
+        if loaded:
+            return loaded
+    return DEFAULT_REQUEST_TYPE_SYNONYMS
+
+
+def _prepare_synonyms_map(
+    synonyms_map: Dict[str, Iterable[Any]]
+) -> Dict[str, List[str]]:
+    prepared: Dict[str, List[str]] = {}
+    for canon, items in synonyms_map.items():
+        prepared[normalize_key(canon)] = _normalize_list(items)
+    return prepared
+
+
+def _match_candidates(
+    value_up: str, synonyms_map: Dict[str, List[str]]
+) -> Tuple[List[str], Optional[str]]:
+    if value_up in synonyms_map:
+        return list(synonyms_map[value_up]), value_up
+    for canon, syns in synonyms_map.items():
+        for term in syns:
+            term_up = normalize_key(term)
+            if term_up and value_up == term_up:
+                return list(syns), canon
+    return [], None
+
+
+def build_request_type_filter_sql(
+    value: str,
+    synonyms_map: Dict[str, Iterable[Any]],
+    *,
+    use_like: bool = True,
+    bind_prefix: str = "rt",
+) -> Tuple[str, Dict[str, Any]]:
+    v = (value or "").strip()
+    v_up = v.upper()
+    normalized_map = _prepare_synonyms_map(synonyms_map)
+
+    candidates, _ = _match_candidates(v_up, normalized_map)
+
+    binds: Dict[str, Any] = {}
+    parts: List[str] = []
+
+    def _append_term(term: str, idx: int) -> None:
+        key = f"{bind_prefix}_{idx}"
+        if use_like:
+            binds[key] = f"%{term}%"
+            parts.append(f"UPPER(TRIM(REQUEST_TYPE)) LIKE UPPER(:{key})")
+        else:
+            binds[key] = term.upper()
+            parts.append(f"UPPER(TRIM(REQUEST_TYPE)) = :{key}")
+
+    if candidates:
+        idx = 0
+        for term in candidates:
+            if term is None:
+                continue
+            text = str(term).strip()
+            if not text:
+                continue
+            _append_term(text, idx)
+            idx += 1
+        if not parts:
+            parts.append("(REQUEST_TYPE IS NULL OR TRIM(REQUEST_TYPE)='')")
+        fragment = "(" + " OR ".join(parts) + ")"
+        return fragment, binds
+
+    _append_term(v, 0)
+    fragment = "(" + " OR ".join(parts) + ")" if len(parts) > 1 else parts[0]
+    return fragment, binds

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -460,12 +460,15 @@ cases:
         - 'ORDER BY MEASURE ASC'
 
   - question: "Show contracts where REQUEST TYPE = Renewal"
-    expect_sql_contains:
+    expect_contains:
       - 'FROM "Contract"'
-      - 'UPPER(REQUEST_TYPE) LIKE UPPER(:req_like)'
+      - 'UPPER(TRIM(REQUEST_TYPE)) LIKE UPPER(:rt_0)'
       - 'ORDER BY REQUEST_DATE DESC'
-    expect_binds:
-      req_like: "%renew%"
+    expect:
+      must_not:
+        - 'FETCH FIRST'
+    meta:
+      explain_like: 'Applied REQUEST_TYPE filter'
 
   - question: "Total gross value per DEPARTMENT_OUL last quarter"
     expect_sql:


### PR DESCRIPTION
## Summary
- add a dedicated Contract request-type synonym module with defaults and settings overrides
- apply synonym-aware REQUEST_TYPE detection in the deterministic planner and contract builder paths
- extend /dw/rate hint parsing and golden tests to cover synonym-powered REQUEST_TYPE filtering

## Testing
- `pytest apps/dw/tests/test_dw_golden.py` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68dbf0862fe083238915c17a021c1898