### PR TITLE
Improve FTS configuration handling and rate feedback parsing

### DIFF
--- a/apps/dw/attempts.py
+++ b/apps/dw/attempts.py
@@ -74,6 +74,14 @@ def run_attempt(
         for key in ("group_by", "sort_by", "sort_desc", "agg", "gross"):
             if key in patched:
                 setattr(intent, key, patched[key])
+        if "full_text_search" in patched:
+            intent.full_text_search = bool(patched["full_text_search"])
+        if "fts_tokens" in patched and patched.get("fts_tokens") is not None:
+            intent.fts_tokens = patched["fts_tokens"]
+        if "fts_operator" in patched and patched.get("fts_operator"):
+            intent.fts_operator = patched["fts_operator"]
+        if "fts_columns" in patched and patched.get("fts_columns"):
+            intent.fts_columns = patched["fts_columns"]
     allow_fts = is_fulltext_allowed()
     if allow_fts:
         default_on = env_flag("DW_FTS_DEFAULT_ON", False)


### PR DESCRIPTION
## Summary
- normalize FTS column resolution so configured values or defaults are always applied
- propagate FTS-related hints from /dw/rate comments into attempts and harden ORDER BY replacement logic

## Testing
- pytest apps/dw/tests/test_search.py

------
https://chatgpt.com/codex/tasks/task_e_68e19b538b40832382a6f50326bdb250