### PR TITLE
Enhance /dw rate feedback parsing and learning

### DIFF
--- a/apps/dw/learning.py
+++ b/apps/dw/learning.py
@@ -1,0 +1,223 @@
+"""Persistence helpers for /dw/rate online learning signals."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+from sqlalchemy import text
+
+
+_DDL_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS dw_rules (
+      id SERIAL PRIMARY KEY,
+      created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      question_norm TEXT NOT NULL,
+      rule_kind TEXT NOT NULL,
+      rule_payload JSONB NOT NULL,
+      enabled BOOLEAN NOT NULL DEFAULT TRUE,
+      scope TEXT NOT NULL DEFAULT 'namespace'
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_dw_rules_enabled
+        ON dw_rules (enabled)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS dw_patches (
+      id SERIAL PRIMARY KEY,
+      created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      inquiry_id BIGINT,
+      question_norm TEXT NOT NULL,
+      rating INT NOT NULL,
+      comment TEXT,
+      patch_payload JSONB,
+      status TEXT NOT NULL DEFAULT 'pending'
+    )
+    """,
+)
+
+_INITIALIZED_ENGINES: set[int] = set()
+
+
+def _ensure_tables(engine) -> None:
+    if engine is None:
+        return
+    key = id(engine)
+    if key in _INITIALIZED_ENGINES:
+        return
+    with engine.begin() as cx:
+        for stmt in _DDL_STATEMENTS:
+            cx.execute(text(stmt))
+    _INITIALIZED_ENGINES.add(key)
+
+
+def _norm_question(question: str) -> str:
+    return " ".join((question or "").strip().lower().split())
+
+
+def _as_json(payload: Any) -> str:
+    return json.dumps(payload or {})
+
+
+def save_positive_rule(engine, question: str, applied_hints: Dict[str, Any]) -> None:
+    """Persist positive feedback (rating >= 4) into ``dw_rules``."""
+
+    if engine is None or not applied_hints:
+        return
+    _ensure_tables(engine)
+    rows: list[tuple[str, Dict[str, Any]]] = []
+
+    group_by = applied_hints.get("group_by")
+    if group_by:
+        rows.append(
+            (
+                "group_by",
+                {
+                    "group_by": group_by,
+                    "gross": bool(applied_hints.get("gross")),
+                },
+            )
+        )
+
+    tokens = applied_hints.get("fts_tokens") or []
+    if tokens:
+        rows.append(
+            (
+                "fts",
+                {
+                    "tokens": tokens,
+                    "operator": applied_hints.get("fts_operator", "OR"),
+                    "columns": applied_hints.get("fts_columns", []),
+                },
+            )
+        )
+
+    eq_filters = applied_hints.get("eq_filters") or []
+    if eq_filters:
+        rows.append(("eq", {"eq_filters": eq_filters}))
+
+    sort_by = applied_hints.get("sort_by")
+    sort_desc = applied_hints.get("sort_desc")
+    if sort_by or sort_desc is not None:
+        rows.append(
+            (
+                "order_by",
+                {
+                    "sort_by": sort_by,
+                    "sort_desc": bool(sort_desc) if sort_desc is not None else None,
+                },
+            )
+        )
+
+    if not rows:
+        return
+
+    with engine.begin() as cx:
+        for kind, payload in rows:
+            cx.execute(
+                text(
+                    """
+                    INSERT INTO dw_rules (question_norm, rule_kind, rule_payload, enabled)
+                    VALUES (:q, :k, :p, TRUE)
+                    """
+                ),
+                {"q": _norm_question(question), "k": kind, "p": _as_json(payload)},
+            )
+
+
+def save_patch(
+    engine,
+    inquiry_id: Optional[int],
+    question: str,
+    rating: int,
+    comment: str,
+    parsed_hints: Dict[str, Any],
+) -> None:
+    """Persist a corrective patch for low-rating feedback (rating <= 2)."""
+
+    if engine is None:
+        return
+    _ensure_tables(engine)
+    with engine.begin() as cx:
+        cx.execute(
+            text(
+                """
+                INSERT INTO dw_patches (inquiry_id, question_norm, rating, comment, patch_payload, status)
+                VALUES (:iid, :q, :r, :c, :p, 'pending')
+                """
+            ),
+            {
+                "iid": inquiry_id,
+                "q": _norm_question(question),
+                "r": int(rating),
+                "c": comment or "",
+                "p": _as_json(parsed_hints or {}),
+            },
+        )
+
+
+def load_rules_for_question(engine, question: str) -> Dict[str, Any]:
+    """Load merged rule hints for a question from ``dw_rules``."""
+
+    if engine is None:
+        return {}
+    _ensure_tables(engine)
+    merged: Dict[str, Any] = {}
+    with engine.connect() as cx:
+        rows = cx.execute(
+            text(
+                """
+                SELECT rule_kind, rule_payload
+                  FROM dw_rules
+                 WHERE enabled = TRUE
+                 ORDER BY id DESC
+                 LIMIT 20
+                """
+            )
+        )
+        for row in rows:
+            kind = row[0] if isinstance(row, tuple) else row["rule_kind"]
+            payload = row[1] if isinstance(row, tuple) else row["rule_payload"]
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {}
+            if not isinstance(payload, dict):
+                continue
+            if kind == "group_by":
+                if payload.get("group_by"):
+                    merged["group_by"] = payload.get("group_by")
+                if payload.get("gross") is not None:
+                    merged["gross"] = payload.get("gross")
+            elif kind == "fts":
+                if payload.get("tokens"):
+                    merged["fts_tokens"] = payload.get("tokens")
+                    merged["fts_operator"] = payload.get("operator", "OR")
+                    if payload.get("columns"):
+                        merged["fts_columns"] = payload.get("columns")
+            elif kind == "eq":
+                eq_payload = payload.get("eq_filters") or []
+                if eq_payload:
+                    existing = merged.setdefault("eq_filters", [])
+                    for item in eq_payload:
+                        if item not in existing:
+                            existing.append(item)
+            elif kind == "order_by":
+                if payload.get("sort_by"):
+                    merged["sort_by"] = payload.get("sort_by")
+                if payload.get("sort_desc") is not None:
+                    merged["sort_desc"] = bool(payload.get("sort_desc"))
+    if merged:
+        merged.setdefault("full_text_search", bool(merged.get("fts_tokens")))
+    return merged
+
+
+__all__ = [
+    "load_rules_for_question",
+    "save_patch",
+    "save_positive_rule",
+]
+

