### PR TITLE
feature/p1-fts-eq-groupby-order-2025-10-1

### DIFF
--- a/apps/dw/patchlib/__init__.py
+++ b/apps/dw/patchlib/__init__.py
@@ -1,0 +1,1 @@
+"""Patch helpers for DW rate comment fallback handling."""

--- a/apps/dw/patchlib/eq_parser.py
+++ b/apps/dw/patchlib/eq_parser.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+Generic equality parser for phrases like:
+- COLUMN = VALUE
+- COLUMN equals VALUE
+- COLUMN is VALUE
+
+Maps display names (with spaces) to actual columns using DW_EXPLICIT_FILTER_COLUMNS.
+Respects DW_ENUM_SYNONYMS for Contract.REQUEST_TYPE.
+"""
+from __future__ import annotations
+
+import re
+from typing import List, Dict
+
+
+def parse_eq_pairs(text: str, explicit_cols: List[str]) -> List[Dict]:
+    # Capture `COLUMN = VALUE` or `COLUMN is VALUE` or `COLUMN equals VALUE`
+    # COLUMN may contain spaces. VALUE may be quoted or not.
+    pat = r"(?P<col>[A-Za-z0-9_ ]+?)\s*(?:=|is|equals)\s*['\"]?(?P<val>[^'\"\n\r]+)['\"]?"
+    eqs = []
+    allowed = {c.strip().upper().replace(" ", "_") for c in explicit_cols or [] if isinstance(c, str)}
+    for m in re.finditer(pat, text or "", flags=re.IGNORECASE):
+        col = m.group("col").strip().upper().replace(" ", "_")
+        val = m.group("val").strip()
+        if col in allowed:
+            eqs.append({"col": col, "val": val, "ci": True, "trim": True})
+    return eqs
+
+
+def expand_request_type_with_synonyms(eqs: List[Dict], enum_syn: Dict) -> List[Dict]:
+    # If col == REQUEST_TYPE → expand synonyms into LIKE/IN plan handled later in SQL builder.
+    # Here we just tag the record.
+    for e in eqs:
+        if str(e.get("col", "")).upper() == "REQUEST_TYPE":
+            e["_use_synonyms"] = True
+    return eqs

--- a/apps/dw/patchlib/fts_builder.py
+++ b/apps/dw/patchlib/fts_builder.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+FTS WHERE builder based on DW_FTS_COLUMNS and tokens.
+Supports operator: OR / AND.
+Engine "like" implemented here; "oracle-text" placeholder for future.
+"""
+from __future__ import annotations
+
+from typing import Tuple, Dict, List
+
+
+def build_like_fts(columns: List[str], tokens_groups: List[List[str]]) -> Tuple[str, Dict[str, str]]:
+    """
+    tokens_groups is a list of groups. Each group is ORed inside, ANDed between groups if len>1.
+    Example:
+        [["it"], ["home care"]] → (group1) OR (group2)  (if caller wants OR between groups)
+        For AND behavior, caller should pass AND-mode; here we only build per-group OR block.
+    We will return a generic AND over groups; caller decides to OR or AND by how he passes groups.
+    For simplicity: we AND between groups (each group can contain multiple tokens ORed).
+    If you want OR-between-groups, pass a single group with all tokens.
+    """
+    where_parts = []
+    binds: Dict[str, str] = {}
+    bidx = 0
+    for group in tokens_groups:
+        ors = []
+        for tok in group:
+            bind_name = f"fts_{bidx}"
+            bidx += 1
+            binds[bind_name] = f"%{tok}%"
+            ors.append("(" + " OR ".join([f"UPPER(NVL({col},'')) LIKE UPPER(:{bind_name})" for col in columns]) + ")")
+        if ors:
+            where_parts.append("(" + " OR ".join(ors) + ")")
+    if not where_parts:
+        return "", {}
+    # AND groups (see planner that chooses AND vs OR composition)
+    return "(" + " AND ".join(where_parts) + ")", binds

--- a/apps/dw/patchlib/order_utils.py
+++ b/apps/dw/patchlib/order_utils.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+"""
+Order/Top/Bottom detectors.
+"""
+import re
+
+ASC_TOKENS = {"lowest", "cheapest", "smallest", "bottom", "أقل"}
+DESC_TOKENS = {"highest", "top", "biggest", "largest", "أعلى"}
+
+
+def detect_order_direction(text: str, default_desc: bool = True) -> str:
+    t = (text or "").lower()
+    if any(tok in t for tok in ASC_TOKENS):
+        return "ASC"
+    if any(tok in t for tok in DESC_TOKENS):
+        return "DESC"
+    return "DESC" if default_desc else "ASC"
+
+
+def detect_top_n(text: str) -> int | None:
+    # e.g., "top 10", "bottom 5"
+    m = re.search(r"\b(?:top|bottom)\s+(\d{1,3})\b", (text or "").lower())
+    return int(m.group(1)) if m else None

