### PR TITLE
Support contract equality filters and structured rate hints

### DIFF
--- a/apps/dw/contract/eq_filters.py
+++ b/apps/dw/contract/eq_filters.py
@@ -1,0 +1,82 @@
+import re
+from typing import Dict, List, Tuple
+
+GROSS_EXPR = (
+    "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + "
+    "CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
+    "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0) * NVL(VAT,0) "
+    "ELSE NVL(VAT,0) END"
+)
+
+def _norm_ident(s: str) -> str:
+    return re.sub(r"\s+", "_", s.strip()).upper()
+
+def detect_eq_filters(question: str,
+                      table: str,
+                      explicit_cols: List[str],
+                      enum_synonyms: Dict[str, Dict]) -> List[Tuple[str, Dict]]:
+    """
+    Returns a list of (column, match_spec) from patterns like 'REQUEST TYPE = Renewal'
+    match_spec contains either 'equals': [..], 'prefix': [..], 'contains': [..] derived from DW_ENUM_SYNONYMS
+    or simple 'value' for plain equality (case-insensitive, trimmed).
+    """
+    out = []
+    # generic: COLUMN = 'value' | "value" | value
+    pat = re.compile(r"\b([A-Za-z_ ][A-Za-z0-9_ ]*?)\s*=\s*(?:'([^']*)'|\"([^\"]*)\"|([^\s,;]+))", re.IGNORECASE)
+    for m in pat.finditer(question):
+        col_raw, v1, v2, v3 = m.groups()
+        col = _norm_ident(col_raw)
+        val = (v1 or v2 or v3 or "").strip()
+        if col not in [c.upper() for c in explicit_cols]:
+            continue
+        key = f"{table}.{col}"
+        syn = enum_synonyms.get(key, enum_synonyms.get(col, {}))
+        if syn:
+            # try to map normalized value to a synonym bucket (lowercase key)
+            norm_val = val.strip().lower()
+            bucket = syn.get(norm_val)
+            if not bucket:
+                for name, spec in syn.items():
+                    if isinstance(name, str) and name.strip().lower() == norm_val:
+                        bucket = spec
+                        break
+            if bucket:
+                out.append((col, {
+                    "equals": bucket.get("equals", []),
+                    "prefix": bucket.get("prefix", []),
+                    "contains": bucket.get("contains", [])
+                }))
+                continue
+        # fall back to simple equality
+        out.append((col, {"value": val}))
+    return out
+
+def build_eq_sql(col: str, spec: Dict, bind_maker) -> Tuple[str, Dict]:
+    """
+    Builds SQL predicate and binds for equality/spec with synonyms. Case-insensitive & trimmed.
+    """
+    binds = {}
+    if "value" in spec:
+        b = bind_maker(f"eq_{col.lower()}")
+        binds[b] = spec["value"]
+        pred = f"TRIM(UPPER({col})) = TRIM(UPPER(:{b}))"
+        return pred, binds
+
+    clauses = []
+    # equals list
+    for i, v in enumerate(spec.get("equals", [])):
+        b = bind_maker(f"eq_{col.lower()}_{i}")
+        binds[b] = v
+        clauses.append(f"TRIM(UPPER({col})) = TRIM(UPPER(:{b}))")
+    # prefix list -> LIKE 'prefix%'
+    for i, v in enumerate(spec.get("prefix", [])):
+        b = bind_maker(f"pre_{col.lower()}_{i}")
+        binds[b] = f"{v}%"
+        clauses.append(f"UPPER(TRIM({col})) LIKE UPPER(:{b})")
+    # contains list -> LIKE '%token%'
+    for i, v in enumerate(spec.get("contains", [])):
+        b = bind_maker(f"con_{col.lower()}_{i}")
+        binds[b] = f"%{v}%"
+        clauses.append(f"UPPER(TRIM({col})) LIKE UPPER(:{b})")
+    pred = "(" + " OR ".join(clauses) + ")"
+    return pred, binds

--- a/apps/dw/contract/rate_apply.py
+++ b/apps/dw/contract/rate_apply.py
@@ -1,0 +1,36 @@
+from typing import Dict, List
+
+from apps.dw.rate_grammar import RateHints
+
+
+def apply_rate_hints_to_contract(hints: RateHints,
+                                 where_parts: List[str],
+                                 binds: Dict[str, object],
+                                 bind_maker):
+    def txt_expr(col: str, ci: bool, trim: bool) -> str:
+        expr = col.upper()
+        if trim:
+            expr = f"TRIM({expr})"
+        if ci:
+            expr = f"UPPER({expr})"
+        return expr
+
+    # equality filters
+    for i, f in enumerate(hints.eq_filters):
+        b = bind_maker(f"rh_eq_{i}")
+        binds[b] = f.value
+        lhs = txt_expr(f.col, f.ci, f.trim)
+        rhs = f":{b}"
+        if f.ci:
+            rhs = f"UPPER({rhs})"
+        if f.trim:
+            rhs = f"TRIM({rhs})"
+        where_parts.append(f"{lhs} = {rhs}")
+
+    # like filters
+    for i, f in enumerate(hints.like_filters):
+        b = bind_maker(f"rh_like_{i}")
+        binds[b] = f"%{f.pattern}%"
+        lhs = txt_expr(f.col, f.ci, f.trim)
+        op = "LIKE"
+        where_parts.append(f"{lhs} {op} :{b}")

