### PR TITLE
Add contract request type synonym filter and golden test

### DIFF
--- a/apps/dw/tables/contracts.py
+++ b/apps/dw/tables/contracts.py
@@ -93,6 +93,7 @@ def _build_reqtype_condition(value: str, bucket: Optional[Dict]) -> Tuple[str, D
 
     if not bucket:
         key = f"rt_like_{idx}"
+        idx += 1
         binds[key] = f"%{_norm(value)}%"
         parts.append(f"UPPER(TRIM(REQUEST_TYPE)) LIKE UPPER(:{key})")
 
@@ -1104,13 +1105,17 @@ def build_sql(intent: Intent, settings: Optional[Dict[str, object]] = None) -> t
             binds["date_start"] = _to_date(intent.window_start)
             binds["date_end"]   = _to_date(intent.window_end)
             parts.append("REQUEST_DATE BETWEEN :date_start AND :date_end")
-            explain.append(f"Window = REQUEST_DATE between {binds['date_start']} and {binds['date_end']}.")
+            intent.explain_parts.append(
+                f"Window = REQUEST_DATE between {binds['date_start']} and {binds['date_end']}."
+            )
     elif intent.window_kind == "END_ONLY":
         if intent.window_start and intent.window_end:
             binds["date_start"] = _to_date(intent.window_start)
             binds["date_end"]   = _to_date(intent.window_end)
             parts.append("END_DATE BETWEEN :date_start AND :date_end")
-            explain.append(f"Window = END_DATE between {binds['date_start']} and {binds['date_end']}.")
+            intent.explain_parts.append(
+                f"Window = END_DATE between {binds['date_start']} and {binds['date_end']}."
+            )
     elif intent.window_kind == "OVERLAP":
         if intent.window_start and intent.window_end:
             binds["date_start"] = _to_date(intent.window_start)

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -11,6 +11,13 @@ cases:
         - 'CONTRACT_STATUS'
       must_not: []
 
+  - id: request_type_synonym_filter
+    question: "Show contracts where REQUEST TYPE = Renewal"
+    expect:
+      contains:
+        - 'WHERE (UPPER(TRIM(REQUEST_TYPE))'
+        - 'ORDER BY REQUEST_DATE DESC'
+
   - id: top10_value_last_month
     question: "top 10 contracts by contract value last month"
     expect:


### PR DESCRIPTION
## Summary
- build contract SQL using request type synonyms loaded from namespace settings
- fix explain tracking when adding date window notes and adjust the fallback LIKE bind bookkeeping
- add a golden test that asserts the generated SQL keeps the request-type filter and default ordering

## Testing
- pytest apps/dw/tests/test_dw_golden.py -k contracts *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68dc5acf561c8323a693f5370b3b7f6e