### PR TITLE
feature/p2-explain-ui-golden-2025-10-07

### DIFF
--- a/apps/dw/tests/golden_dw_contracts.yaml
+++ b/apps/dw/tests/golden_dw_contracts.yaml
@@ -24,6 +24,10 @@ cases:
       - "LIKE UPPER(:fts_0)"
       - "LIKE UPPER(:fts_1)"
       - "ORDER BY REQUEST_DATE DESC"
+    expect_not_contains:
+      - "Fallback listing"
+    explain_contains:
+      - "FTS("
 
   - id: patch_fts_and_tokens
     question: "list all contracts has it and home care"

--- a/longchain/__init__.py
+++ b/longchain/__init__.py
@@ -1,0 +1,23 @@
+"""Minimal Flask application exposing the lightweight DW blueprint."""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - allow environments without Flask
+    from flask import Flask
+except Exception:  # pragma: no cover
+    Flask = None  # type: ignore[assignment]
+else:
+    from longchain.apps.dw.app import dw_bp
+
+
+def create_app():  # pragma: no cover - exercised via tests
+    if Flask is None:
+        raise RuntimeError("Flask is required to create the longchain app")
+    app = Flask(__name__, template_folder="templates")
+    app.register_blueprint(dw_bp, url_prefix="/dw")
+    return app
+
+
+app = create_app() if "Flask" in globals() and Flask is not None else None
+
+__all__ = ["app", "create_app"]

--- a/longchain/apps/dw/__init__.py
+++ b/longchain/apps/dw/__init__.py
@@ -1,0 +1,19 @@
+"""Lightweight DW blueprint and helpers for the longchain tests."""
+
+from .app import (
+    dw_bp,
+    answer,
+    rate,
+    explain_view,
+    save_answer_snapshot,
+    load_answer_snapshot,
+)
+
+__all__ = [
+    "dw_bp",
+    "answer",
+    "rate",
+    "explain_view",
+    "save_answer_snapshot",
+    "load_answer_snapshot",
+]

