### PR TITLE
Add strict rate feedback parsing

### DIFF
--- a/apps/dw/intent.py
+++ b/apps/dw/intent.py
@@ -4,7 +4,7 @@ from typing import Optional, List, Dict, Any, TYPE_CHECKING
 from apps.dw.tables import for_namespace
 from apps.dw.tables.base import TableSpec
 from apps.dw.tables.contract import ContractSpec
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from word2number import w2n
 from dateutil.relativedelta import relativedelta
 from datetime import date, timedelta
@@ -30,6 +30,7 @@ class NLIntent(BaseModel):
     full_text_search: Optional[bool] = None
     fts_tokens: Optional[List[str]] = None
     notes: Dict[str, Any] = {}
+    eq_filters: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 _RE_REQUESTED = re.compile(r'\b(requested|request\s+date|request_date|request type|request\s*type)\b', re.I)

--- a/apps/dw/rate_grammar.py
+++ b/apps/dw/rate_grammar.py
@@ -1,6 +1,9 @@
 import re
 from dataclasses import dataclass, field
-from typing import List, Tuple, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard for type checkers
+    from .intent import NLIntent
 
 
 @dataclass
@@ -30,6 +33,30 @@ class RateHints:
 
 
 _flags_re = re.compile(r"\(([^)]*)\)\s*$")
+
+
+@dataclass
+class StrictFilter:
+    col: str
+    value: str
+    ci: bool = False
+    trim: bool = False
+
+
+@dataclass
+class StrictOrderHint:
+    expr: str
+    desc: bool
+
+
+@dataclass
+class StrictRateHints:
+    filters: List[StrictFilter] = field(default_factory=list)
+    group_by: List[str] = field(default_factory=list)
+    order_by: List[StrictOrderHint] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (self.filters or self.group_by or self.order_by)
 
 
 def _parse_flags(s: str) -> Tuple[bool, bool]:
@@ -114,3 +141,125 @@ def parse_rate_comment(comment: str) -> RateHints:
             except ValueError:
                 pass
     return hints
+
+
+_EQ_RE = re.compile(
+    r"""(?ix)
+    \b(?:filter|where)\s*:\s*
+    (?P<col>[A-Z0-9_.]+)\s*
+    (?:=|==|eq)\s*
+    (?P<val>
+        "(?P<dq>[^"\\]*(?:\\.[^"\\]*)*)"  # double-quoted
+        |'(?:\\'|[^'])*'                       # single-quoted
+        |[A-Z0-9_\-./@]+                        # bare token
+    )
+    \s*
+    (?P<trail>\([^)]*\))?                     # optional flags like (ci, trim)
+    \s*;?
+    """
+)
+
+_FLAGS_RE = re.compile(r"(?i)\bflags\s*:\s*(?P<flags>[^;]+)")
+_GROUP_RE = re.compile(r"(?i)\bgroup_by\s*:\s*([A-Z0-9_,\s]+);?")
+_ORDER_RE = re.compile(r"(?i)\border_by\s*:\s*([A-Z0-9_]+)\s+(asc|desc)\s*;?")
+
+
+def _strip_quotes(raw: str) -> str:
+    text = raw.strip()
+    if len(text) >= 2 and text[0] in {'"', "'"} and text[-1] == text[0]:
+        body = text[1:-1]
+        if text[0] == '"':
+            body = body.replace("\\\"", '"')
+        else:
+            body = body.replace("\\'", "'")
+        return body
+    return text
+
+
+def _extract_flag_values(flag_blob: str) -> Dict[str, bool]:
+    values = {frag.strip().lower() for frag in flag_blob.split(",") if frag.strip()}
+    return {"ci": "ci" in values or "case_insensitive" in values, "trim": "trim" in values}
+
+
+def parse_rate_comment_strict(comment: Optional[str]) -> StrictRateHints:
+    hints = StrictRateHints()
+    text = (comment or "").strip()
+    if not text:
+        return hints
+
+    global_flags = {"ci": False, "trim": False}
+    fm = _FLAGS_RE.search(text)
+    if fm:
+        global_flags.update(_extract_flag_values(fm.group("flags")))
+
+    for match in _EQ_RE.finditer(text):
+        col = (match.group("col") or "").strip().upper()
+        if not col:
+            continue
+        raw_val = match.group("val") or ""
+        value = _strip_quotes(raw_val)
+        flags = dict(global_flags)
+        trail = match.group("trail") or ""
+        if trail:
+            flags.update(_extract_flag_values(trail.strip("()")))
+        hints.filters.append(
+            StrictFilter(col=col, value=value, ci=flags["ci"], trim=flags["trim"])
+        )
+
+    grp_match = _GROUP_RE.search(text)
+    if grp_match:
+        cols = [c.strip().upper() for c in grp_match.group(1).split(",") if c.strip()]
+        if cols:
+            hints.group_by.extend(cols)
+
+    order_match = _ORDER_RE.search(text)
+    if order_match:
+        expr = order_match.group(1).strip().upper()
+        direction = order_match.group(2).strip().lower() == "desc"
+        if expr:
+            hints.order_by.append(StrictOrderHint(expr=expr, desc=direction))
+
+    return hints
+
+
+def merge_rate_comment_hints(
+    intent: "NLIntent",
+    hints: StrictRateHints,
+    allowed_columns: Iterable[str],
+) -> "NLIntent":
+    if hints.is_empty():
+        return intent
+
+    allowed_map = {col.upper(): col.upper() for col in allowed_columns}
+
+    try:
+        merged = intent.copy(deep=True)  # type: ignore[attr-defined]
+    except Exception:
+        merged = intent
+
+    existing_filters: List[Dict[str, Any]] = list(getattr(merged, "eq_filters", []) or [])
+    for filt in hints.filters:
+        canonical = allowed_map.get(filt.col.upper())
+        if not canonical:
+            continue
+        existing_filters.append(
+            {
+                "col": canonical,
+                "op": "eq",
+                "val": filt.value,
+                "ci": bool(filt.ci),
+                "trim": bool(filt.trim),
+            }
+        )
+    if existing_filters:
+        merged.eq_filters = existing_filters  # type: ignore[attr-defined]
+
+    if hints.group_by:
+        merged.group_by = hints.group_by[0]
+
+    if hints.order_by:
+        first = hints.order_by[0]
+        merged.sort_by = first.expr
+        merged.sort_desc = first.desc
+
+    return merged

