### PR TITLE
Improve DW contract planner full-text search handling

### DIFF
--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -535,7 +535,7 @@ def answer():
     prefixes = _coerce_prefixes(payload.get("prefixes"))
     auth_email = payload.get("auth_email") or None
     full_text_search = bool(payload.get("full_text_search", False))
-    overrides = {"full_text_search": full_text_search} if "full_text_search" in payload else {}
+    overrides = {"full_text_search": full_text_search}
 
     namespace = (payload.get("namespace") or "dw::common").strip() or "dw::common"
     contract_sql, contract_binds, contract_meta = _plan_contract_sql(


### PR DESCRIPTION
## Summary
- Always forward the `full_text_search` flag from the DW answer route to the deterministic planner
- Load Contract FTS columns from the `dw::common` namespace and build smarter predicates that support short tokens via regex
- Normalize equality filters such as `departments = ...` before composing WHERE clauses and surface FTS metadata/errors consistently

## Testing
- `pytest apps/dw/tests -q` *(fails: missing pydantic dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68de52b4886c83239b4843606b647a99