--- a/longchain/apps/dw/app.py
+++ b/longchain/apps/dw/app.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import copy
+import itertools
+import re
+import threading
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from flask import Blueprint, jsonify, render_template, request
+
+from . import settings as dw_settings
+from .examples import retrieve_examples_for_question, save_example_if_positive
+from .explain import build_user_explain
+from .fts import build_fts_where
+from .rules import choose_canary
+from .settings import Settings
+
+
+SETTINGS = Settings()
+dw_bp = Blueprint("dw", __name__)
+
+
+_INQUIRY_COUNTER = itertools.count(1)
+_SNAPSHOT_LOCK = threading.Lock()
+_SNAPSHOTS: Dict[int, Dict[str, Any]] = {}
+
+_EQ_PATTERN = re.compile(r"(?P<col>[A-Za-z0-9_\"\. ]+)\s*=\s*(?P<val>'[^']*'|\"[^\"]*\"|[A-Za-z0-9_./-]+)", re.IGNORECASE)
+
+
+def _clean_eq_value(raw: str) -> str:
+    text = (raw or "").strip()
+    if text.startswith("'") and text.endswith("'"):
+        return text[1:-1]
+    if text.startswith('"') and text.endswith('"'):
+        return text[1:-1]
+    return text
+
+
+def _normalize_col(col: str) -> str:
+    text = (col or "").strip()
+    if text.startswith('"') and text.endswith('"'):
+        return text.strip('"')
+    return re.sub(r"\s+", "_", text.upper())
+
+
+def _parse_eq_filters(text: str) -> List[Dict[str, Any]]:
+    filters: List[Dict[str, Any]] = []
+    seen: set[Tuple[str, str]] = set()
+    for match in _EQ_PATTERN.finditer(text or ""):
+        col_raw = match.group("col")
+        val_raw = match.group("val")
+        col = _normalize_col(col_raw)
+        val = _clean_eq_value(val_raw)
+        key = (col, val.upper())
+        if key in seen:
+            continue
+        seen.add(key)
+        filters.append({
+            "col": col,
+            "val": val,
+            "ci": True,
+            "trim": True,
+        })
+    return filters
+
+
+def _build_eq_sql(eq_filters: List[Dict[str, Any]]) -> Tuple[List[str], Dict[str, Any]]:
+    sql_parts: List[str] = []
+    binds: Dict[str, Any] = {}
+    for idx, spec in enumerate(eq_filters):
+        col = _normalize_col(spec.get("col"))
+        if not col:
+            continue
+        bind = f"eq_{idx}"
+        sql_parts.append(f"UPPER(TRIM({col})) = UPPER(TRIM(:{bind}))")
+        binds[bind] = spec.get("val")
+    return sql_parts, binds
+
+
+def _default_fts_debug(columns: Optional[List[str]] = None) -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "mode": "explicit",
+        "operator": None,
+        "columns": columns or dw_settings.get_fts_columns("Contract"),
+        "tokens": [],
+        "binds": {},
+        "error": None,
+        "engine": dw_settings.get_fts_engine("like"),
+    }
+
+
+def _prepare_fts(question: str, *, full_text_search: bool, override: Optional[Dict[str, Any]]) -> Tuple[str, Dict[str, Any], Dict[str, Any]]:
+    if override:
+        text = override.get("text") or ""
+        operator = override.get("operator")
+        sql, binds, debug = build_fts_where("Contract", text, force_operator=operator)
+        if override.get("tokens"):
+            debug["tokens"] = list(override.get("tokens") or [])
+        debug["enabled"] = bool(sql)
+    elif full_text_search:
+        sql, binds, debug = build_fts_where("Contract", question)
+    else:
+        return "", {}, _default_fts_debug()
+
+    debug.setdefault("columns", dw_settings.get_fts_columns("Contract"))
+    debug.setdefault("tokens", [])
+    debug.setdefault("binds", {})
+    debug["engine"] = dw_settings.get_fts_engine("like")
+    return sql, binds, debug
+
+
+def _plan_query(
+    question: str,
+    *,
+    eq_filters: Optional[List[Dict[str, Any]]] = None,
+    full_text_search: bool = False,
+    fts_override: Optional[Dict[str, Any]] = None,
+    sort_by: Optional[str] = None,
+    sort_desc: bool = True,
+) -> Dict[str, Any]:
+    eq_filters = list(eq_filters or [])
+    default_date_col = dw_settings.get_date_column("REQUEST_DATE")
+    sort_column = (sort_by or default_date_col).strip() or "REQUEST_DATE"
+
+    fts_sql, fts_binds, fts_debug = _prepare_fts(question, full_text_search=full_text_search, override=fts_override)
+    eq_sqls, eq_binds = _build_eq_sql(eq_filters)
+
+    where_parts: List[str] = []
+    if fts_sql:
+        where_parts.append(fts_sql)
+    if eq_sqls:
+        where_parts.append("(" + " AND ".join(eq_sqls) + ")")
+
+    binds: Dict[str, Any] = {}
+    binds.update(fts_binds)
+    binds.update(eq_binds)
+
+    sql_lines = [
+        "SELECT *",
+        'FROM "Contract"',
+    ]
+    if where_parts:
+        sql_lines.append("WHERE " + " AND ".join(where_parts))
+    direction = "DESC" if sort_desc else "ASC"
+    sql_lines.append(f"ORDER BY {sort_column} {direction}")
+    sql = "\n".join(sql_lines)
+
+    intent = {
+        "question": question,
+        "eq_filters": eq_filters,
+        "group_by": None,
+        "sort_by": sort_column,
+        "sort_desc": sort_desc,
+        "measure_sql": None,
+        "date_column": default_date_col,
+        "fts_tokens": list(fts_debug.get("tokens") or []),
+        "fts_operator": fts_debug.get("operator") or ("OR" if fts_debug.get("enabled") else None),
+    }
+
+    meta = {
+        "binds": binds,
+        "fts": fts_debug,
+        "eq_filters": eq_filters,
+        "sort_by": sort_column,
+        "sort_desc": sort_desc,
+        "gross": False,
+        "clarifier_intent": intent,
+    }
+
+    debug = {
+        "intent": intent,
+        "fts": fts_debug,
+    }
+
+    return {
+        "sql": sql,
+        "meta": meta,
+        "intent": intent,
+        "debug": debug,
+    }
+
+
+def _next_inquiry_id() -> int:
+    return next(_INQUIRY_COUNTER)
+
+
+def save_answer_snapshot(inquiry_id: int, record: Dict[str, Any]) -> None:
+    with _SNAPSHOT_LOCK:
+        _SNAPSHOTS[inquiry_id] = copy.deepcopy(record)
+
+
+def load_answer_snapshot(inquiry_id: int) -> Optional[Dict[str, Any]]:
+    with _SNAPSHOT_LOCK:
+        rec = _SNAPSHOTS.get(inquiry_id)
+        return copy.deepcopy(rec) if rec is not None else None
+
+
+def _rate_comment_hints(comment: str) -> Dict[str, Any]:
+    hints: Dict[str, Any] = {}
+    pieces = [p.strip() for p in (comment or "").split(";") if p.strip()]
+    for piece in pieces:
+        if ":" not in piece:
+            continue
+        key, value = piece.split(":", 1)
+        key = key.strip().lower()
+        value = value.strip()
+        if not value:
+            continue
+        if key == "fts":
+            tokens = [tok.strip() for tok in re.split(r"[|,]", value) if tok.strip()]
+            if tokens:
+                operator = "AND" if " and " in value.lower() and "|" not in value else "OR"
+                hints["fts_tokens"] = tokens
+                hints["fts_operator"] = operator
+                glue = " AND " if operator == "AND" else " OR "
+                hints["fts_text"] = glue.join(tokens)
+        elif key == "eq":
+            eq_filters = _parse_eq_filters(value)
+            if eq_filters:
+                hints["eq_filters"] = eq_filters
+        elif key == "order_by":
+            parts = value.split()
+            if parts:
+                hints["sort_by"] = _normalize_col(parts[0])
+                if len(parts) > 1:
+                    hints["sort_desc"] = parts[1].strip().lower() != "asc"
+        elif key == "group_by":  # pragma: no cover - currently unused but ready
+            cols = [
+                _normalize_col(c)
+                for c in re.split(r",", value)
+                if c.strip()
+            ]
+            if cols:
+                hints["group_by"] = cols
+        elif key == "gross":
+            hints["gross"] = value.strip().lower() in {"1", "true", "yes", "y"}
+    return hints
+
+
+@dw_bp.post("/answer")
+def answer() -> Any:
+    payload = request.get_json(force=True) or {}
+    question = payload.get("question", "")
+    full_text_search = bool(payload.get("full_text_search"))
+
+    eq_filters = _parse_eq_filters(question)
+    plan = _plan_query(
+        question,
+        eq_filters=eq_filters,
+        full_text_search=full_text_search,
+    )
+
+    inquiry_id = _next_inquiry_id()
+    plan["meta"]["canary"] = choose_canary(inquiry_id)
+
+    examples = retrieve_examples_for_question(question)
+    if examples:
+        plan["meta"]["examples_used"] = [
+            {"q": row.get("q"), "score": row.get("score")}
+            for row in examples[:3]
+        ]
+
+    explain_payload = {
+        "intent": plan["intent"],
+        "fts": plan["meta"].get("fts", {}),
+        "sql": plan["sql"],
+        "meta": plan["meta"],
+    }
+    user_explain = build_user_explain(explain_payload)
+    plan["meta"]["user_explain"] = user_explain
+    plan["meta"]["explain"] = plan["meta"].get("explain") or user_explain
+
+    response = {
+        "ok": True,
+        "inquiry_id": inquiry_id,
+        "sql": plan["sql"],
+        "meta": plan["meta"],
+        "debug": plan["debug"],
+        "rows": [],
+    }
+
+    snapshot = {
+        "inquiry_id": inquiry_id,
+        "question": question,
+        "sql": plan["sql"],
+        "meta": plan["meta"],
+        "intent": plan["intent"],
+        "debug": plan["debug"],
+        "created_at": time.time(),
+        "payload": payload,
+    }
+    save_answer_snapshot(inquiry_id, snapshot)
+
+    return jsonify(response)
+
+
+@dw_bp.post("/rate")
+def rate() -> Any:
+    payload = request.get_json(force=True) or {}
+    inquiry_id = payload.get("inquiry_id")
+    if not inquiry_id:
+        return jsonify({"ok": False, "error": "Missing inquiry_id"}), 400
+
+    snapshot = load_answer_snapshot(int(inquiry_id))
+    if not snapshot:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+
+    hints = _rate_comment_hints(payload.get("comment", ""))
+    orig_intent = snapshot.get("intent", {})
+
+    eq_filters = hints.get("eq_filters", orig_intent.get("eq_filters") or [])
+    sort_by = hints.get("sort_by") or orig_intent.get("sort_by")
+    sort_desc = hints.get("sort_desc") if "sort_desc" in hints else orig_intent.get("sort_desc", True)
+
+    fts_override = None
+    if hints.get("fts_tokens"):
+        fts_override = {
+            "tokens": hints.get("fts_tokens"),
+            "operator": hints.get("fts_operator"),
+            "text": hints.get("fts_text"),
+        }
+
+    plan = _plan_query(
+        snapshot.get("question", ""),
+        eq_filters=eq_filters,
+        full_text_search=bool(fts_override),
+        fts_override=fts_override,
+        sort_by=sort_by,
+        sort_desc=bool(sort_desc),
+    )
+
+    plan["meta"]["source"] = "rate"
+    plan["meta"]["user_explain"] = build_user_explain(
+        {
+            "intent": plan["intent"],
+            "fts": plan["meta"].get("fts", {}),
+            "sql": plan["sql"],
+            "meta": plan["meta"],
+        }
+    )
+    plan["meta"]["explain"] = plan["meta"].get("explain") or plan["meta"]["user_explain"]
+
+    final_sql = plan["sql"]
+    try:
+        save_example_if_positive(
+            inquiry_id=int(inquiry_id),
+            question=snapshot.get("question", ""),
+            sql=final_sql,
+            rating=payload.get("rating"),
+        )
+    except Exception:
+        pass
+
+    response = {
+        "ok": True,
+        "inquiry_id": inquiry_id,
+        "sql": final_sql,
+        "meta": plan["meta"],
+        "debug": plan["debug"],
+    }
+    return jsonify(response)
+
+
+@dw_bp.get("/explain")
+def explain_view() -> Any:
+    enabled = SETTINGS.get_bool("DW_EXPLAIN_UI_ENABLED", default=True, scope="namespace")
+    if enabled is False:
+        return jsonify({"ok": False, "error": "Explain UI is disabled"}), 403
+
+    inquiry_id = request.args.get("inquiry_id", type=int)
+    if not inquiry_id:
+        return jsonify({"ok": False, "error": "Missing inquiry_id"}), 400
+
+    rec = load_answer_snapshot(inquiry_id)
+    if not rec:
+        return jsonify({"ok": False, "error": "Not found"}), 404
+
+    intent = rec.get("intent") or rec.get("debug", {}).get("intent", {})
+    meta = rec.get("meta", {})
+    fts_meta = meta.get("fts") or rec.get("debug", {}).get("fts", {})
+
+    data = {
+        "inquiry_id": inquiry_id,
+        "question": rec.get("question"),
+        "intent": intent,
+        "fts": fts_meta,
+        "sql": rec.get("sql"),
+        "meta": meta,
+    }
+    data["user_explain"] = build_user_explain(
+        {"intent": intent, "fts": fts_meta, "sql": data["sql"], "meta": meta}
+    )
+    return render_template("dw/explain.html", data=data)
+
+
+__all__ = [
+    "dw_bp",
+    "answer",
+    "rate",
+    "explain_view",
+    "save_answer_snapshot",
+    "load_answer_snapshot",
+]

