### PR TITLE
Improve equality filter detection and FTS support

### DIFF
--- a/apps/dw/fts.py
+++ b/apps/dw/fts.py
@@ -1,79 +1,140 @@
+"""Full-text search helpers for DW queries."""
+
 from __future__ import annotations
 
-"""Lightweight FTS token extraction and SQL helpers."""
+import re
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
-from typing import Dict, List, Tuple
+
+_STOP_WORDS = {"list", "all", "contracts", "where", "has", "have"}
 
 
 def extract_fts_tokens(question: str) -> List[str]:
-    """Return ordered, deduplicated tokens from simple ``has`` patterns."""
+    """Backward-compatible token extraction used by legacy planners."""
 
-    if not question:
-        return []
-
-    q = " ".join((question or "").strip().split()).lower()
-    if not q or " has " not in q:
-        return []
-
-    tail = q.split(" has ", 1)[1]
-    normalized = (
-        tail.replace(" and ", " or ")
-        .replace(",", " or ")
-        .replace("/", " or ")
-    )
-    raw_terms = [part.strip() for part in normalized.split(" or ")]
-
-    tokens: List[str] = []
-    seen: set[str] = set()
-    for term in raw_terms:
-        if not term:
-            continue
-        cleaned = term.strip("'\"")
-        cleaned = " ".join(cleaned.split())
-        if not cleaned:
-            continue
-        key = cleaned.lower()
-        if key in {"or", "and", "=", "=="}:
-            continue
-        if key not in seen:
-            seen.add(key)
-            tokens.append(cleaned)
+    tokens, _ = _tokenize_question(question or "")
     return tokens
 
 
 def build_fts_where(
-    table: str,
-    columns: List[str],
-    tokens: List[str],
+    question: str,
+    settings: Any,
     *,
-    start_index: int = 0,
-) -> Tuple[str, Dict[str, str]]:
-    """Construct a SQL WHERE fragment for case-insensitive LIKE search across columns."""
+    table: str = "Contract",
+    mode: str = "auto",
+) -> Tuple[Optional[str], Dict[str, str], Optional[str]]:
+    """Return a SQL WHERE fragment for LIKE-based FTS and the bind parameters."""
 
-    if not columns or not tokens:
-        return "", {}
+    columns = list(_load_fts_columns(settings, table))
+    if not columns:
+        return None, {}, None
+
+    tokens, join_op = _tokenize_question(question or "")
+    if not tokens:
+        return None, {}, None
 
     clauses: List[str] = []
     binds: Dict[str, str] = {}
 
-    def _quote(col: str) -> str:
-        c = col.strip()
-        if c.startswith('"') and c.endswith('"'):
-            return c
-        return f'"{c}"'
-
-    quoted_cols = [_quote(col) for col in columns if col]
     for idx, token in enumerate(tokens):
-        bind = f"fts_{start_index + idx}"
+        bind = f"fts_{idx}"
         binds[bind] = f"%{token}%"
-        like_parts = [f"UPPER(TRIM({col})) LIKE UPPER(:{bind})" for col in quoted_cols]
-        if like_parts:
-            clauses.append("(" + " OR ".join(like_parts) + ")")
+        per_col = [f"UPPER(TRIM({col})) LIKE UPPER(:{bind})" for col in columns]
+        if per_col:
+            clauses.append("(" + " OR ".join(per_col) + ")")
 
     if not clauses:
-        return "", {}
+        return None, {}, None
 
-    return "(" + " OR ".join(clauses) + ")", binds
+    where_sql = "(" + f" {join_op} ".join(clauses) + ")"
+    return where_sql, binds, join_op
+
+
+def _tokenize_question(question: str) -> Tuple[List[str], str]:
+    text = " ".join((question or "").split()).lower()
+    if not text:
+        return [], "OR"
+
+    if " and " in text:
+        parts = re.split(r"\s+and\s+", text)
+        op = "AND"
+    elif " or " in text:
+        parts = re.split(r"\s+or\s+", text)
+        op = "OR"
+    else:
+        parts = [text]
+        op = "OR"
+
+    tokens: List[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        for segment in re.split(r"[,/;]\s*", part):
+            words = [w for w in segment.split() if w and w not in _STOP_WORDS]
+            if not words:
+                continue
+            phrase = " ".join(words)
+            phrase = phrase.strip("'\"")
+            if not phrase or phrase in seen:
+                continue
+            seen.add(phrase)
+            tokens.append(phrase)
+    return tokens, op
+
+
+def _load_fts_columns(settings: Any, table: str) -> Iterable[str]:
+    raw = _settings_get(settings, "DW_FTS_COLUMNS", {}) or {}
+    columns: List[str] = []
+    if isinstance(raw, dict):
+        candidates = [table, table.strip('"'), table.upper(), table.lower(), "*"]
+        for key in candidates:
+            vals = raw.get(key)
+            if isinstance(vals, list):
+                columns.extend(vals)
+    elif isinstance(raw, list):
+        columns.extend(raw)
+
+    for col in columns:
+        norm = _normalize_column(col)
+        if norm:
+            yield norm
+
+
+def _normalize_column(col: Any) -> Optional[str]:
+    if not isinstance(col, str):
+        return None
+    cleaned = col.strip()
+    if not cleaned:
+        return None
+    if cleaned.startswith('"') and cleaned.endswith('"'):
+        return cleaned
+    cleaned = cleaned.replace(" ", "_")
+    if "." in cleaned:
+        return ".".join(_normalize_column(part) or part for part in cleaned.split("."))
+    return f'"{cleaned.upper()}"'
+
+
+def _settings_get(settings: Any, key: str, default: Any = None) -> Any:
+    if settings is None:
+        return default
+    getter_json = getattr(settings, "get_json", None)
+    if callable(getter_json):
+        try:
+            value = getter_json(key, default)
+        except TypeError:
+            value = getter_json(key)
+        if value is not None:
+            return value
+    getter = getattr(settings, "get", None)
+    if callable(getter):
+        try:
+            value = getter(key, default)
+        except TypeError:
+            value = getter(key)
+        if value is not None:
+            return value
+    if isinstance(settings, dict):
+        return settings.get(key, default)
+    return default
 
 
 __all__ = ["extract_fts_tokens", "build_fts_where"]


### PR DESCRIPTION
## Summary
- detect explicit equality filters in `parse_intent`, expand values with DW_ENUM_SYNONYMS, and wire full-text clauses into manual binds
- extend the SQL builder to honour synonym buckets when generating equality predicates
- harden `/dw/rate` comment parsing and hint application so that equality values ignore trailing flags and carry simple synonym metadata
- replace the legacy FTS helper with a version that loads DW_FTS_COLUMNS, supports AND/OR tokenisation, and returns bind metadata

## Testing
- pytest apps/dw/tests -q *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68df2682fe3483238e63d646e4b68698