### PR TITLE
feature/p1p2-consolidated-2025-10-07

### DIFF
--- a/apps/dw/admin_rules.py
+++ b/apps/dw/admin_rules.py
@@ -1,0 +1,38 @@
+from flask import Blueprint, render_template, redirect, url_for
+from sqlalchemy import text
+
+from apps.dw.learning import _engine
+
+admin_rules_bp = Blueprint("admin_rules", __name__, url_prefix="/admin/rules")
+
+
+@admin_rules_bp.route("/")
+def list_rules():
+    eng = _engine()
+    patches = []
+    if eng:
+        with eng.begin() as cx:
+            patches = cx.execute(
+                text(
+                    "SELECT id, inquiry_id, status, created_at, patch_json FROM dw_patches ORDER BY id DESC LIMIT 200"
+                )
+            ).mappings().all()
+    return render_template("dw/admin_rules.html", patches=patches)
+
+
+@admin_rules_bp.route("/approve/<int:pid>", methods=["POST"])
+def approve(pid):
+    eng = _engine()
+    if eng:
+        with eng.begin() as cx:
+            cx.execute(text("UPDATE dw_patches SET status='approved' WHERE id=:i"), {"i": pid})
+    return redirect(url_for("admin_rules.list_rules"))
+
+
+@admin_rules_bp.route("/reject/<int:pid>", methods=["POST"])
+def reject(pid):
+    eng = _engine()
+    if eng:
+        with eng.begin() as cx:
+            cx.execute(text("UPDATE dw_patches SET status='rejected' WHERE id=:i"), {"i": pid})
+    return redirect(url_for("admin_rules.list_rules"))

--- a/apps/dw/app.py
+++ b/apps/dw/app.py
@@ -1493,3 +1493,14 @@ def answer():
 
 def create_dw_blueprint(*args, **kwargs):
     return dw_bp
+
+# ensure FTS engine check and default
+from apps.dw.settings import get_setting
+
+def fts_engine():
+    eng = (get_setting("DW_FTS_ENGINE", scope="namespace") or "like")
+    try:
+        eng = eng.lower()
+    except Exception:
+        eng = "like"
+    return "like" if eng not in ("like", "oracle-text") else eng

--- a/apps/dw/rate.py
+++ b/apps/dw/rate.py
@@ -1,51 +1,10 @@
-from __future__ import annotations
-
-import logging
-from datetime import datetime
-from typing import Dict, List, Sequence
-
 from flask import Blueprint, request, jsonify
 
-from apps.dw.patchlib.order_utils import (
-    detect_order_direction as _patch_detect_order_direction,
-    detect_top_n as _patch_detect_top_n,
-)
-from apps.dw.patchlib.rate_parser import parse_rate_comment as parse_rate_comment_patch
-from apps.dw.patchlib.settings_util import (
-    get_explicit_filter_columns as _patch_get_explicit_filter_columns,
-    get_enum_synonyms as _patch_get_enum_synonyms,
-    get_fts_columns as _patch_get_fts_columns,
-)
-from apps.dw.sql_builder import build_eq_where_from_pairs, build_fts_where as build_fts_where_patch
-from .settings import get_setting
-from .sql_builder import build_measure_sql, quote_ident, strip_double_order_by
-from .learn_store import LearningStore, ExampleRecord, PatchRecord
-from .utils import safe_upper
-from .settings_defaults import DEFAULT_EXPLICIT_FILTER_COLUMNS
-from .rate_helpers import (
-    build_eq_clause,
-    build_fts_like_where,
-    choose_fts_columns,
-    parse_rate_comment,
-)
+from apps.dw.sql_builder import build_rate_sql
+from apps.dw.settings import get_setting
+from apps.dw.learning import record_feedback, to_patch_from_comment
 
 rate_bp = Blueprint("rate", __name__)