--- a/longchain/apps/dw/examples.py
+++ b/longchain/apps/dw/examples.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List
+import re
+
+
+def _normalize_q(q: str) -> str:
+    q = (q or "").strip().lower()
+    q = re.sub(r"\s+", " ", q)
+    return q
+
+
+# In-memory examples store used for tests. Keys are normalized questions.
+_EXAMPLES: Dict[str, Dict[str, Any]] = {}
+
+
+def save_example_if_positive(inquiry_id: int, question: str, sql: str, rating: int) -> None:
+    """Persist highly-rated examples for lightweight suggestion retrieval."""
+    try:
+        if rating is None or rating < 4:
+            return
+        qn = _normalize_q(question)
+        if not qn:
+            return
+        existing = _EXAMPLES.get(qn)
+        if not existing or rating > existing.get("stars", 0):
+            _EXAMPLES[qn] = {
+                "inquiry_id": inquiry_id,
+                "q_norm": qn,
+                "sql": sql,
+                "stars": int(rating),
+            }
+    except Exception:  # pragma: no cover - defensive, never raise during rating flow
+        pass
+
+
+def _lexical_score(a: str, b: str) -> float:
+    set_a = set(a.split())
+    set_b = set(b.split())
+    if not set_a and not set_b:
+        return 0.0
+    overlap = set_a & set_b
+    union = set_a | set_b
+    return round(len(overlap) / max(1, len(union)), 3)
+
+
+def retrieve_examples_for_question(question: str) -> List[Dict[str, Any]]:
+    qn = _normalize_q(question)
+    results: List[Dict[str, Any]] = []
+    if not qn:
+        return results
+    for rec in _EXAMPLES.values():
+        score = _lexical_score(qn, rec.get("q_norm", ""))
+        results.append({
+            "q": rec.get("q_norm"),
+            "sql": rec.get("sql"),
+            "score": score,
+            "stars": rec.get("stars", 0),
+        })
+    results.sort(key=lambda item: item["score"], reverse=True)
+    return results[:5]

