### PR TITLE
Respect rate hint FTS flags and fix ORDER BY replacement

### DIFF
--- a/apps/dw/rating.py
+++ b/apps/dw/rating.py
@@ -183,11 +183,18 @@ def rate():
         )
         if inquiry_row:
             ns, q = inquiry_row[0], inquiry_row[1]
+            fts_present = bool(
+                (hints_dict.get("fts_tokens") if hints_dict else None)
+                or (hints_dict.get("full_text_search") if hints_dict else None)
+                or getattr(hints_obj, "fts_tokens", None)
+                or getattr(hints_obj, "full_text_search", None)
+            )
             alt = run_attempt(
                 q,
                 ns,
                 attempt_no=2,
                 strategy=alt_strategy,
+                full_text_search=True if fts_present else None,
                 rate_comment=comment or None,
             )
             if comment and hints_dict:


### PR DESCRIPTION
## Summary
- preserve full text search settings coming from /dw/rate hints when retrying attempts
- propagate FTS intent from rating feedback into reruns and avoid duplicating ORDER BY clauses

## Testing
- pytest *(fails: missing dependency `pydantic` in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2ea3ed8788323a72e5c459a3e62e8