### PR TITLE
Add explicit REQUEST_TYPE parsing to contract planner

### DIFF
--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -17,6 +17,8 @@ cases:
       contains:
         - 'WHERE (UPPER(TRIM(REQUEST_TYPE))'
         - 'ORDER BY REQUEST_DATE DESC'
+      must_not:
+        - 'FETCH FIRST'
 
   - id: top10_value_last_month
     question: "top 10 contracts by contract value last month"


### PR DESCRIPTION
## Summary
- detect explicit REQUEST TYPE references in contract questions and build a synonyms-aware predicate with a default request-date ordering
- extend the contracts golden test to assert the REQUEST_TYPE filter behavior and absence of FETCH FIRST for listings

## Testing
- pytest apps/dw/tests/test_dw_golden.py -q *(fails: missing pydantic dependency in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc5c4b63188323b16b3f35f16af728