--- a/longchain/apps/dw/explain.py
+++ b/longchain/apps/dw/explain.py
@@ -1,0 +1,53 @@
+from typing import Dict, List, Any
+
+
+def _fmt_eq_filters(eq_filters: List[Dict[str, Any]]) -> str:
+    if not eq_filters:
+        return "None"
+    parts = []
+    for f in eq_filters:
+        col = f.get("col")
+        val = f.get("val")
+        ci = f.get("ci", False)
+        trim = f.get("trim", False)
+        parts.append(f"{col} = {val} (ci={ci}, trim={trim})")
+    return "; ".join(parts)
+
+
+def _fmt_fts(fts: Dict[str, Any]) -> str:
+    if not fts or not fts.get("enabled"):
+        return "Disabled"
+    cols = fts.get("columns") or []
+    tokens = fts.get("tokens") or []
+    operator = fts.get("operator") or "OR"
+    engine = fts.get("engine") or "like"
+    if isinstance(tokens, list) and tokens and isinstance(tokens[0], list):
+        tok_str = " OR ".join([" AND ".join(grp) for grp in tokens])
+    else:
+        tok_str = " | ".join(tokens)
+    return f"FTS({engine}) on {len(cols)} cols; operator={operator}; tokens=[{tok_str}]"
+
+
+def build_user_explain(payload: Dict[str, Any]) -> str:
+    """
+    Compact English rationale for end users.
+    Summarizes filters, FTS mode/tokens, grouping, ordering, and measure.
+    """
+    intent = payload.get("intent", {})
+    fts = payload.get("fts", {})
+    gb = intent.get("group_by")
+    sort_by = intent.get("sort_by")
+    sort_desc = intent.get("sort_desc")
+    measure_sql = intent.get("measure_sql")
+    eq_filters = intent.get("eq_filters") or []
+
+    bits: List[str] = []
+    bits.append(f"Applied equality filters: {_fmt_eq_filters(eq_filters)}.")
+    bits.append(_fmt_fts(fts) + ".")
+    if gb:
+        bits.append(f"Grouped by {gb}.")
+    if sort_by:
+        bits.append(f"Ordered by {sort_by} {'DESC' if sort_desc else 'ASC'}.")
+    if measure_sql:
+        bits.append("Gross measure applied." if "VAT" in str(measure_sql).upper() else "Simple measure.")
+    return " ".join(bits)

