### PR TITLE
Add structured SQL generation for /dw/rate feedback

### DIFF
--- a/apps/dw/learn/__init__.py
+++ b/apps/dw/learn/__init__.py
@@ -1,0 +1,3 @@
+"""Learning helpers for /dw/rate feedback."""
+
+__all__ = ["store"]

--- a/apps/dw/learn/store.py
+++ b/apps/dw/learn/store.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Lightweight feedback store for /dw/rate overrides."""
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+from sqlalchemy import create_engine, text
+
+
+def _get_env(name: str, default: str | None = None) -> str | None:
+    return os.environ.get(name, default)
+
+
+def _db_url() -> str:
+    return _get_env("MEMORY_DB_URL") or "sqlite:////tmp/copilot_mem_dev.sqlite"
+
+
+def ensure_schema() -> None:
+    """Create feedback tables when they do not exist."""
+    engine = create_engine(_db_url())
+    with engine.begin() as cx:
+        cx.execute(
+            text(
+                """
+        CREATE TABLE IF NOT EXISTS dw_feedback (
+            id SERIAL PRIMARY KEY,
+            inquiry_id BIGINT,
+            rating INT,
+            comment TEXT,
+            hints_json TEXT,
+            created_at TIMESTAMP DEFAULT NOW()
+        )
+        """
+            )
+        )
+        cx.execute(
+            text(
+                """
+        CREATE TABLE IF NOT EXISTS dw_patches (
+            id SERIAL PRIMARY KEY,
+            inquiry_id BIGINT,
+            kind VARCHAR(50),
+            payload_json TEXT,
+            created_at TIMESTAMP DEFAULT NOW(),
+            approved BOOLEAN DEFAULT FALSE
+        )
+        """
+            )
+        )
+
+
+def save_feedback(inquiry_id: int, rating: int, comment: str, hints_payload: Dict[str, Any]) -> None:
+    """Persist a feedback row for later governance."""
+    ensure_schema()
+    engine = create_engine(_db_url())
+    payload = json.dumps(hints_payload, ensure_ascii=False)
+    with engine.begin() as cx:
+        cx.execute(
+            text(
+                """
+        INSERT INTO dw_feedback (inquiry_id, rating, comment, hints_json)
+        VALUES (:iid, :rating, :comment, :payload)
+        """
+            ),
+            {
+                "iid": inquiry_id,
+                "rating": rating,
+                "comment": comment,
+                "payload": payload,
+            },
+        )
+
+
+__all__ = ["ensure_schema", "save_feedback"]

--- a/apps/dw/rate_comment.py
+++ b/apps/dw/rate_comment.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Parse /dw/rate free-text comments into structured hints."""
+from __future__ import annotations
+
+import re
+from typing import Dict, List, Optional
+
+_WS = r"\s*"
+
+
+def _split_kv_parts(comment: str) -> List[str]:
+    """Split the comment by ';' while removing empty parts."""
+    if not comment:
+        return []
+    return [part.strip() for part in re.split(r";", comment) if part.strip()]
+
+
+def _normalize(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", value).strip()
+
+
+def parse_rate_comment(comment: str) -> Dict[str, object]:
+    """Return structured hints extracted from the ``comment`` text.
+
+    The returned dictionary contains the following keys:
+
+    ``fts_tokens``
+        List of tokens extracted from ``fts:`` parts.
+
+    ``fts_operator``
+        Either ``"AND"`` or ``"OR"`` depending on the separators used.
+
+    ``eq_filters``
+        List of dictionaries with ``col``/``val`` pairs coming from ``eq:`` hints.
+
+    ``group_by``
+        Optional column passed via ``group_by:`` hint.
+
+    ``gross``
+        Optional boolean value parsed from ``gross:`` hint.
+
+    ``sort_by`` / ``sort_desc``
+        Column name and direction parsed from ``order_by:`` hint.
+    """
+    out: Dict[str, object] = {
+        "fts_tokens": [],
+        "fts_operator": "OR",
+        "eq_filters": [],
+        "group_by": None,
+        "gross": None,
+        "sort_by": None,
+        "sort_desc": None,
+    }
+    if not comment:
+        return out
+
+    parts = _split_kv_parts(comment)
+    for part in parts:
+        # fts: it | home care   OR   fts: it & home care
+        match = re.match(r"^\s*fts\s*:\s*(.+)$", part, flags=re.IGNORECASE)
+        if match:
+            body = match.group(1).strip()
+            if "&" in body or re.search(r"\band\b", body, flags=re.IGNORECASE):
+                tokens = [tok.strip() for tok in re.split(r"[&]|(?i:\band\b)", body) if tok.strip()]
+                out["fts_operator"] = "AND"
+            else:
+                tokens = [tok.strip() for tok in body.split("|") if tok.strip()]
+                out["fts_operator"] = "OR"
+            out["fts_tokens"] = [_normalize(tok) for tok in tokens]
+            continue
+
+        match = re.match(r"^\s*eq\s*:\s*([A-Za-z0-9_]+)\s*=\s*(.+)$", part, flags=re.IGNORECASE)
+        if match:
+            column = _normalize(match.group(1).upper())
+            value = _normalize(match.group(2))
+            out.setdefault("eq_filters", []).append(
+                {"col": column, "val": value, "ci": True, "trim": True}
+            )
+            continue
+
+        match = re.match(r"^\s*group_by\s*:\s*([A-Za-z0-9_]+)\s*$", part, flags=re.IGNORECASE)
+        if match:
+            out["group_by"] = _normalize(match.group(1).upper())
+            continue
+
+        match = re.match(r"^\s*gross\s*:\s*(true|false)\s*$", part, flags=re.IGNORECASE)
+        if match:
+            out["gross"] = match.group(1).lower() == "true"
+            continue
+
+        match = re.match(
+            r"^\s*order_by\s*:\s*([A-Za-z0-9_]+)\s*(asc|desc)?\s*$",
+            part,
+            flags=re.IGNORECASE,
+        )
+        if match:
+            out["sort_by"] = _normalize(match.group(1).upper())
+            direction = match.group(2).lower() if match.group(2) else "desc"
+            out["sort_desc"] = direction == "desc"
+            continue
+
+    return out
+
+
+__all__ = ["parse_rate_comment"]


### PR DESCRIPTION
## Summary
- add a parser that converts /dw/rate comments into FTS, equality, grouping and ordering hints
- build deterministic SQL for rate feedback using new builder helpers and persist feedback payloads
- integrate the structured SQL response into the /dw/rate endpoint with detailed debug output

## Testing
- pytest -q *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e2ec81b3d48323b6aff506ce015753