### PR TITLE
Support Contract planner full-text overrides

### DIFF
--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -535,8 +535,8 @@ cases:
     payload:
       full_text_search: true
     expect_sql_contains:
-      - 'UPPER("CONTRACT_SUBJECT") LIKE UPPER(:fts_0)'
-      - 'UPPER("CONTRACT_SUBJECT") LIKE UPPER(:fts_1)'
+      - 'LIKE UPPER(:kw_0)'
+      - 'LIKE UPPER(:kw_1)'
       - 'ORDER BY REQUEST_DATE DESC'
 
   - id: fts_has_it_single
@@ -544,5 +544,14 @@ cases:
     payload:
       full_text_search: true
     expect_sql_contains:
-      - 'UPPER("CONTRACT_SUBJECT") LIKE UPPER(:fts_0)'
+      - 'LIKE UPPER(:kw_0)'
       - 'ORDER BY REQUEST_DATE DESC'
+
+  - id: stakeholder_like_or
+    question: "list all contracts where stakeholder has Tamer Said Aly Abdelgawad or u1835 or Amr Taher A Maghrabi"
+    expect_sql_contains:
+      - 'CONTRACT_STAKEHOLDER_1'
+      - 'CONTRACT_STAKEHOLDER_8'
+      - 'LIKE UPPER(:sh_0)'
+      - 'LIKE UPPER(:sh_1)'
+      - 'LIKE UPPER(:sh_2)'


### PR DESCRIPTION
## Summary
- forward the full_text_search flag from the DW answer route to the deterministic planner and surface planner FTS diagnostics in the debug payload
- enhance the contract planner to load configured FTS columns, extract search terms, apply OR-based LIKE filters, and add stakeholder keyword support across all eight slots
- expand DW golden tests to cover updated keyword binding names and stakeholder OR handling

## Testing
- `python tests/run_golden_dw_yaml.py` *(fails: Flask is not installed in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd9a6db3908323bb34ae4d6fed5196