--- a/longchain/apps/dw/rules.py
+++ b/longchain/apps/dw/rules.py
@@ -1,0 +1,20 @@
+import hashlib
+
+from .settings import Settings
+
+
+def choose_canary(inquiry_id: int) -> bool:
+    settings = Settings()
+    enabled = settings.get_bool("DW_RULES_CANARY_ENABLED", default=False, scope="namespace")
+    if not enabled:
+        return False
+    pct = settings.get_int("DW_RULES_CANARY_PERCENT", default=10, scope="namespace")
+    if pct is None:
+        pct = 10
+    pct = max(0, min(100, int(pct)))
+    digest = hashlib.sha1(str(inquiry_id).encode()).hexdigest()
+    h_val = int(digest, 16)
+    return (h_val % 100) < pct
+
+
+__all__ = ["choose_canary"]

--- a/longchain/apps/dw/tests/test_explain_and_golden.py
+++ b/longchain/apps/dw/tests/test_explain_and_golden.py
@@ -1,0 +1,57 @@
+import pytest
+
+pytest.importorskip("flask")
+
+from longchain import app as flask_app
+
+
+@pytest.fixture()
+def client():
+    if flask_app is None:
+        pytest.skip("Flask application is unavailable")
+    return flask_app.test_client()
+
+
+def test_explain_contains_fts_and_order(client):
+    payload = {
+        "prefixes": [],
+        "question": "list all contracts has it or home care",
+        "auth_email": "dev@example.com",
+        "full_text_search": True,
+    }
+    rv = client.post("/dw/answer", json=payload)
+    assert rv.status_code == 200
+    data = rv.get_json()
+    assert data["ok"] is True
+    meta = data["meta"]
+    assert "Fallback listing" not in (meta.get("explain") or "")
+    assert "FTS(" in meta.get("user_explain", "")
+    assert "ORDER BY REQUEST_DATE DESC" in data["sql"]
+
+
+def test_rate_applies_eq_and_fts(client):
+    rv = client.post(
+        "/dw/answer",
+        json={
+            "prefixes": [],
+            "question": "list all contracts has it or home care and ENTITY = DSFH",
+            "auth_email": "dev@example.com",
+            "full_text_search": True,
+        },
+    )
+    ans = rv.get_json()
+    inq = ans["inquiry_id"]
+
+    rv2 = client.post(
+        "/dw/rate",
+        json={
+            "inquiry_id": inq,
+            "rating": 1,
+            "comment": "fts: it | home care; eq: ENTITY = DSFH; order_by: REQUEST_DATE desc;",
+        },
+    )
+    fix = rv2.get_json()
+    sql = fix.get("sql", "")
+    assert "LIKE UPPER(:fts_0)" in sql and "LIKE UPPER(:fts_1)" in sql
+    assert "UPPER(TRIM(ENTITY))" in sql or "ENTITY = :eq_0" in sql
+    assert "ORDER BY REQUEST_DATE DESC" in sql

