### PR TITLE
Improve /dw/rate comment parsing and clarify intent output

### DIFF
--- a/apps/dw/rate_comment.py
+++ b/apps/dw/rate_comment.py
@@ -3,16 +3,13 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, List, Optional
-
-_WS = r"\s*"
+from typing import Dict, Iterator, List, Optional, Tuple
 
 
-def _split_kv_parts(comment: str) -> List[str]:
-    """Split the comment by ';' while removing empty parts."""
-    if not comment:
-        return []
-    return [part.strip() for part in re.split(r";", comment) if part.strip()]
+_DIRECTIVE_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*:")
+_FTS_AND_RE = re.compile(r"\s*(?:&|\band\b)\s*", re.IGNORECASE)
+_FTS_OR_RE = re.compile(r"\s*(?:\||,|\bor\b)\s*", re.IGNORECASE)
+_FLAG_RE = re.compile(r"\(([^)]*)\)\s*$")
 
 
 def _normalize(value: Optional[str]) -> str:
@@ -21,29 +18,135 @@ def _normalize(value: Optional[str]) -> str:
     return re.sub(r"\s+", " ", value).strip()
 
 
+def _strip_quotes(value: str) -> str:
+    text = value.strip()
+    if len(text) >= 2 and text[0] in {'"', "'"} and text[-1] == text[0]:
+        return text[1:-1]
+    return text
+
+
+def _iter_directives(comment: str) -> Iterator[Tuple[str, str]]:
+    """Yield (directive, body) pairs respecting nested ';' inside bodies."""
+
+    if not comment:
+        return iter(())
+
+    text = comment.strip()
+    if not text:
+        return iter(())
+
+    matches = list(_DIRECTIVE_RE.finditer(text))
+    if not matches:
+        return iter(())
+
+    parts: List[Tuple[str, str]] = []
+    for index, match in enumerate(matches):
+        key = match.group(1)
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        body = text[start:end].strip().rstrip("; ")
+        parts.append((key, body))
+    return iter(parts)
+
+
+def _parse_fts(body: str) -> Tuple[List[str], str]:
+    if not body:
+        return [], "OR"
+    operator = "OR"
+    if _FTS_AND_RE.search(body):
+        tokens = [tok for tok in _FTS_AND_RE.split(body) if tok.strip()]
+        operator = "AND"
+    else:
+        tokens = [tok for tok in _FTS_OR_RE.split(body) if tok.strip()]
+    cleaned = []
+    for token in tokens:
+        normalized = _normalize(_strip_quotes(token))
+        if normalized:
+            cleaned.append(normalized)
+    return cleaned, operator
+
+
+def _extract_flags(flag_blob: str) -> Tuple[bool, bool, bool]:
+    ci = False
+    trim = False
+    valid = True
+    if not flag_blob:
+        return ci, trim, False
+    seen_any = False
+    for flag in flag_blob.split(","):
+        name = flag.strip().lower()
+        if not name:
+            continue
+        seen_any = True
+        if name in {"ci", "case_insensitive"}:
+            ci = True
+        elif name == "trim":
+            trim = True
+        else:
+            valid = False
+    return ci, trim, valid and seen_any
+
+
+def _parse_eq_clause(clause: str) -> Optional[Dict[str, object]]:
+    if not clause or "=" not in clause:
+        return None
+    flags_ci = False
+    flags_trim = False
+    match = _FLAG_RE.search(clause)
+    if match:
+        ci, trim, valid = _extract_flags(match.group(1))
+        if valid:
+            flags_ci = ci
+            flags_trim = trim
+            clause = clause[: match.start()].rstrip()
+
+    lhs, rhs = clause.split("=", 1)
+    column = _normalize(lhs).upper()
+    value = _strip_quotes(_normalize(rhs))
+    if not column or not value:
+        return None
+    return {"col": column, "val": value, "ci": flags_ci, "trim": flags_trim}
+
+
+def _parse_eq(body: str) -> List[Dict[str, object]]:
+    if not body:
+        return []
+    clauses: List[Dict[str, object]] = []
+    for part in re.split(r";", body):
+        parsed = _parse_eq_clause(part.strip())
+        if parsed:
+            clauses.append(parsed)
+    return clauses
+
+
+def _parse_group_by(body: str) -> Optional[str]:
+    if not body:
+        return None
+    cols = [
+        _normalize(segment).upper().replace(" ", "_")
+        for segment in body.split(",")
+        if _normalize(segment)
+    ]
+    return cols[0] if cols else None
+
+
+def _parse_order(body: str) -> Tuple[Optional[str], Optional[bool]]:
+    if not body:
+        return None, None
+    match = re.match(r"(.+?)\s+(asc|desc)$", body.strip(), flags=re.IGNORECASE)
+    if match:
+        column = _normalize(match.group(1)).upper().replace(" ", "_")
+        direction = match.group(2).lower() == "desc"
+        return column or None, direction
+    column = _normalize(body).upper().replace(" ", "_")
+    if not column:
+        return None, None
+    return column, True
+
+
 def parse_rate_comment(comment: str) -> Dict[str, object]:
-    """Return structured hints extracted from the ``comment`` text.
+    """Return structured hints extracted from a ``/dw/rate`` comment."""
 
-    The returned dictionary contains the following keys:
-
-    ``fts_tokens``
-        List of tokens extracted from ``fts:`` parts.
-
-    ``fts_operator``
-        Either ``"AND"`` or ``"OR"`` depending on the separators used.
-
-    ``eq_filters``
-        List of dictionaries with ``col``/``val`` pairs coming from ``eq:`` hints.
-
-    ``group_by``
-        Optional column passed via ``group_by:`` hint.
-
-    ``gross``
-        Optional boolean value parsed from ``gross:`` hint.
-
-    ``sort_by`` / ``sort_desc``
-        Column name and direction parsed from ``order_by:`` hint.
-    """
     out: Dict[str, object] = {
         "fts_tokens": [],
         "fts_operator": "OR",
@@ -56,50 +159,34 @@ def parse_rate_comment(comment: str) -> Dict[str, object]:
     if not comment:
         return out
 
-    parts = _split_kv_parts(comment)
-    for part in parts:
-        # fts: it | home care   OR   fts: it & home care
-        match = re.match(r"^\s*fts\s*:\s*(.+)$", part, flags=re.IGNORECASE)
-        if match:
-            body = match.group(1).strip()
-            if "&" in body or re.search(r"\band\b", body, flags=re.IGNORECASE):
-                tokens = [tok.strip() for tok in re.split(r"[&]|(?i:\band\b)", body) if tok.strip()]
-                out["fts_operator"] = "AND"
-            else:
-                tokens = [tok.strip() for tok in body.split("|") if tok.strip()]
-                out["fts_operator"] = "OR"
-            out["fts_tokens"] = [_normalize(tok) for tok in tokens]
-            continue
+    eq_filters: List[Dict[str, object]] = []
 
-        match = re.match(r"^\s*eq\s*:\s*([A-Za-z0-9_]+)\s*=\s*(.+)$", part, flags=re.IGNORECASE)
-        if match:
-            column = _normalize(match.group(1).upper())
-            value = _normalize(match.group(2))
-            out.setdefault("eq_filters", []).append(
-                {"col": column, "val": value, "ci": True, "trim": True}
-            )
-            continue
+    for key, body in _iter_directives(comment):
+        directive = key.strip().lower()
+        if directive == "fts":
+            tokens, operator = _parse_fts(body)
+            if tokens:
+                out["fts_tokens"] = tokens
+                out["fts_operator"] = operator or "OR"
+        elif directive == "eq":
+            eq_filters.extend(_parse_eq(body))
+        elif directive == "group_by":
+            group = _parse_group_by(body)
+            if group:
+                out["group_by"] = group
+        elif directive == "order_by":
+            column, desc = _parse_order(body)
+            if column:
+                out["sort_by"] = column
+                out["sort_desc"] = True if desc is None else bool(desc)
+        elif directive == "gross":
+            if body:
+                lowered = body.strip().lower()
+                if lowered in {"true", "false"}:
+                    out["gross"] = lowered == "true"
 
-        match = re.match(r"^\s*group_by\s*:\s*([A-Za-z0-9_]+)\s*$", part, flags=re.IGNORECASE)
-        if match:
-            out["group_by"] = _normalize(match.group(1).upper())
-            continue
-
-        match = re.match(r"^\s*gross\s*:\s*(true|false)\s*$", part, flags=re.IGNORECASE)
-        if match:
-            out["gross"] = match.group(1).lower() == "true"
-            continue
-
-        match = re.match(
-            r"^\s*order_by\s*:\s*([A-Za-z0-9_]+)\s*(asc|desc)?\s*$",
-            part,
-            flags=re.IGNORECASE,
-        )
-        if match:
-            out["sort_by"] = _normalize(match.group(1).upper())
-            direction = match.group(2).lower() if match.group(2) else "desc"
-            out["sort_desc"] = direction == "desc"
-            continue
+    if eq_filters:
+        out["eq_filters"] = eq_filters
 
     return out
 

--- a/apps/dw/rating.py
+++ b/apps/dw/rating.py
@@ -129,6 +129,7 @@ def rate():
     if not comment and feedback:
         comment = feedback
     structured_hints = parse_rate_comment_structured(comment or "")
+    structured_hints["full_text_search"] = bool(structured_hints.get("fts_tokens"))
     if not inquiry_id or rating < 1 or rating > 5:
         return jsonify({"ok": False, "error": "invalid payload"}), 400
 
@@ -289,6 +290,7 @@ def rate():
         )
         rate_debug = {
             "intent": {
+                "wants_all_columns": True,
                 "full_text_search": bool(fts_tokens),
                 "fts_tokens": fts_tokens,
                 "fts_operator": structured_hints.get("fts_operator") or "OR",
@@ -351,6 +353,9 @@ def rate():
             meta.setdefault("attempt_no", 2)
             meta.setdefault("strategy", "rate_overrides")
             meta["binds"] = rate_binds
+            intent_debug = rate_debug.get("intent")
+            if intent_debug:
+                meta["clarifier_intent"] = intent_debug
             payload.setdefault("rows", [])
             payload["retry"] = payload.get("retry") or True
             debug_section = payload.setdefault("debug", {})

--- a/tests/test_rate_comment.py
+++ b/tests/test_rate_comment.py
@@ -1,0 +1,56 @@
+"""Tests for the /dw/rate structured comment parser."""
+
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from apps.dw.rate_comment import parse_rate_comment
+
+
+def test_parse_rate_comment_with_fts_and_order():
+    comment = "fts: it | home care; order_by: request_date asc;"
+    result = parse_rate_comment(comment)
+
+    assert result["fts_tokens"] == ["it", "home care"]
+    assert result["fts_operator"] == "OR"
+    assert result["sort_by"] == "REQUEST_DATE"
+    assert result["sort_desc"] is False
+
+
+def test_parse_rate_comment_with_and_operator_and_flags():
+    comment = "eq: entity = DSFH (ci, trim); fts: acute & oncology"
+    result = parse_rate_comment(comment)
+
+    assert result["fts_tokens"] == ["acute", "oncology"]
+    assert result["fts_operator"] == "AND"
+    assert result["eq_filters"] == [
+        {"col": "ENTITY", "val": "DSFH", "ci": True, "trim": True}
+    ]
+
+
+def test_parse_rate_comment_multi_eq_and_group_by():
+    comment = "eq: entity = DSFH; request_type = 'Renewal'; group_by: owner_department"
+    result = parse_rate_comment(comment)
+
+    assert result["group_by"] == "OWNER_DEPARTMENT"
+    assert result["eq_filters"] == [
+        {"col": "ENTITY", "val": "DSFH", "ci": False, "trim": False},
+        {"col": "REQUEST_TYPE", "val": "Renewal", "ci": False, "trim": False},
+    ]
+
+
+def test_parse_rate_comment_preserves_parentheses_in_value():
+    comment = "eq: notes = 'ACME (Holdings)'"
+    result = parse_rate_comment(comment)
+
+    assert result["eq_filters"] == [
+        {"col": "NOTES", "val": "ACME (Holdings)", "ci": False, "trim": False}
+    ]
+
+
+def test_parse_rate_comment_gross_boolean():
+    comment = "gross: true"
+    result = parse_rate_comment(comment)
+
+    assert result["gross"] is True


### PR DESCRIPTION
## Summary
- expand the structured /dw/rate comment parser to capture FTS tokens, multi-column equality filters, and additional directives without leaking flag text into values
- honor case-insensitive/trim flags when building equality WHERE clauses and surface the normalized intent in the /dw/rate response metadata
- add unit coverage for the revised parser grammar

## Testing
- pytest tests/test_rate_comment.py

------
https://chatgpt.com/codex/tasks/task_e_68e3e72b8138832397d4dd6482314c4f