--- a/apps/dw/rate_feedback/intent_utils.py
+++ b/apps/dw/rate_feedback/intent_utils.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List
 
+from apps.dw.sql_utils import resolve_group_by
+
 
 def get_fts_columns(settings) -> List[str]:
     """
@@ -77,4 +79,10 @@ def apply_rate_hints_to_intent(intent: Dict[str, Any], hints, settings) -> None:
             seen.add(key)
             dedup.append(f)
     intent["eq_filters"] = dedup
+
+    group_col = resolve_group_by(getattr(hints, "group_by", None))
+    if group_col:
+        intent["group_by"] = group_col
+    if getattr(hints, "gross", None) is not None:
+        intent["gross"] = bool(hints.gross)
 

--- a/apps/dw/rate_feedback/sql_builder.py
+++ b/apps/dw/rate_feedback/sql_builder.py
@@ -1,8 +1,11 @@
 from typing import Any, Dict, List, Tuple
 
+from apps.dw.sql_utils import pick_measure_sql, resolve_group_by
+
 
 def _make_like_bind(val: str) -> str:
     """Wrap a token with %wildcards% suitable for LIKE."""
+
     return f"%{val}%"
 
 
@@ -11,10 +14,11 @@ def _fts_condition_sql(
 ) -> str:
     """
     Build a composable SQL condition for FTS-like search:
-      (UPPER(NVL(col,'')) LIKE UPPER(:b0) OR ... OR UPPER(NVL(colN,'')) LIKE UPPER(:b0))
-      <OP> (same for next token) ...
-    Returns the SQL string and fills 'binds' in-place with bidx -> %token%
+      (UPPER(NVL(col,'')) LIKE UPPER(:b0) OR ...)
+      <OP> (same for next token).
+    Populates ``binds`` with wildcard-wrapped values.
     """
+
     op = "AND" if str(operator).upper() == "AND" else "OR"
     token_groups: List[str] = []
     for idx, token in enumerate(tokens):
@@ -29,14 +33,33 @@ def _fts_condition_sql(
     return "(" + f" {op} ".join(token_groups) + ")"
 
 
+def _append_where_clauses(where_clauses: List[str]) -> str:
+    if not where_clauses:
+        return ""
+    return "\nWHERE " + "\n  AND ".join(where_clauses)
+
+
+def _normalize_sort(sort_by: str, measure_alias: str, group_alias: str) -> str:
+    if not sort_by:
+        return measure_alias
+    key = sort_by.upper()
+    if key in {"TOTAL_GROSS", "TOTAL", "VALUE", "MEASURE"}:
+        return measure_alias
+    if key in {"GROUP", "GROUP_KEY"}:
+        return group_alias
+    return sort_by
+
+
 def build_contract_sql(intent: Dict[str, Any], settings: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
     """
-    Compose a SELECT against the Contract table honoring:
+    Compose a SELECT against the Contract table honoring rate hints:
       - eq_filters (exact matches with optional ci/trim)
       - fts_tokens across configured FTS columns (LIKE)
