### PR TITLE
Add explicit equality filter handling for DocuWare contracts

### DIFF
--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -19,6 +19,7 @@ cases:
         - 'ORDER BY REQUEST_DATE DESC'
       must_not:
         - 'FETCH FIRST'
+        - 'FROM "Contract"\nORDER BY REQUEST_DATE DESC\n'
 
   - id: top10_value_last_month
     question: "top 10 contracts by contract value last month"


### PR DESCRIPTION
## Summary
- add explicit equality parsing utilities to the DocuWare contract planner, wiring them into the SQL builder and defaulting list queries to REQUEST_DATE ordering when equality filters apply
- provide a mem-settings adapter to reuse existing settings loaders while avoiding duplicate request-type clauses when explicit filters are detected
- sanitize rate hint literals to strip trailing hints and extend the golden contract case to guard against fallback SQL output

## Testing
- pytest apps/dw/tests/test_dw_golden.py *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68dd0b37d2a88323a8b0cb3c5b6fdfbf