-LOGGER = logging.getLogger("dw.rate")
-
-# ---------------------------
-# Rate Comment Parsing
-# ---------------------------
-def _resolve_allowed_column(raw_col: str | None, allowed: Sequence[str]) -> str | None:
-    if not raw_col:
-        return None
-    target = raw_col.strip().upper()
-    for candidate in allowed:
-        candidate_up = candidate.strip().upper()
-        if target == candidate_up:
-            return candidate
-        if target.replace(" ", "") == candidate_up.replace(" ", ""):
-            return candidate
-    return None
 
 
 @rate_bp.route("/dw/rate", methods=["POST"])
@@ -53,333 +12,64 @@ def rate():
     payload = request.get_json(force=True, silent=True) or {}
     inquiry_id = payload.get("inquiry_id")
     rating = payload.get("rating")
-    comment = payload.get("comment") or ""
+    comment = (payload.get("comment") or "").strip()
+    record_feedback(inquiry_id=inquiry_id, rating=rating, comment=comment)
 
-    patch_hints = parse_rate_comment_patch(comment)
-    patch_has_directives = any(
-        [
-            patch_hints.get("fts"),
-            patch_hints.get("eq"),
-            patch_hints.get("group_by"),
-            patch_hints.get("gross") is not None,
-            patch_hints.get("order_by"),
-            _patch_detect_top_n(comment),
-        ]
-    )
+    patch = None
+    if rating is not None and int(rating) <= 2 and comment:
+        patch = to_patch_from_comment(comment)
 
-    if patch_has_directives:
-        try:
-            explicit_cols = _patch_get_explicit_filter_columns() or []
-            allowed = {
-                str(col).strip().upper().replace(" ", "_")
-                for col in explicit_cols
-                if isinstance(col, str) and col.strip()
-            }
+    resp = {"ok": True, "inquiry_id": inquiry_id, "debug": {}}
 
-            eq_pairs: List[Dict] = []
-            for pair in patch_hints.get("eq") or []:
-                col = str(pair.get("col") or "").upper()
-                if not col:
-                    continue
-                if allowed and col not in allowed:
-                    continue
-                eq_pairs.append(pair)
+    if patch:
+        intent = {
+            "eq_filters": patch.get("eq_filters") or [],
+            "fts": {
+                "enabled": bool(patch.get("fts_tokens")),
+                "operator": patch.get("fts_operator") or "OR",
+                "tokens": [[t] for t in (patch.get("fts_tokens") or [])],
+                "columns": (get_setting("DW_FTS_COLUMNS", scope="namespace") or {}).get("Contract", []),
+            },
+            "group_by": patch.get("group_by"),
+            "sort_by": patch.get("sort_by"),
+            "sort_desc": patch.get("sort_desc"),
+            "top_n": patch.get("top_n"),
+            "gross": patch.get("gross"),
+        }
+    else:
+        intent = {
+            "eq_filters": [],
+            "fts": {"enabled": False},
+            "group_by": None,
+            "sort_by": "REQUEST_DATE",
+            "sort_desc": True,
+            "top_n": None,
+            "gross": None,
+        }
 
