### PR TITLE
Enhance DW FTS handling and hints

### DIFF
--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -243,6 +243,17 @@ cases:
       - fts_0
       - fts_1
 
+  - id: fts_tokens_from_settings
+    question: "list all contracts has it or home care"
+    full_text_search: true
+    expect:
+      sql_contains:
+        - 'UPPER(TRIM(CONTRACT_SUBJECT)) LIKE'
+        - 'UPPER(TRIM(CONTRACT_PURPOSE)) LIKE'
+        - 'ORDER BY REQUEST_DATE DESC'
+      not_contains:
+        - 'ORDER BY REQUEST_DATE DESC\nORDER BY REQUEST_DATE DESC'
+
   - id: dept_equality_alias
     question: "list all contracts where departments = SUPPORT SERVICES"
     expect_sql_contains:


### PR DESCRIPTION
## Summary
- populate NL intents with default FTS columns, tokens, and operators based on incoming requests
- parse FTS directives from /dw/rate comments while merging equality filters without duplicates
- inject FTS predicates and a single ORDER BY clause in the DW SQL builder and cover the behaviour with a golden test

## Testing
- pytest apps/dw/tests -k golden_dw_contracts -q *(fails: missing pydantic dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68e193e8a86883238f1caeee53c4b731