-      - requested order_by
+      - optional group_by/gross hints
+      - requested ordering without duplicate ORDER BY clauses
     """
-    sql = 'SELECT * FROM "Contract"'
+
+    table = '"Contract"'
     where_clauses: List[str] = []
     binds: Dict[str, Any] = {}
 
@@ -44,6 +67,8 @@ def build_contract_sql(intent: Dict[str, Any], settings: Dict[str, Any]) -> Tupl
     for i, f in enumerate(intent.get("eq_filters", []) or []):
         col = f.get("col", "").upper()
         val = f.get("val", "")
+        if not col:
+            continue
         ci = bool(f.get("ci", True))
         trim = bool(f.get("trim", True))
         bname = f"eq_{i}"
@@ -67,16 +92,36 @@ def build_contract_sql(intent: Dict[str, Any], settings: Dict[str, Any]) -> Tupl
         if cond:
             where_clauses.append(cond)
 
-    if where_clauses:
-        sql += "\nWHERE " + "\n  AND ".join(where_clauses)
+    where_sql = _append_where_clauses(where_clauses)
 
-    # ORDER BY
-    sort_by = intent.get("sort_by")
-    sort_desc = bool(intent.get("sort_desc"))
-    if sort_by:
-        sql += f"\nORDER BY {sort_by} {'DESC' if sort_desc else 'ASC'}"
-    else:
-        sql += "\nORDER BY REQUEST_DATE DESC"
+    group_col = resolve_group_by(intent.get("group_by"))
+    gross_flag = bool(intent.get("gross"))
+    aggregate = bool(group_col)
+    measure_sql, measure_alias = pick_measure_sql(gross_flag, aggregate=aggregate)
 
-    return sql, binds
+    if group_col:
+        lines: List[str] = [
+            f"SELECT {group_col} AS GROUP_KEY",
+            f"       {measure_sql} AS {measure_alias}",
+            "       COUNT(*) AS CNT",
+            f"FROM {table}",
+        ]
+        if where_sql:
+            lines.append(where_sql.strip())
+        lines.append(f"GROUP BY {group_col}")
+
+        sort_by = str(intent.get("sort_by") or "MEASURE").strip()
+        sort_desc = bool(intent.get("sort_desc", True))
+        order_expr = _normalize_sort(sort_by, measure_alias, "GROUP_KEY")
+        lines.append(f"ORDER BY {order_expr} {'DESC' if sort_desc else 'ASC'}")
+        return "\n".join(lines), binds
+
+    # Non-grouped listing
+    lines = [f"SELECT * FROM {table}"]
+    if where_sql:
+        lines.append(where_sql.strip())
+    sort_by = str(intent.get("sort_by") or "REQUEST_DATE").strip() or "REQUEST_DATE"
+    sort_desc = bool(intent.get("sort_desc", True))
+    lines.append(f"ORDER BY {sort_by} {'DESC' if sort_desc else 'ASC'}")
+    return "\n".join(lines), binds
 

--- a/apps/dw/sql_utils.py
+++ b/apps/dw/sql_utils.py
@@ -1,0 +1,64 @@
+"""Common SQL helpers for deterministic DW queries."""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+
+GROSS_SQL = (
+    "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + "
+    "CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
+    "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0)*NVL(VAT,0) ELSE NVL(VAT,0) END"
+)
+
+NET_SQL = "NVL(CONTRACT_VALUE_NET_OF_VAT,0)"
+
+_SAFE_GROUP_BY = {
+    "OWNER_DEPARTMENT": "OWNER_DEPARTMENT",
+    "DEPARTMENT_OUL": "DEPARTMENT_OUL",
+    "ENTITY": "ENTITY",
+    "ENTITY_NO": "ENTITY_NO",
+    "CONTRACT_STATUS": "CONTRACT_STATUS",
+    "REQUEST_TYPE": "REQUEST_TYPE",
+    "CONTRACT_OWNER": "CONTRACT_OWNER",
+    "REQUESTER": "REQUESTER",
+    "YEAR": "YEAR",
+}
+
+_GROUP_BY_SYNONYMS = {
+    "department": "OWNER_DEPARTMENT",
+    "owner department": "OWNER_DEPARTMENT",
+    "oul": "DEPARTMENT_OUL",
+    "entity no": "ENTITY_NO",
+    "entity number": "ENTITY_NO",
+    "status": "CONTRACT_STATUS",
+    "request type": "REQUEST_TYPE",
+    "owner": "CONTRACT_OWNER",
+}
+
+
+def resolve_group_by(value: Optional[str]) -> Optional[str]:
+    """Return a safe group-by column or ``None`` if unsupported."""
+
+    if not value:
+        return None
+    text = str(value).strip().strip('"')
+    if not text:
+        return None
+    upper = text.upper()
+    if upper in _SAFE_GROUP_BY:
+        return _SAFE_GROUP_BY[upper]
+    synonym = _GROUP_BY_SYNONYMS.get(text.lower())
+    if synonym:
+        return synonym
+    return None
+
+
+def pick_measure_sql(gross: bool, *, aggregate: bool = False) -> Tuple[str, str]:
+    """Return ``(sql_expression, alias)`` for the requested value basis."""
+
+    expr = GROSS_SQL if gross else NET_SQL
+    if aggregate:
+        return f"SUM({expr})", "MEASURE"
+    return expr, "MEASURE"
+


### PR DESCRIPTION
## Summary
- extend /dw rate comment parsing to capture group_by, gross and smarter FTS hints
- add deterministic SQL helpers to honour grouping, gross measure selection and avoid duplicate ORDER BY clauses
- persist positive and corrective feedback into MEMORY_DB rules/patches and replay them when answering

## Testing
- python -m compileall apps/dw/rate_feedback apps/dw/rating.py apps/dw/app.py apps/dw/learning.py apps/dw/sql_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e28f504c108323beb709eaaf136495