### PR TITLE
feature/p0-eq-multi-fts-guard-2025-10-06

### DIFF
--- a/apps/dw/eq_parser.py
+++ b/apps/dw/eq_parser.py
@@ -3,9 +3,26 @@
 from __future__ import annotations
 
 import re
-from typing import Dict, Iterable, List, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
-__all__ = ["parse_eq_filters_from_text", "build_eq_where_and_binds"]
+__all__ = [
+    "parse_eq_filters_from_text",
+    "build_eq_where_and_binds",
+    "extract_eq_filters_from_text",
+    "normalize_column",
+    "parse_rate_comment",
+    "strip_eq_from_text",
+]
+
+# Lightweight pattern for simple ``COLUMN = VALUE`` detection used by fallback paths.
+_EQ_RE = re.compile(
+    r"""
+    (?P<col>[A-Za-z0-9_ ]+)\s*
+    (?:=|==|is|equals)\s*
+    ['\"]?(?P<val>[^'\"]+)['\"]?
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 
 # Column synonyms supported for quick mapping from display names.
 _EQ_SYNONYMS = {
@@ -128,3 +145,89 @@ def build_eq_where_and_binds(
         predicates.append(f"({column_expr} = {bind_expr})")
     where_sql = " AND ".join(predicates) if predicates else ""
     return where_sql, binds
+
+
+def normalize_column(col: str) -> str:
+    """Normalize a human-friendly column name to uppercase with underscores."""
+
+    return re.sub(r"\s+", "_", (col or "").strip()).upper()
+
+
+def extract_eq_filters_from_text(
+    text: str,
+    explicit_columns: Iterable[str],
+) -> List[Dict[str, Any]]:
+    """Extract equality predicates from free text when column is whitelisted."""
+
+    filters: List[Dict[str, Any]] = []
+    allowed = {normalize_column(col): str(col).strip().upper() for col in (explicit_columns or []) if col}
+    if not allowed:
+        return filters
+
+    for match in _EQ_RE.finditer(text or ""):
+        col_key = normalize_column(match.group("col") or "")
+        if col_key not in allowed:
+            continue
+        value = (match.group("val") or "").strip()
+        if not value:
+            continue
+        filters.append({"col": allowed[col_key], "val": value, "ci": True, "trim": True})
+    return filters
+
+
+def strip_eq_from_text(text: str, explicit_columns: Iterable[str]) -> str:
+    allowed = {normalize_column(col) for col in (explicit_columns or []) if col}
+
+    def _repl(match: re.Match[str]) -> str:
+        col_key = normalize_column(match.group("col") or "")
+        return " " if col_key in allowed else match.group(0)
+
+    return _EQ_RE.sub(_repl, text or "")
+
+
+def parse_rate_comment(comment: str) -> Dict[str, Any]:
+    """Parse lightweight ``fts``/``eq`` hints from a rate comment string."""
+
+    intent: Dict[str, Any] = {
+        "fts_tokens": [],
+        "fts_operator": "OR",
+        "eq_filters": [],
+        "order_by": None,
+        "order_desc": None,
+        "group_by": None,
+        "gross": None,
+    }
+    if not comment:
+        return intent
+
+    fts_match = re.search(r"fts\s*:\s*([^;]+)", comment, flags=re.IGNORECASE)
+    if fts_match:
+        tokens = [tok.strip() for tok in fts_match.group(1).split("|") if tok.strip()]
+        intent["fts_tokens"] = tokens
+        intent["fts_operator"] = "OR"
+
+    for eq_match in re.finditer(r"eq\s*:\s*([^;]+)", comment, flags=re.IGNORECASE):
+        expr = eq_match.group(1)
+        match = _EQ_RE.search(expr or "")
+        if not match:
+            continue
+        col = normalize_column(match.group("col") or "")
+        val = (match.group("val") or "").strip()
+        if not col or not val:
+            continue
+        intent["eq_filters"].append({"col": col, "val": val, "ci": True, "trim": True})
+
+    order = re.search(r"order_by\s*:\s*([A-Za-z0-9_ ]+)\s+(asc|desc)", comment, flags=re.IGNORECASE)
+    if order:
+        intent["order_by"] = normalize_column(order.group(1) or "")
+        intent["order_desc"] = (order.group(2) or "").strip().lower() == "desc"
+
+    group = re.search(r"group_by\s*:\s*([A-Za-z0-9_ ]+)", comment, flags=re.IGNORECASE)
+    if group:
+        intent["group_by"] = normalize_column(group.group(1) or "")
+
+    gross = re.search(r"gross\s*:\s*(true|false)", comment, flags=re.IGNORECASE)
+    if gross:
+        intent["gross"] = (gross.group(1) or "").strip().lower() == "true"
+
+    return intent

--- a/apps/dw/fts_builder.py
+++ b/apps/dw/fts_builder.py
@@ -1,0 +1,49 @@
+from typing import Dict, List, Tuple
+
+
+def build_like_predicates(columns: List[str], bind_name: str) -> str:
+    """Build an OR chain of ``UPPER(NVL(col,'')) LIKE UPPER(:bind)`` predicates."""
+
+    safe_columns = [col.strip() for col in columns or [] if col and str(col).strip()]
+    or_terms = [f"UPPER(NVL({col},'')) LIKE UPPER(:{bind_name})" for col in safe_columns]
+    return "(" + " OR ".join(or_terms) + ")"
+
+
+def build_fts_where(
+    tokens_groups: List[List[str]],
+    columns: List[str],
+    operator_between_groups: str,
+    binds_out: Dict[str, str],
+) -> Tuple[str, Dict[str, str]]:
+    """Return a WHERE fragment for LIKE-based full-text search.
+
+    ``tokens_groups`` is a list of token collections. Tokens within the same
+    collection are OR'd together; collections are combined using
+    ``operator_between_groups`` ("AND" or "OR"). ``binds_out`` is mutated in
+    place with generated bind variables (``fts_0``, ``fts_1`` ...).
+    """
+
+    if not tokens_groups or not columns:
+        return "", binds_out
+
+    group_sql: List[str] = []
+    bind_idx = len([k for k in binds_out if str(k).startswith("fts_")])
+
+    for group in tokens_groups:
+        tokens = [tok.strip() for tok in group if tok and tok.strip()]
+        if not tokens:
+            continue
+        subterms: List[str] = []
+        for token in tokens:
+            bind_name = f"fts_{bind_idx}"
+            bind_idx += 1
+            binds_out[bind_name] = f"%{token}%"
+            subterms.append(build_like_predicates(columns, bind_name))
+        if subterms:
+            group_sql.append("(" + " OR ".join(subterms) + ")")
+
+    if not group_sql:
+        return "", binds_out
+
+    op = "AND" if operator_between_groups.upper() == "AND" else "OR"
+    return "(" + f" {op} ".join(group_sql) + ")", binds_out

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -718,3 +718,22 @@ cases:
         - 'UPPER(TRIM(OWNER_DEPARTMENT)) = UPPER(TRIM(:eq_0))'
       binds:
         - 'eq_0'
+- namespace: dw::common
+  question: "list all contracts has it or home care"
+  full_text_search: true
+  expect_sql_contains:
+    - "LIKE UPPER(:fts_0)"
+    - "LIKE UPPER(:fts_1)"
+    - "ORDER BY REQUEST_DATE DESC"
+  expect_sql_not_contains:
+    - "SELECT * FROM \"Contract\"\nORDER BY REQUEST_DATE DESC\nORDER BY REQUEST_DATE DESC"
+
+- namespace: dw::common
+  question: "list all contracts has it or home care and ENTITY = DSFH and REPRESENTATIVE_EMAIL = samer@procare-sa.com"
+  full_text_search: true
+  expect_sql_contains:
+    - "LIKE UPPER(:fts_0)"
+    - "LIKE UPPER(:fts_1)"
+    - "UPPER(TRIM(ENTITY)) = UPPER(TRIM(:eq_0))"
+    - "UPPER(TRIM(REPRESENTATIVE_EMAIL)) = UPPER(TRIM(:eq_1))"
+    - "ORDER BY REQUEST_DATE DESC"


### PR DESCRIPTION
## Summary
- add a reusable LIKE-based FTS builder that can merge grouped tokens onto configured columns
- extend the equality parser with lightweight helpers for free-text questions and feedback comments
- wire a safe LIKE fallback into /dw/answer so we combine extracted equality predicates with FTS binds and log the richer debug metadata
- append golden scenarios that assert the combined LIKE and equality behaviour

## Testing
- pytest apps/dw/tests/test_dw_golden.py *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68e43ab068188323b65de5d3e5bf9f74