-            fts_info = patch_hints.get("fts") or {}
-            fts_tokens = fts_info.get("tokens") or []
-            fts_mode = fts_info.get("mode") or "OR"
-            fts_sql, fts_binds = build_fts_where_patch(fts_tokens, fts_mode)
-
-            eq_sql, eq_binds = build_eq_where_from_pairs(eq_pairs, _patch_get_enum_synonyms())
-
-            where_parts_patch = [part for part in (fts_sql, eq_sql) if part]
-            where_sql = (" WHERE " + " AND ".join(where_parts_patch)) if where_parts_patch else ""
-
-            group_by_col = patch_hints.get("group_by")
-            gross_flag = patch_hints.get("gross")
-            measure_expr = (
-                "NVL(CONTRACT_VALUE_NET_OF_VAT,0) + CASE WHEN NVL(VAT,0) BETWEEN 0 AND 1 "
-                "THEN NVL(CONTRACT_VALUE_NET_OF_VAT,0)*NVL(VAT,0) ELSE NVL(VAT,0) END"
-            )
-
-            if group_by_col:
-                select_sql = f"SELECT {group_by_col} AS GROUP_KEY"
-                default_order_col = "CNT"
-                if gross_flag is True:
-                    select_sql += f", SUM({measure_expr}) AS TOTAL_GROSS"
-                    default_order_col = "TOTAL_GROSS"
-                select_sql += ", COUNT(*) AS CNT"
-                final_sql = (
-                    f"{select_sql}\n"
-                    f"FROM \"Contract\"{where_sql}\n"
-                    f"GROUP BY {group_by_col}"
-                )
-            else:
-                final_sql = f'SELECT *\nFROM "Contract"{where_sql}'
-                default_order_col = "REQUEST_DATE"
-
-            order_hint = patch_hints.get("order_by")
-            if order_hint:
-                order_col = order_hint.get("col") or default_order_col
-                order_dir = (order_hint.get("dir") or "DESC").upper()
-            else:
-                order_col = default_order_col
-                order_dir = _patch_detect_order_direction(comment, default_desc=True)
-
-            if not order_col:
-                order_col = "REQUEST_DATE"
-            if not order_dir:
-                order_dir = "DESC"
-
-            final_sql += f"\nORDER BY {order_col} {order_dir}"
-
-            top_n = _patch_detect_top_n(comment)
-            if top_n:
-                final_sql += f"\nFETCH FIRST {top_n} ROWS ONLY"
-
-            binds: Dict[str, object] = {}
-            binds.update(fts_binds)
-            binds.update(eq_binds)
-
-            debug_fts = {
-                "enabled": bool(fts_tokens),
-                "mode": (fts_mode or "OR").upper(),
-                "tokens": fts_tokens,
-                "columns": _patch_get_fts_columns("Contract"),
-                "binds": list(fts_binds.keys()),
-                "error": None,
-            }
-            debug_eq = {
-                "pairs": eq_pairs,
-                "binds": list(eq_binds.keys()),
-            }
-            debug_payload = {
-                "fts": debug_fts,
-                "eq": debug_eq,
+    enum_syn = (get_setting("DW_ENUM_SYNONYMS", scope="namespace") or {}).get("Contract.REQUEST_TYPE", {})
+    sql, binds = build_rate_sql(intent, enum_syn=enum_syn)
+    resp.update(
+        {
+            "retry": True,
+            "sql": sql,
+            "debug": {
+                "intent": intent,
+                "rate_hints": patch or {},
                 "validation": {
                     "ok": True,
-                    "errors": [],
                     "binds": list(binds.keys()),
                     "bind_names": list(binds.keys()),
+                    "errors": [],
                 },
-                "rate_patch": True,
-            }
-
-            response_payload = {
-                "ok": True,
-                "inquiry_id": inquiry_id,
-                "sql": final_sql,
-                "meta": {
-                    "attempt_no": 2,
-                    "binds": binds,
-                    "clarifier_intent": {
-                        "fts": fts_tokens,
-                        "eq": eq_pairs,
-                        "group_by": group_by_col,
-                        "gross": gross_flag,
-                    },
-                    "fts": debug_fts,
-                },
-                "debug": debug_payload,
-                "rows": [],
-                "retry": True,
-            }
-
-            return jsonify(response_payload)
-        except Exception:  # pragma: no cover - defensive fallback
-            LOGGER.exception("[dw/rate] patch handler failed; using legacy pipeline")
-
-    hints_intent = parse_rate_comment(comment)
-
-    measure_sql = build_measure_sql()
-
-    binds: dict = {}
-    where_parts: list[str] = []
-    order_by: str | None = None
-    sort_desc: bool | None = None
-
-    namespace_settings = {
-        "DW_FTS_COLUMNS": get_setting("DW_FTS_COLUMNS", scope="namespace") or {},
-        "DW_EXPLICIT_FILTER_COLUMNS": get_setting("DW_EXPLICIT_FILTER_COLUMNS", scope="namespace")
-        or DEFAULT_EXPLICIT_FILTER_COLUMNS,
-    }
-
-    raw_fts_columns = choose_fts_columns(namespace_settings)
-    fts_columns = [quote_ident(col) for col in raw_fts_columns]
-    fts_tokens = hints_intent.get("fts_tokens") or []
-    fts_operator = hints_intent.get("fts_operator") or "OR"
-    fts_where, fts_binds = build_fts_like_where(fts_columns, fts_tokens, operator=fts_operator)
-    fts_enabled = bool(fts_where)
-    if fts_where:
-        where_parts.append(fts_where)
-        binds.update(fts_binds)
-
-    raw_allowed_eq = namespace_settings.get("DW_EXPLICIT_FILTER_COLUMNS")
-    if not isinstance(raw_allowed_eq, Sequence) or isinstance(raw_allowed_eq, (str, bytes)):
-        allowed_eq_columns: List[str] = list(DEFAULT_EXPLICIT_FILTER_COLUMNS)
-    else:
-        allowed_eq_columns = [str(col).strip() for col in raw_allowed_eq if isinstance(col, str) and col.strip()]
-        if not allowed_eq_columns:
-            allowed_eq_columns = list(DEFAULT_EXPLICIT_FILTER_COLUMNS)
-
-    eq_filters = []
-    eq_applied: List[Dict[str, str]] = []
-    for filt in hints_intent.get("eq_filters") or []:
-        resolved = _resolve_allowed_column(filt.get("col"), allowed_eq_columns)
-        if not resolved:
-            continue
-        eq_filter = dict(filt)
-        eq_filter["col"] = quote_ident(resolved)
-        eq_filters.append(eq_filter)
-        eq_applied.append({**filt, "col": resolved})
-
-    eq_where, eq_binds = build_eq_clause(eq_filters)
-    if eq_where:
-        where_parts.append(eq_where)
-        binds.update(eq_binds)
-
-    group_by_resolved: List[str] = []
-    group_by_display: List[str] = []
-    for col in hints_intent.get("group_by") or []:
-        resolved = _resolve_allowed_column(col, allowed_eq_columns)
-        if resolved:
-            group_by_resolved.append(quote_ident(resolved))
-            group_by_display.append(resolved)
-
-    gross_flag = hints_intent.get("gross")
-
-    order_hint = hints_intent.get("order_by") or {}
-    if order_hint:
-        resolved = _resolve_allowed_column(order_hint.get("col"), allowed_eq_columns)
-        if resolved:
-            order_by = quote_ident(resolved)
-            sort_desc = (order_hint.get("dir") or "DESC").upper() != "ASC"
-        else:
-            col_upper = (order_hint.get("col") or "").strip().upper()
-            if col_upper in {"MEASURE", "CNT", "COUNT"}:
-                order_by = col_upper if col_upper != "COUNT" else "CNT"
-                sort_desc = (order_hint.get("dir") or "DESC").upper() != "ASC"
-            elif col_upper == "REQUEST_DATE":
-                order_by = quote_ident("REQUEST_DATE")
-                sort_desc = (order_hint.get("dir") or "DESC").upper() != "ASC"
-
-    table_setting = get_setting("DW_CONTRACT_TABLE", scope="namespace")
-    if isinstance(table_setting, str) and table_setting.strip():
-        table = table_setting.strip()
-    else:
-        table = '"Contract"'
-    if not table.startswith('"'):
-        table = quote_ident(table)
-
-    final_sql: str
-
-    if group_by_resolved:
-        select_group = ", ".join(group_by_resolved)
-        if gross_flag is True:
-            select_cols = f"{select_group}, SUM({measure_sql}) AS MEASURE, COUNT(*) AS CNT"
-            default_order_col = "MEASURE"
-        elif gross_flag is False:
-            select_cols = f"{select_group}, COUNT(*) AS CNT"
-            default_order_col = "CNT"
-        else:
-            select_cols = f"{select_group}, COUNT(*) AS CNT"
-            default_order_col = "CNT"
-        where_sql = " WHERE " + " AND ".join(where_parts) if where_parts else ""
-        order_col = order_by or default_order_col
-        order_upper = safe_upper(order_col.strip('"')) if isinstance(order_col, str) else None
-        if order_upper == "REQUEST_DATE":
-            order_col = default_order_col
-        if order_col not in ("MEASURE", "CNT"):
-            order_col = quote_ident(str(order_col).strip('"'))
-        direction = "DESC" if (sort_desc is True or sort_desc is None) else "ASC"
-        final_sql = (
-            f"SELECT {select_cols}\n"
-            f"FROM {table}{where_sql}\n"
-            f"GROUP BY {select_group}\n"
-            f"ORDER BY {order_col} {direction}"
-        )
-    else:
-        where_sql = " WHERE " + " AND ".join(where_parts) if where_parts else ""
-        if order_by is None:
-            order_by = quote_ident("REQUEST_DATE")
-            sort_desc = True
-        direction = "DESC" if (sort_desc is True or sort_desc is None) else "ASC"
-        final_sql = f"SELECT * FROM {table}{where_sql}\nORDER BY {order_by} {direction}"
-
-    final_sql = strip_double_order_by(final_sql)
-
-    debug = {
-        "fts": {
-            "enabled": bool(fts_enabled),
-            "mode": "like" if fts_enabled else None,
-            "tokens": fts_tokens or None,
-            "columns": raw_fts_columns if fts_enabled else None,
-            "binds": list(fts_binds.keys()) if fts_enabled else None,
-            "error": None,
-        },
-        "eq": {
-            "applied": eq_applied,
-            "binds": list(eq_binds.keys()),
-        },
-        "intent": {
-            "agg": None if not group_by_resolved else ("count" if gross_flag is not True else "sum"),
-            "date_column": "OVERLAP",
-            "eq_filters": hints_intent.get("eq_filters") or [],
-            "group_by": group_by_display,
-            "measure_sql": measure_sql,
-        },
-        "validation": {
-            "ok": True,
-            "errors": [],
-            "binds": list(binds.keys()),
-            "bind_names": list(binds.keys()),
-        },
-    }
-
-    try:
-        store = LearningStore()
-        if rating is not None:
-            if rating >= 4:
-                store.save_example(
-                    ExampleRecord(
-                        inquiry_id=inquiry_id,
-                        question=payload.get("question") or "",
-                        sql=final_sql,
-                        created_at=datetime.utcnow(),
-                    )
-                )
-            elif rating <= 2 and comment:
-                store.save_patch(
-                    PatchRecord(
-                        inquiry_id=inquiry_id,
-                        comment=comment,
-                        produced_sql=final_sql,
-                        created_at=datetime.utcnow(),
-                    )
-                )
-    except Exception as e:  # pragma: no cover - defensive logging path
-        debug["learning_store_error"] = str(e)
-
-    return jsonify(
-        {
-            "ok": True,
-            "inquiry_id": inquiry_id,
-            "sql": final_sql,
+            },
             "meta": {
                 "attempt_no": 2,
                 "binds": binds,
-                "clarifier_intent": debug["intent"],
-                "fts": debug["fts"],
-                "rate_hints": {
-                    "comment_present": bool(comment),
-                    "eq_filters": len(eq_applied),
-                    "group_by": group_by_display if group_by_display else None,
-                    "order_by_applied": True,
-                    "where_applied": bool(where_parts),
-                },
+                "clarifier_intent": intent,
+                "strategy": "det_overlaps_gross",
+                "wants_all_columns": True,
             },
-            "debug": debug,
-            "rows": [],
-            "retry": True,
         }
     )
+    return jsonify(resp), 200

--- a/apps/dw/templates/dw/admin_rules.html
+++ b/apps/dw/templates/dw/admin_rules.html
@@ -1,0 +1,45 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>DW Rules & Patches</title>
+    <style>
+      body { font-family: system-ui, Arial, sans-serif; margin: 24px; }
+      table { border-collapse: collapse; width: 100%; }
+      th, td { border: 1px solid #ddd; padding: 8px; font-size: 14px; vertical-align: top; }
+      th { background: #f7f7f7; }
+      pre { margin: 0; white-space: pre-wrap; word-break: break-word; }
+      .actions form { display: inline-block; margin-right: 8px; }
+    </style>
+  </head>
+  <body>
+    <h2>DW Patches (proposed)</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Inquiry</th>
+          <th>Status</th>
+          <th>Created</th>
+          <th>Patch</th>
+          <th>Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for p in patches %}
+        <tr>
+          <td>{{ p.id }}</td>
+          <td>{{ p.inquiry_id }}</td>
+          <td>{{ p.status }}</td>
+          <td>{{ p.created_at }}</td>
+          <td><pre>{{ p.patch_json }}</pre></td>
+          <td class="actions">
+            <form method="post" action="{{ url_for('admin_rules.approve', pid=p.id) }}"><button>Approve</button></form>
+            <form method="post" action="{{ url_for('admin_rules.reject', pid=p.id) }}"><button>Reject</button></form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </body>
+</html>

--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -846,3 +846,48 @@ cases:
     - "UPPER(TRIM(ENTITY)) = UPPER(TRIM(:eq_0))"
     - "UPPER(TRIM(REPRESENTATIVE_EMAIL)) = UPPER(TRIM(:eq_1))"
     - "ORDER BY REQUEST_DATE DESC"
+# --- Patch 2 Golden Adds ------------------------------------------------------
+- question: "Show contracts where REQUEST TYPE = Renewal"
+  namespace: "dw::common"
+  ok: true
+  assert_sql_contains:
+    - "UPPER(TRIM(REQUEST_TYPE))"
+    - "IN ("
+    - "ORDER BY REQUEST_DATE DESC"
+  assert_not_contains:
+    - "Fallback listing"
+
+- question: "list all contracts has it"
+  namespace: "dw::common"
+  full_text_search: true
+  ok: true
+  assert_sql_contains:
+    - "LIKE UPPER(:fts_0)"
+  assert_not_contains:
+    - "no_columns"
+    - "Fallback listing"
+
+- question: "list all contracts has it or home care"
+  namespace: "dw::common"
+  full_text_search: true
+  ok: true
+  assert_sql_contains:
+    - "LIKE UPPER(:fts_0)"
+    - "LIKE UPPER(:fts_1)"
+    - " ORDER BY REQUEST_DATE DESC"
+
+- question: "For ENTITY_NO = 'E-123', total and count by CONTRACT_STATUS."
+  namespace: "dw::common"
+  ok: true
+  assert_sql_contains:
+    - "GROUP BY CONTRACT_STATUS"
+    - "ORDER BY TOTAL_GROSS DESC"
+  assert_not_contains:
+    - "Fallback listing"
+
+- question: "bottom 5 by gross last month"
+  namespace: "dw::common"
+  ok: true
+  assert_sql_contains:
+    - "ORDER BY TOTAL_GROSS ASC"
+    - "FETCH FIRST 5 ROWS ONLY"


### PR DESCRIPTION
## Summary
- add lightweight DW rate handler that records feedback, parses low ratings into SQL intent patches, and returns structured debug metadata
- extend SQL builder and intent utilities to cover simplified equality, FTS, and aggregation parsing for contracts plus add an admin UI for reviewing stored patches
- persist feedback and patch hints in memory DB tables with helpers to parse structured comments and expose recent rules via a Flask blueprint template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e46f4e2868832380a9eb282f220a28