### PR TITLE
Add deterministic REQUEST_TYPE filtering for Contract builder

### DIFF
--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -146,6 +146,16 @@ cases:
     assertions:
       request_window: true
 
+  - id: request_type_equals_renewal
+    question: "Show contracts where REQUEST TYPE = Renewal"
+    expect:
+      sql_like:
+        - 'FROM "Contract"'
+      must_not: []
+    assert_all_of:
+      - 'UPPER(TRIM(REQUEST_TYPE))'
+      - 'ORDER BY REQUEST_DATE DESC'
+
   - id: distinct_entity_counts
     question: "List distinct ENTITY values and their contract counts."
     expect:


### PR DESCRIPTION
## Summary
- add helper utilities to resolve REQUEST_TYPE synonyms and bind filters when the question contains an explicit request type
- ensure the builder defaults to ordering by REQUEST_DATE DESC when only the request type filter is applied
- extend the golden contract suite with a case covering the explicit REQUEST_TYPE filter handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc498248c08323824e0d7a8f183b13