--- a/apps/dw/patchlib/rate_parser.py
+++ b/apps/dw/patchlib/rate_parser.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""
+Parse /dw/rate comment hints like:
+- fts: it | home care
+- fts: it & home care
+- eq: ENTITY = DSFH
+- group_by: CONTRACT_STATUS
+- gross: true
+- order_by: REQUEST_DATE desc
+"""
+from __future__ import annotations
+
+import re
+from typing import Dict
+
+
+def parse_rate_comment(comment: str) -> Dict[str, object]:
+    out = {"fts": None, "eq": [], "group_by": None, "gross": None, "order_by": None}
+    if not comment:
+        return out
+    lines = [x.strip() for x in comment.split(";") if x.strip()]
+    for ln in lines:
+        if ln.lower().startswith("fts:"):
+            payload = ln.split(":", 1)[1].strip()
+            # support OR with |, AND with &
+            if "&" in payload and "|" not in payload:
+                tokens = [t.strip() for t in payload.split("&") if t.strip()]
+                out["fts"] = {"mode": "AND", "tokens": tokens}
+            else:
+                tokens = [t.strip() for t in re.split(r"[|,]", payload) if t.strip()]
+                out["fts"] = {"mode": "OR", "tokens": tokens}
+        elif ln.lower().startswith("eq:"):
+            payload = ln.split(":", 1)[1].strip()
+            m = re.match(r"([A-Za-z0-9_ ]+)\s*=\s*(.+)$", payload)
+            if m:
+                col = m.group(1).strip().upper().replace(" ", "_")
+                val = m.group(2).strip().strip("'").strip('"')
+                out["eq"].append({"col": col, "val": val, "ci": True, "trim": True})
+        elif ln.lower().startswith("group_by:"):
+            out["group_by"] = ln.split(":", 1)[1].strip().upper().replace(" ", "_")
+        elif ln.lower().startswith("gross:"):
+            raw = ln.split(":", 1)[1].strip().lower()
+            out["gross"] = (raw in ("1", "true", "yes", "on"))
+        elif ln.lower().startswith("order_by:"):
+            part = ln.split(":", 1)[1].strip()
+            m = re.match(r"([A-Za-z0-9_ ]+)\s+(asc|desc)$", part, flags=re.IGNORECASE)
+            if m:
+                out["order_by"] = {"col": m.group(1).strip().upper().replace(" ", "_"), "dir": m.group(2).upper()}
+    return out

--- a/apps/dw/patchlib/settings_util.py
+++ b/apps/dw/patchlib/settings_util.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+Utilities to read DW settings in a consistent way.
+All comments must stay in English (per project convention).
+"""
+from __future__ import annotations
+
+try:
+    from apps.common.settings import get_setting  # type: ignore
+except Exception:  # pragma: no cover - fallback to DW helper
+    from apps.dw.settings_util import get_setting  # type: ignore
+
+
+def get_json_setting(ns_key: str, default=None):
+    val = get_setting(ns_key)
+    return val if isinstance(val, dict) or isinstance(val, list) else (default if default is not None else {})
+
+
+def get_fts_engine() -> str:
+    # allowed: "like" (safe), "oracle-text" (if enabled). Default to "like".
+    eng = get_setting("DW_FTS_ENGINE")
+    return str(eng).strip().lower() if eng else "like"
+
+
+def get_fts_columns(table: str = "Contract") -> list:
+    cols = get_json_setting("DW_FTS_COLUMNS", {})
+    if isinstance(cols, dict):
+        table_cols = cols.get(table) or []
+        fallback_cols = cols.get("*") or []
+        # merge and keep order: table-specific first, then any extras in "*"
+        merged = list(dict.fromkeys([*table_cols, *fallback_cols]))
+        return merged
+    return []
+
+
+def get_explicit_filter_columns() -> list:
+    cols = get_setting("DW_EXPLICIT_FILTER_COLUMNS")
+    return cols if isinstance(cols, list) else []
+
+
+def get_enum_synonyms() -> dict:
+    return get_json_setting("DW_ENUM_SYNONYMS", {})

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -11,6 +11,50 @@ cases:
         - 'CONTRACT_STATUS'
       must_not: []
 
+  - id: patch_fts_single_it
+    question: "list all contracts has it"
+    expect_contains:
+      - "WHERE"
+      - "LIKE UPPER(:fts_0)"
+      - "ORDER BY REQUEST_DATE DESC"
+
+  - id: patch_fts_or_tokens
+    question: "list all contracts has it or home care"
+    expect_contains:
+      - "LIKE UPPER(:fts_0)"
+      - "LIKE UPPER(:fts_1)"
+      - "ORDER BY REQUEST_DATE DESC"
+
+  - id: patch_fts_and_tokens
+    question: "list all contracts has it and home care"
+    expect_contains:
+      - "LIKE UPPER(:fts_0)"
+      - "LIKE UPPER(:fts_1)"
+      - " AND "
+      - "ORDER BY REQUEST_DATE DESC"
+
+  - id: patch_eq_request_type_synonym
+    question: "Show contracts where REQUEST TYPE = Renewal"
+    expect_contains:
+      - "REQUEST_TYPE"
+      - "IN ("
+      - "ORDER BY REQUEST_DATE DESC"
+    expect_not_contains:
+      - "Fallback listing"
+
+  - id: patch_group_by_entity_totals
+    question: "For ENTITY_NO = 'E-123', total and count by CONTRACT_STATUS."
+    expect_contains:
+      - "GROUP BY CONTRACT_STATUS"
+      - "COUNT(*) AS CNT"
+
+  - id: patch_lowest_gross_top_n
+    question: "lowest 5 contracts by gross last month"
+    expect_contains:
+      - "ORDER BY"
+      - " ASC"
+      - "FETCH FIRST 5 ROWS ONLY"
+
   - id: request_type_synonym_filter
     question: "Show contracts where REQUEST TYPE = Renewal"
     expect:


### PR DESCRIPTION
## Summary
- add patchlib utilities for reading DW settings, parsing comments, and building fallback FTS clauses
- extend the SQL builder with helpers to translate rate comment FTS/equality hints
- integrate a /dw/rate comment fallback path and add golden coverage for the new behaviors

## Testing
- pytest tests/test_rate_comment.py
- pytest tests/test_dw_simple.py::test_rate_endpoint_uses_rate_comment


------
https://chatgpt.com/codex/tasks/task_e_68e4645388948323b87085026d6cd52d