### PR TITLE
feature/p2-explain-ui-golden-2025-10-07

### DIFF
--- a/longchain/apps/dw/explain.py
+++ b/longchain/apps/dw/explain.py
@@ -1,4 +1,143 @@
-from typing import Dict, List, Any
+from typing import Any, Dict, List, Tuple
+
+
+def _fmt_bool(flag: Any) -> str:
+    return "true" if flag else "false"
+
+
+def _safe_upper(value: Any) -> str:
+    try:
+        return str(value).upper()
+    except Exception:
+        return str(value)
+
+
+def _list_to_inline(items: List[str], limit: int = 8) -> str:
+    values = [str(item) for item in items if str(item).strip()]
+    if not values:
+        return "—"
+    if len(values) <= limit:
+        return ", ".join(values)
+    head = ", ".join(values[:limit])
+    remaining = len(values) - limit
+    return f"{head} …(+{remaining})"
+
+
+def build_explain_struct(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize DW answer payload into a compact explain struct."""
+
+    payload = payload or {}
+    debug = payload.get("debug", {}) or {}
+    meta = payload.get("meta", {}) or {}
+
+    intent = (
+        debug.get("intent")
+        or debug.get("clarifier_intent")
+        or meta.get("clarifier_intent")
+        or {}
+    )
+    fts_dbg = debug.get("fts") or meta.get("fts") or {}
+    binds = meta.get("binds") or {}
+    sql_text = payload.get("sql", "") or ""
+
+    eq_filters = intent.get("eq_filters") or []
+    fts_tokens = intent.get("fts_tokens") or fts_dbg.get("tokens") or []
+    fts_columns = intent.get("fts_columns") or fts_dbg.get("columns") or []
+    fts_operator = intent.get("fts_operator") or fts_dbg.get("operator") or "OR"
+    full_text_search = bool(intent.get("full_text_search")) or bool(fts_dbg.get("enabled"))
+
+    struct = {
+        "eq_filters": eq_filters,
+        "fts": {
+            "enabled": bool(full_text_search) or bool(fts_tokens),
+            "operator": fts_operator,
+            "tokens": fts_tokens,
+            "columns": fts_columns,
+        },
+        "group_by": intent.get("group_by"),
+        "order_by": {
+            "column": intent.get("sort_by"),
+            "desc": bool(intent.get("sort_desc")),
+        },
+        "gross": {
+            "enabled": bool(intent.get("gross")),
+            "expr": intent.get("measure_sql"),
+        },
+        "binds_count": len(binds),
+        "strategy": meta.get("strategy"),
+        "sql_len": len(sql_text),
+    }
+    return struct
+
+
+def build_explain_text(struct: Dict[str, Any]) -> str:
+    """Turn explain struct into a concise English rationale."""
+
+    struct = struct or {}
+    parts: List[str] = []
+
+    eq_filters = struct.get("eq_filters") or []
+    if eq_filters:
+        fragments: List[str] = []
+        for filt in eq_filters:
+            column = filt.get("col") or filt.get("column")
+            value = filt.get("val") or filt.get("value")
+            if not column:
+                continue
+            chunk = f"{column} = {value}"
+            flags: List[str] = []
+            if filt.get("ci"):
+                flags.append("ci")
+            if filt.get("trim"):
+                flags.append("trim")
+            if flags:
+                chunk += f" ({'/'.join(flags)})"
+            fragments.append(chunk)
+        if fragments:
+            parts.append(
+                "Applied equality filters: " + _list_to_inline(fragments, limit=6) + "."
+            )
+
+    fts = struct.get("fts") or {}
+    if fts.get("enabled"):
+        tokens = fts.get("tokens") or []
+        columns = fts.get("columns") or []
+        operator = fts.get("operator") or "OR"
+        if tokens:
+            parts.append(
+                f"Full‑text search using {operator} over tokens: "
+                f"{_list_to_inline(tokens, limit=6)}."
+            )
+        if columns:
+            parts.append(
+                f"Search columns: {_list_to_inline([_safe_upper(c) for c in columns], limit=6)}."
+            )
+
+    group_by = struct.get("group_by")
+    if group_by:
+        parts.append(f"Grouped by: {group_by}.")
+
+    order_by = struct.get("order_by") or {}
+    if order_by.get("column"):
+        direction = "DESC" if order_by.get("desc") else "ASC"
+        parts.append(f"Ordered by {order_by.get('column')} {direction}.")
+
+    gross = struct.get("gross") or {}
+    if gross.get("enabled"):
+        expr = gross.get("expr") or "custom gross measure"
+        parts.append(f"Used gross measure: {expr}.")
+
+    if not parts:
+        parts.append("Default listing strategy with no explicit filters detected.")
+    return " ".join(parts)
+
+
+def build_explain(payload: Dict[str, Any]) -> Tuple[str, Dict[str, Any]]:
+    """Convenience wrapper returning both text and struct."""
+
+    struct = build_explain_struct(payload)
+    text = build_explain_text(struct)
+    return text, struct
 
 
 def _fmt_eq_filters(eq_filters: List[Dict[str, Any]]) -> str:
@@ -29,10 +168,8 @@ def _fmt_fts(fts: Dict[str, Any]) -> str:
 
 
 def build_user_explain(payload: Dict[str, Any]) -> str:
-    """
-    Compact English rationale for end users.
-    Summarizes filters, FTS mode/tokens, grouping, ordering, and measure.
-    """
+    """Backward-compatible rationale used by legacy UI pieces."""
+
     intent = payload.get("intent", {})
     fts = payload.get("fts", {})
     gb = intent.get("group_by")
@@ -49,5 +186,7 @@ def build_user_explain(payload: Dict[str, Any]) -> str:
     if sort_by:
         bits.append(f"Ordered by {sort_by} {'DESC' if sort_desc else 'ASC'}.")
     if measure_sql:
-        bits.append("Gross measure applied." if "VAT" in str(measure_sql).upper() else "Simple measure.")
+        bits.append(
+            "Gross measure applied." if "VAT" in str(measure_sql).upper() else "Simple measure."
+        )
     return " ".join(bits)

--- a/longchain/apps/dw/templates/explain.html
+++ b/longchain/apps/dw/templates/explain.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>DW Explain</title>
+    <style>
+      body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; margin: 24px; color: #1f2937; }
+      .card { border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin-bottom: 16px; background: #fff; }
+      h1 { font-size: 20px; margin-bottom: 12px; }
+      h2 { font-size: 16px; margin: 16px 0 8px; }
+      pre { background: #f9fafb; border: 1px solid #e5e7eb; padding: 12px; border-radius: 6px; overflow: auto; }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
+      .kv { display: grid; grid-template-columns: 220px 1fr; gap: 8px 16px; }
+      .muted { color: #6b7280; }
+      .badge { display: inline-block; padding: 2px 8px; border: 1px solid #d1d5db; border-radius: 999px; font-size: 12px; margin-right: 6px; background: #f9fafb; }
+    </style>
+  </head>
+  <body>
+    <div class="card">
+      <h1>Explain — Interpretation</h1>
+      <p>{{ explain_text }}</p>
+    </div>
+
+    <div class="card">
+      <h2>Summary</h2>
+      <div class="kv">
+        <div class="muted">Order By</div><div>{{ explain_struct.order_by.column }} {{ "DESC" if explain_struct.order_by.desc else "ASC" }}</div>
+        <div class="muted">Group By</div><div>{{ explain_struct.group_by or "—" }}</div>
+        <div class="muted">Gross</div><div>{{ "enabled" if explain_struct.gross.enabled else "disabled" }}</div>
+        <div class="muted">FTS</div>
+        <div>
+          {% if explain_struct.fts.enabled %}
+            <span class="badge">{{ explain_struct.fts.operator }}</span>
+            {% for t in explain_struct.fts.tokens %}<span class="badge">{{ t }}</span>{% endfor %}
+          {% else %}disabled{% endif %}
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <h2>SQL</h2>
+      <pre><code>{{ sql }}</code></pre>
+    </div>
+
+    <div class="card">
+      <h2>Binds</h2>
+      <pre><code>{{ binds|tojson(indent=2) }}</code></pre>
+    </div>
+
+    <div class="card">
+      <h2>Debug (raw)</h2>
+      <pre><code>{{ debug|tojson(indent=2) }}</code></pre>
+    </div>
+  </body>
+</html>

--- a/longchain/apps/dw/tests/golden_p2_explain_fts.yaml
+++ b/longchain/apps/dw/tests/golden_p2_explain_fts.yaml
@@ -1,0 +1,67 @@
+# Golden tests for Explain/FTS/Order/Group By cosmetics
+
+- name: "fts_or_contracts_it_or_homecare"
+  request:
+    endpoint: /dw/answer
+    body:
+      prefixes: []
+      question: "list all contracts has it or home care"
+      auth_email: "amr.yami1@gmail.com"
+      full_text_search: true
+  expect:
+    must_contain:
+      - "LIKE UPPER(:fts_0)"
+      - "LIKE UPPER(:fts_1)"
+      - "ORDER BY REQUEST_DATE DESC"
+    must_not_contain:
+      - "SELECT * FROM \"Contract\"\nORDER BY REQUEST_DATE DESC\nORDER BY REQUEST_DATE DESC"
+    require_order_by: "REQUEST_DATE"
+    require_order_dir: "DESC"
+    require_explain_contains:
+      - "Full‑text search"
+      - "Ordered by REQUEST_DATE DESC"
+
+- name: "eq_request_type_synonyms"
+  request:
+    endpoint: /dw/answer
+    body:
+      prefixes: []
+      question: "Show contracts where REQUEST TYPE = Renewal"
+      auth_email: "amr.yami1@gmail.com"
+  expect:
+    must_contain:
+      - "REQUEST_TYPE"
+      - "ORDER BY REQUEST_DATE DESC"
+    require_order_by: "REQUEST_DATE"
+    require_order_dir: "DESC"
+    require_explain_contains:
+      - "Applied equality filters"
+
+- name: "group_by_department_oul"
+  request:
+    endpoint: /dw/answer
+    body:
+      prefixes: []
+      question: "Total gross per DEPARTMENT_OUL"
+      auth_email: "amr.yami1@gmail.com"
+  expect:
+    must_contain:
+      - "GROUP BY DEPARTMENT_OUL"
+    require_group_by: "DEPARTMENT_OUL"
+    require_explain_contains:
+      - "Grouped by: DEPARTMENT_OUL"
+
+- name: "lowest_direction_check"
+  request:
+    endpoint: /dw/answer
+    body:
+      prefixes: []
+      question: "show lowest contracts by value"
+      auth_email: "amr.yami1@gmail.com"
+  expect:
+    must_contain:
+      - "ORDER BY"
+      - "ASC"
+    require_order_dir: "ASC"
+    require_explain_contains:
+      - "Ordered by"

--- a/longchain/apps/dw/tests/test_explain_and_golden.py
+++ b/longchain/apps/dw/tests/test_explain_and_golden.py
@@ -1,4 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
 import pytest
+
+try:  # pragma: no cover - optional dependency for YAML parsing
+    import yaml
+except ModuleNotFoundError:  # pragma: no cover - fallback when PyYAML unavailable
+    yaml = None  # type: ignore[assignment]
 
 pytest.importorskip("flask")
 
@@ -10,6 +20,16 @@ def client():
     if flask_app is None:
         pytest.skip("Flask application is unavailable")
     return flask_app.test_client()
+
+
+def _contains_all(text: str, fragments: Iterable[str]) -> bool:
+    body = text or ""
+    return all(fragment in body for fragment in fragments if fragment)
+
+
+def _contains_none(text: str, fragments: Iterable[str]) -> bool:
+    body = text or ""
+    return all(fragment not in body for fragment in fragments if fragment)
 
 
 def test_explain_contains_fts_and_order(client):
@@ -27,6 +47,22 @@ def test_explain_contains_fts_and_order(client):
     assert "Fallback listing" not in (meta.get("explain") or "")
     assert "FTS(" in meta.get("user_explain", "")
     assert "ORDER BY REQUEST_DATE DESC" in data["sql"]
+
+
+def test_explain_struct_populated(client):
+    payload = {
+        "prefixes": [],
+        "question": "show contracts where REQUEST TYPE = Renewal",
+        "auth_email": "dev@example.com",
+    }
+    rv = client.post("/dw/answer", json=payload)
+    assert rv.status_code == 200
+    data = rv.get_json()
+    struct = data["debug"].get("explain_struct")
+    assert struct is not None
+    assert struct["order_by"]["column"]
+    assert struct["order_by"]["desc"] is True
+    assert data["explain"].startswith("Applied equality filters")
 
 
 def test_rate_applies_eq_and_fts(client):
@@ -55,3 +91,69 @@ def test_rate_applies_eq_and_fts(client):
     assert "LIKE UPPER(:fts_0)" in sql and "LIKE UPPER(:fts_1)" in sql
     assert "UPPER(TRIM(ENTITY))" in sql or "ENTITY = :eq_0" in sql
     assert "ORDER BY REQUEST_DATE DESC" in sql
+
+
+def test_admin_explain_renders(client):
+    base = client.post(
+        "/dw/answer",
+        json={
+            "prefixes": [],
+            "question": "Total gross per DEPARTMENT_OUL",
+            "auth_email": "dev@example.com",
+        },
+    ).get_json()
+
+    rv = client.post("/dw/admin/explain", json=base)
+    assert rv.status_code == 200
+    text = rv.get_data(as_text=True)
+    assert "Explain — Interpretation" in text
+    assert "GROUP BY" in text
+
+
+def test_golden_cases_from_yaml(client):
+    if yaml is None:
+        pytest.skip("PyYAML is required for golden YAML parsing")
+
+    yaml_path = Path(__file__).with_name("golden_p2_explain_fts.yaml")
+    cases = yaml.safe_load(yaml_path.read_text(encoding="utf-8")) or []
+    assert cases, "Golden YAML should contain cases"
+
+    for case in cases:
+        request_cfg: Dict[str, Any] = case.get("request") or {}
+        endpoint = request_cfg.get("endpoint") or "/dw/answer"
+        body = request_cfg.get("body") or {}
+        rv = client.post(endpoint, json=body)
+        assert rv.status_code == 200, f"Request failed for {case.get('name')}"
+        data = rv.get_json()
+
+        sql = data.get("sql", "")
+        explain_text = data.get("explain", "") or data.get("meta", {}).get("explain", "")
+
+        expect: Dict[str, Any] = case.get("expect") or {}
+        must = expect.get("must_contain") or []
+        assert _contains_all(sql, must), f"Missing SQL fragments for {case.get('name')}: {must}"
+
+        must_not = expect.get("must_not_contain") or []
+        assert _contains_none(sql, must_not), f"Forbidden SQL fragment in {case.get('name')}: {must_not}"
+
+        order_col = expect.get("require_order_by")
+        if order_col:
+            assert "ORDER BY" in sql.upper()
+            assert order_col.upper() in sql.upper()
+
+        order_dir = expect.get("require_order_dir")
+        if order_dir:
+            assert order_dir.upper() in sql.upper()
+
+        group_col = expect.get("require_group_by")
+        if group_col:
+            assert "GROUP BY" in sql.upper()
+            assert group_col.upper() in sql.upper()
+
+        explain_frags = expect.get("require_explain_contains") or []
+        assert _contains_all(explain_text, explain_frags), (
+            f"Explain missing fragments for {case.get('name')}: {explain_frags}"
+        )
+
+        struct = data.get("debug", {}).get("explain_struct")
+        assert struct is not None, "Explain struct should be present"


### PR DESCRIPTION
## Summary
- add structured explain builder that returns both human-readable text and metadata
- enrich DW answer responses and provide an /dw/admin/explain HTML view backed by the new template
- extend tests with golden coverage for explain output and YAML-driven expectations

## Testing
- pytest longchain/apps/dw/tests/test_explain_and_golden.py

------
https://chatgpt.com/codex/tasks/task_e_68e504f299508323987fab040e96fe8d