--- a/longchain/templates/dw/explain.html
+++ b/longchain/templates/dw/explain.html
@@ -1,0 +1,63 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>DW Explain</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; line-height: 1.5; }
+    .card { border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin-bottom: 16px; }
+    .k { color:#666; font-weight:600; }
+    pre { background: #f7f7f7; padding: 12px; border-radius: 6px; overflow:auto; }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; }
+    h1 { font-size: 20px; margin: 0 0 12px; }
+    .pill { display:inline-block; padding:2px 8px; border-radius:999px; background:#eee; margin-right:6px; font-size:12px; }
+  </style>
+</head>
+<body>
+  <h1>Answer Explanation</h1>
+  <div class="card">
+    <div><span class="k">Inquiry ID:</span> {{ data.inquiry_id }}</div>
+    <div><span class="k">Question:</span> {{ data.question }}</div>
+    <div><span class="k">Date Column:</span> {{ data.intent.date_column }}</div>
+    <div><span class="k">Group By:</span> {{ data.intent.group_by or 'None' }}</div>
+    <div><span class="k">Order By:</span> {{ data.intent.sort_by or 'None' }} {{ 'DESC' if data.intent.sort_desc else 'ASC' if data.intent.sort_by else '' }}</div>
+    <div><span class="k">Gross:</span> {{ 'Yes' if data.meta.gross or (data.intent.measure_sql and 'VAT' in data.intent.measure_sql|upper) else 'No' }}</div>
+  </div>
+
+  <div class="card">
+    <div><span class="k">Equality Filters:</span></div>
+    {% if data.intent.eq_filters %}
+      <ul>
+        {% for f in data.intent.eq_filters %}
+          <li><code>{{ f.col }}</code> = <code>{{ f.val }}</code> (ci={{ 'true' if f.ci else 'false' }}, trim={{ 'true' if f.trim else 'false' }})</li>
+        {% endfor %}
+      </ul>
+    {% else %}
+      <div>None</div>
+    {% endif %}
+  </div>
+
+  <div class="card">
+    <div><span class="k">Full Text Search:</span></div>
+    {% if data.fts and data.fts.enabled %}
+      <div>Engine: <span class="pill">{{ data.fts.engine or 'like' }}</span> Operator: <span class="pill">{{ data.intent.fts_operator or 'OR' }}</span></div>
+      <div>Columns ({{ data.fts.columns|length }}):</div>
+      <pre><code>{{ data.fts.columns|join(', ') }}</code></pre>
+      <div>Tokens:</div>
+      <pre><code>{{ data.intent.fts_tokens }}</code></pre>
+    {% else %}
+      <div>Disabled</div>
+    {% endif %}
+  </div>
+
+  <div class="card">
+    <div><span class="k">Final SQL:</span></div>
+    <pre><code>{{ data.sql }}</code></pre>
+  </div>
+  <div class="card">
+    <div><span class="k">Rationale:</span></div>
+    <div>{{ data.user_explain }}</div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a lightweight DW blueprint with explain snapshots, rating storage, and a simple HTML explain page
- persist positive examples in memory and expose canary sampling plus user facing explanations
- extend golden tests to check explain strings and add longchain-specific pytest coverage

## Testing
- pytest longchain/apps/dw/tests/test_explain_and_golden.py

------
https://chatgpt.com/codex/tasks/task_e_68e4e02e46a0832388e985e6feb73124