--- a/apps/dw/rate_hints.py
+++ b/apps/dw/rate_hints.py
@@ -283,6 +283,8 @@ def parse_rate_hints(comment: Optional[str], settings_get_json=None) -> RateHint
             col = _canon_col(col_raw) or _canon_col(col_raw.replace(" ", "_"))
             if not col:
                 return
+            if op in ("=", "=="):
+                return  # handled by strict parser / builder
             if col == "REQUEST_TYPE" and op != "!=":
                 frag, extra_binds = apply_reqtype_filter(val_raw)
                 where_clauses.append(frag)

--- a/apps/dw/settings_defaults.py
+++ b/apps/dw/settings_defaults.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import List
+
+# Default allow-list for columns that can be filtered explicitly from feedback.
+DEFAULT_EXPLICIT_FILTER_COLUMNS: List[str] = [
+    "CONTRACT_STATUS",
+    "REQUEST_TYPE",
+    "ENTITY",
+    "ENTITY_NO",
+    "OWNER_DEPARTMENT",
+    "DEPARTMENT_OUL",
+    "CONTRACT_OWNER",
+    "CONTRACT_ID",
+]

--- a/apps/dw/settings_utils.py
+++ b/apps/dw/settings_utils.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Optional, Sequence
+
+
+def _normalize_columns(raw: Iterable[str]) -> List[str]:
+    seen = set()
+    result: List[str] = []
+    for col in raw:
+        if not col:
+            continue
+        upper = str(col).strip().upper()
+        if not upper or upper in seen:
+            continue
+        result.append(upper)
+        seen.add(upper)
+    return result
+
+
+def load_explicit_filter_columns(
+    getter: Optional[Callable[..., Sequence[str] | str | None]],
+    namespace: str,
+    default: Sequence[str],
+) -> List[str]:
+    """Return the explicit filter column list for ``namespace``.
+
+    ``getter`` is typically ``settings.get_json``. We accept lists/tuples/sets or
+    comma-separated strings. Fallback to ``default`` when nothing is configured.
+    """
+    effective = list(default)
+    if not callable(getter):
+        return _normalize_columns(effective)
+
+    try:
+        raw = getter("DW_EXPLICIT_FILTER_COLUMNS", scope="namespace", namespace=namespace)
+    except TypeError:
+        raw = getter("DW_EXPLICIT_FILTER_COLUMNS")
+
+    if isinstance(raw, (list, tuple, set)):
+        candidates = [str(col).strip() for col in raw if col is not None]
+        if candidates:
+            effective = candidates
+    elif isinstance(raw, str):
+        parts = [part.strip() for part in raw.split(",")]
+        candidates = [part for part in parts if part]
+        if candidates:
+            effective = candidates
+
+    return _normalize_columns(effective)


### PR DESCRIPTION
## Summary
- parse /rate comments with a strict grammar that captures equality filters, grouping and ordering hints
- extend NLIntent and the SQL builder to carry explicit equality filters built from the structured hints
- add helpers to load allowed filter columns from settings and avoid double-applying equality filters in legacy hint parsing

## Testing
- python -m compileall apps/dw/rate_grammar.py apps/dw/attempts.py apps/dw/app.py apps/dw/rate_hints.py apps/dw/builder.py apps/dw/intent.py apps/dw/settings_defaults.py apps/dw/settings_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1b8515588323b37c33bf4874bcc3