--- a/apps/dw/rate_grammar.py
+++ b/apps/dw/rate_grammar.py
@@ -1,0 +1,109 @@
+import re
+from dataclasses import dataclass, field
+from typing import List, Tuple, Optional
+
+
+@dataclass
+class EqFilter:
+    col: str
+    value: str
+    ci: bool = True
+    trim: bool = True
+
+
+@dataclass
+class LikeFilter:
+    col: str
+    pattern: str
+    ci: bool = True
+    trim: bool = True
+
+
+@dataclass
+class RateHints:
+    eq_filters: List[EqFilter] = field(default_factory=list)
+    like_filters: List[LikeFilter] = field(default_factory=list)
+    group_by: List[str] = field(default_factory=list)
+    order_by: List[Tuple[str, str]] = field(default_factory=list)  # (expr, 'asc'|'desc')
+    measure: Optional[str] = None  # 'gross' | 'net' | None
+    top_n: Optional[int] = None
+
+
+_flags_re = re.compile(r"\(([^)]*)\)\s*$")
+
+
+def _parse_flags(s: str) -> Tuple[bool, bool]:
+    ci = True
+    trim = True
+    m = _flags_re.search(s)
+    if not m:
+        return ci, trim
+    flags = {t.strip().lower() for t in m.group(1).split(",")}
+    ci = ("ci" in flags) or ("case_insensitive" in flags)
+    trim = ("trim" in flags)
+    return ci, trim
+
+
+def parse_rate_comment(comment: str) -> RateHints:
+    """
+    Very small grammar:
+      filter: COL = 'value' (ci, trim);
+      filter: COL ~ token;  -> LIKE %token%
+      group_by: COL[, COL...];
+      order_by: EXPR asc|desc;
+      measure: gross|net;
+      top: N;
+    """
+    hints = RateHints()
+    # split by ';'
+    parts = [p.strip() for p in comment.split(";") if p.strip()]
+    for p in parts:
+        if p.lower().startswith("filter:"):
+            body = p.split(":", 1)[1].strip()
+            # try equality first: COL = 'value' [flags]
+            m = re.match(r"([A-Za-z_][A-Za-z0-9_ ]*?)\s*=\s*(.+)$", body)
+            if m:
+                col = m.group(1).strip()
+                raw_val = m.group(2).strip()
+                ci, trim = _parse_flags(raw_val)
+                # strip flags from tail
+                raw_val = _flags_re.sub("", raw_val).strip()
+                # strip quotes if any
+                if (raw_val.startswith("'") and raw_val.endswith("'")) or \
+                   (raw_val.startswith('"') and raw_val.endswith('"')):
+                    raw_val = raw_val[1:-1]
+                hints.eq_filters.append(EqFilter(col=col, value=raw_val, ci=ci, trim=trim))
+                continue
+            # like: COL ~ token
+            m = re.match(r"([A-Za-z_][A-Za-z0-9_ ]*?)\s*~\s*(.+)$", body)
+            if m:
+                col = m.group(1).strip()
+                token = m.group(2).strip()
+                ci, trim = _parse_flags(token)
+                token = _flags_re.sub("", token).strip().strip("'\"")
+                hints.like_filters.append(LikeFilter(col=col, pattern=token, ci=ci, trim=trim))
+                continue
+
+        elif p.lower().startswith("group_by:"):
+            cols = p.split(":", 1)[1]
+            hints.group_by = [c.strip().upper().replace(" ", "_") for c in cols.split(",") if c.strip()]
+
+        elif p.lower().startswith("order_by:"):
+            body = p.split(":", 1)[1].strip()
+            m = re.match(r"(.+?)\s+(asc|desc)$", body, re.IGNORECASE)
+            if m:
+                hints.order_by.append((m.group(1).strip(), m.group(2).lower()))
+            else:
+                hints.order_by.append((body, "desc"))
+
+        elif p.lower().startswith("measure:"):
+            val = p.split(":", 1)[1].strip().lower()
+            if val in ("gross", "net"):
+                hints.measure = val
+
+        elif p.lower().startswith("top:"):
+            try:
+                hints.top_n = int(p.split(":", 1)[1].strip())
+            except ValueError:
+                pass
+    return hints


### PR DESCRIPTION
## Summary
- add a reusable detector to infer Contract column equality filters and plug it into the table builder
- introduce a structured /dw/rate comment parser and helper to translate hints into SQL filters
- apply the new hints in the docuware app and attempts path so rate comments add case-insensitive trimmed predicates

## Testing
- `pytest apps/dw/tests/test_dw_golden.py -k nothing` *(fails: missing pydantic dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dd031addb88323aabaf8be1744b046